### PR TITLE
update paraview iteration/time when stopping due to a NaN.  Not that

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1338,6 +1338,8 @@ void M2ulPhyS::Check_NAN()
   if( print>0 )
   {
     auto hUp = Up->HostRead(); // get GPU data
+    paraviewColl->SetCycle(iter);
+    paraviewColl->SetTime(time);
     paraviewColl->Save();
     MPI_Barrier(MPI_COMM_WORLD);
     MPI_Abort(MPI_COMM_WORLD,1);


### PR DESCRIPTION
this would ever happen.