### PR TITLE
Add conditional to ensure that serial_fes will only be used on task 0

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -175,9 +175,10 @@ void M2ulPhyS::restart_files_hdf5(string mode)
 
   if(mode == "write")
     {
-      if ( (config.RestartSerial() == "write") && (nprocs_ > 1) )
+      if ( (config.RestartSerial() == "write") && (nprocs_ > 1) && (mpi.Root()) )
 	{
 	  assert( (locToGlobElem != NULL) && (partitioning_ != NULL) );
+          assert( serial_fes != NULL );
 	  dims[0] = serial_fes->GetNDofs();
 	}
       else


### PR DESCRIPTION
This doesn't seem to affect our default cpu build, but I was seeing test failures in the serial write tests due to seg faults when using different compiler flags (specifically, I added '-g -pg -O2').  Not sure why that triggered the problem, but it is fixed by never trying to access `serial_fes` on mpi tasks other than root.