### PR TITLE
Add option to specify partition file in run file.

### DIFF
--- a/src/run_configuration.cpp
+++ b/src/run_configuration.cpp
@@ -7,6 +7,8 @@
 RunConfiguration::RunConfiguration()
 {
   // Initialize with default values
+  partFile.clear();
+
   ref_levels = 0;
   timeIntegratorType = 4;
   solOrder = 4;
@@ -92,6 +94,13 @@ void RunConfiguration::readInputFile(std::string inpuFileName)
       {
         ss >> word;
         ref_levels = stoi(word);
+
+      // partition file name
+      } else if( word.compare("PART_FILE")==0 )
+      {
+        ss >> word;
+        partFile.clear();
+        partFile = word;
 
       // output file name
       }else if( word.compare("OUTPUT_NAME")==0 )

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -24,7 +24,10 @@ private:
   // mesh file file
   string meshFile;
   int ref_levels;
-  
+
+  // partition file
+  string partFile;
+
   // output file name
   string outputFile;
   
@@ -128,6 +131,7 @@ public:
   
   string GetMeshFileName(){return meshFile;}
   string GetOutputName(){return outputFile;}
+  string GetPartitionFileName(){return partFile;}
   int GetUniformRefLevels(){return ref_levels;}
 
   int GetTimeIntegratorType(){return timeIntegratorType;}


### PR DESCRIPTION
This PR will allow the user to specify the parallel decomposition using a 'partitioning' file, which, after two lines of metadata, has `number_of_elements` lines which indicate which mpi task each element is assigned to.  That is,

```
number_of_elements <int>
number_of_processors <int>
<rank of elem 0>
<rank of elem 1>
...
<rank of last elem>
```
Such a file can be obtained using the MFEM [mesh-explorer miniapp] (https://mfem.org/meshing/#meshing-miniapps).  See specifically [L960-L967](https://github.com/mfem/mfem/blob/cf90fad7fbfd56da3916b0adbb80d5174b7b5a06/miniapps/meshing/mesh-explorer.cpp#L960) where the partitioning file is written.  

In principle, we could also have `tps` write such a file if none is provided, but this isn't being done yet, mostly because the `ParMesh` ctor doesn't return the partitioning by default, so it isn't easy to get, as far as I can tell.

Regardless, letting the user provide this info will make it easier to move runs across machines, MFEM versions, METIS versions, etc and generally cope better with any other changes that might introduce jitter in the default partitioning.