### PR TITLE
Add a SAVE_MEAN_HIST runtime option that, when enabled, will include …

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1066,7 +1066,7 @@ void M2ulPhyS::Iterate()
         paraviewColl->Save();
         auto dUp = Up->ReadWrite(); // sets memory to GPU
 
-        average->write_meanANDrms_restart_files();
+        average->write_meanANDrms_restart_files(iter,time);
       }
 
 
@@ -1114,7 +1114,7 @@ void M2ulPhyS::Iterate()
     paraviewColl->SetTime(time);
     paraviewColl->Save();
 
-    average->write_meanANDrms_restart_files();
+    average->write_meanANDrms_restart_files(iter,time);
 
 #ifndef _MASA_
     // If _MASA_ is defined, this is handled above

--- a/src/averaging_and_rms.cpp
+++ b/src/averaging_and_rms.cpp
@@ -143,47 +143,19 @@ void Averaging::addSampleMean(const int &iter)
   }
 }
 
-void Averaging::write_meanANDrms_restart_files()
+void Averaging::write_meanANDrms_restart_files(const int &iter, const double &time)
 {
   if( computeMean )
   {
+    if(config.isMeanHistEnabled())
+      {
+        paraviewMean->SetCycle(iter);
+        paraviewMean->SetTime(time);
+      }
+
     paraviewMean->Save();
     
-//     string serialName = "restart_mean_";
-//     serialName.append( config.GetOutputName() );
-//     serialName.append( ".sol" );
-//     
-//     string serialNameRMS = "restart_rms_";
-//     serialNameRMS.append( config.GetOutputName() );
-//     serialNameRMS.append( ".sol" );
-//     
-//     string fileName = groupsMPI->getParallelName( serialName );
-//     string rmsName  = groupsMPI->getParallelName( serialNameRMS );
-//     ofstream file( fileName, std::ofstream::trunc );
-//     ofstream rmsfile( rmsName, std::ofstream::trunc );
-//     file.precision(8);
-//     rmsfile.precision(8);
-//     
-//     double *data = meanUp->GetData();
-//     double *dataRMS = rms->GetData();
-//     
-//     // write cycle and time
-//     file<<samplesMean<<" "<<sampleInterval<<endl;
-//     
-//     
-//     int dof = vfes->GetNDofs();
-//     
-//     for(int i=0;i<dof*num_equation;i++)
-//     {
-//       file << data[i] <<endl;
-//     }
-//     file.close();
-//     
-//     for(int i=0;i<dof*numRMS;i++)
-//     {
-//       rmsfile << dataRMS[i] <<endl;
-//     }
-//     rmsfile.close();
+
   }
 }
 

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -63,7 +63,7 @@ public:
   ~Averaging();
   
   void addSampleMean(const int &iter);
-  void write_meanANDrms_restart_files();
+  void write_meanANDrms_restart_files(const int &iter, const double &time);
   void read_meanANDrms_restart_files();
   
   int GetSamplesMean(){return samplesMean;}

--- a/src/run_configuration.cpp
+++ b/src/run_configuration.cpp
@@ -31,6 +31,7 @@ RunConfiguration::RunConfiguration()
   sampleInterval = 0;
   startIter = 0;
   restartMean = false;
+  meanHistEnable = true;
   
   itersOut = 50;
   workFluid = DRY_AIR;
@@ -168,7 +169,11 @@ void RunConfiguration::readInputFile(std::string inpuFileName)
         
         ss >> word;
         sampleInterval = stoi( word );
-        
+
+      }else if( word.compare("SAVE_MEAN_HIST")==0 )
+      {
+        meanHistEnable = true;
+
       }else if( word.compare("CONTINUE_MEAN_CALC")==0 )
       {
         restartMean = true;

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -83,6 +83,7 @@ private:
   int sampleInterval;
   int startIter;
   bool restartMean;
+  bool meanHistEnable;
   
   // working fluid. Options thus far
   // DRY_AIR
@@ -168,6 +169,7 @@ public:
   int GetMeanStartIter(){return startIter;}
   int GetMeanSampleInterval(){return sampleInterval;}
   bool GetRestartMean(){return restartMean;}
+  bool isMeanHistEnabled(){return meanHistEnable;}
   
   WorkingFluid GetWorkingFluid(){return workFluid;}
   double GetViscMult(){return visc_mult;}

--- a/src/runfileExample.run
+++ b/src/runfileExample.run
@@ -1,3 +1,4 @@
+# -*- mode: sh -*-
 # Example Runfile
 
 # Mesh file
@@ -32,6 +33,10 @@ RM_CHECK_FREQUENCY 500
 # computes mean and RMS starting from iter start iter
 # and adds a new value every sampleInterval iterations
 CALC_MEAN_RMS 12400 20
+
+# whether to dump mean values every ITERS_OUT for paraview; if not set,
+# only the current value will be preserved.
+SAVE_MEAN_HIST
 
 # if simulation is to restart computing mean
 CONTINUE_MEAN_CALC


### PR DESCRIPTION
…iteration

and timing info with averaged fields saved in paraview output. This will a
history to be maintained in a similar fashion as primitive solution paraview
output.