### PR TITLE
Change inlet/outlet MPI groups

### DIFF
--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -115,14 +115,14 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
       if (patchType.second == VISC_ISOTH) wallData = config.GetWallData(w);
 
       wallBCmap[patchType.first] = new WallBC(rsolver, mixture, _runFile.GetEquationSystem(), fluxClass, vfes, intRules,
-                                          _dt, dim, num_equation, patchType.first, patchType.second, wallData,
-                                          intPointsElIDBC, _maxIntPoints, config.isAxisymmetric());
+                                              _dt, dim, num_equation, patchType.first, patchType.second, wallData,
+                                              intPointsElIDBC, _maxIntPoints, config.isAxisymmetric());
     }
   }
 
   // assign list of elements to each BC
   const int NumBCelems = vfes->GetNBE();
-  
+
   // Inlets
   if (NumBCelems > 0 && inletBCmap.size() > 0) {
     Mesh *mesh_bc = vfes->GetMesh();
@@ -140,13 +140,12 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
           if (tr->Attribute == attr) list.Append(el);
         }
       }
-      
+
       std::unordered_map<int, BoundaryCondition *>::const_iterator ibc = inletBCmap.find(attr);
       if (ibc != inletBCmap.end()) ibc->second->setElementList(list);
     }
   }
-  
-  
+
   // Outlets
   if (NumBCelems > 0 && outletBCmap.size() > 0) {
     Mesh *mesh_bc = vfes->GetMesh();
@@ -169,7 +168,7 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
       if (obc != outletBCmap.end()) obc->second->setElementList(list);
     }
   }
-  
+
   // Walls
   if (NumBCelems > 0 && wallBCmap.size() > 0) {
     Mesh *mesh_bc = vfes->GetMesh();
@@ -192,18 +191,17 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
       if (wbc != wallBCmap.end()) wbc->second->setElementList(list);
     }
   }
-  
 }
 
 BCintegrator::~BCintegrator() {
   for (auto bc = inletBCmap.begin(); bc != inletBCmap.end(); bc++) {
     delete bc->second;
   }
-  
+
   for (auto bc = outletBCmap.begin(); bc != outletBCmap.end(); bc++) {
     delete bc->second;
   }
-  
+
   for (auto bc = wallBCmap.begin(); bc != wallBCmap.end(); bc++) {
     delete bc->second;
   }
@@ -213,11 +211,11 @@ void BCintegrator::initBCs() {
   for (auto bc = inletBCmap.begin(); bc != inletBCmap.end(); bc++) {
     bc->second->initBCs();
   }
-  
+
   for (auto bc = outletBCmap.begin(); bc != outletBCmap.end(); bc++) {
     bc->second->initBCs();
   }
-  
+
   for (auto bc = wallBCmap.begin(); bc != wallBCmap.end(); bc++) {
     bc->second->initBCs();
   }
@@ -228,23 +226,23 @@ void BCintegrator::computeBdrFlux(const int attr, Vector &normal, Vector &stateI
   std::unordered_map<int, BoundaryCondition *>::const_iterator ibc = inletBCmap.find(attr);
   std::unordered_map<int, BoundaryCondition *>::const_iterator obc = outletBCmap.find(attr);
   std::unordered_map<int, BoundaryCondition *>::const_iterator wbc = wallBCmap.find(attr);
-  
+
   if (ibc != inletBCmap.end()) ibc->second->computeBdrFlux(normal, stateIn, gradState, radius, bdrFlux);
   if (obc != outletBCmap.end()) obc->second->computeBdrFlux(normal, stateIn, gradState, radius, bdrFlux);
   if (wbc != wallBCmap.end()) wbc->second->computeBdrFlux(normal, stateIn, gradState, radius, bdrFlux);
-  
-//   BCmap[attr]->computeBdrFlux(normal, stateIn, gradState, radius, bdrFlux);
+
+  //   BCmap[attr]->computeBdrFlux(normal, stateIn, gradState, radius, bdrFlux);
 }
 
 void BCintegrator::updateBCMean(ParGridFunction *Up) {
   for (auto bc = inletBCmap.begin(); bc != inletBCmap.end(); bc++) {
     bc->second->updateMean(intRules, Up);
   }
-  
+
   for (auto bc = outletBCmap.begin(); bc != outletBCmap.end(); bc++) {
     bc->second->updateMean(intRules, Up);
   }
-  
+
   for (auto bc = wallBCmap.begin(); bc != wallBCmap.end(); bc++) {
     bc->second->updateMean(intRules, Up);
   }
@@ -256,13 +254,13 @@ void BCintegrator::integrateBCs(Vector &y, const Vector &x, const Array<int> &no
                               x, nodesIDs, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, maxIntPoints,
                               maxDofs);
   }
-  
+
   for (auto bc = outletBCmap.begin(); bc != outletBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
                               x, nodesIDs, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, maxIntPoints,
                               maxDofs);
   }
-  
+
   for (auto bc = wallBCmap.begin(); bc != wallBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
                               x, nodesIDs, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, maxIntPoints,

--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -61,7 +61,9 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
       num_equation(_num_equation),
       maxIntPoints(_maxIntPoints),
       maxDofs(_maxDofs) {
-  BCmap.clear();
+  inletBCmap.clear();
+  outletBCmap.clear();
+  wallBCmap.clear();
 
   // Init inlet BCs
   for (int in = 0; in < config.GetInletPatchType()->size(); in++) {
@@ -74,7 +76,7 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
 
     if (attrInMesh) {
       Array<double> data = config.GetInletData(in);
-      BCmap[patchANDtype.first] =
+      inletBCmap[patchANDtype.first] =
           new InletBC(groupsMPI, _runFile.GetEquationSystem(), rsolver, mixture, vfes, intRules, _dt, dim, num_equation,
                       patchANDtype.first, config.GetReferenceLength(), patchANDtype.second, data, _maxIntPoints,
                       _maxDofs, config.isAxisymmetric());
@@ -91,7 +93,7 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
 
     if (attrInMesh) {
       Array<double> data = config.GetOutletData(o);
-      BCmap[patchANDtype.first] =
+      outletBCmap[patchANDtype.first] =
           new OutletBC(groupsMPI, _runFile.GetEquationSystem(), rsolver, mixture, vfes, intRules, _dt, dim,
                        num_equation, patchANDtype.first, config.GetReferenceLength(), patchANDtype.second, data,
                        _maxIntPoints, _maxDofs, config.isAxisymmetric());
@@ -112,7 +114,7 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
       Array<double> wallData;
       if (patchType.second == VISC_ISOTH) wallData = config.GetWallData(w);
 
-      BCmap[patchType.first] = new WallBC(rsolver, mixture, _runFile.GetEquationSystem(), fluxClass, vfes, intRules,
+      wallBCmap[patchType.first] = new WallBC(rsolver, mixture, _runFile.GetEquationSystem(), fluxClass, vfes, intRules,
                                           _dt, dim, num_equation, patchType.first, patchType.second, wallData,
                                           intPointsElIDBC, _maxIntPoints, config.isAxisymmetric());
     }
@@ -120,7 +122,33 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
 
   // assign list of elements to each BC
   const int NumBCelems = vfes->GetNBE();
-  if (NumBCelems > 0 && BCmap.size() > 0) {
+  
+  // Inlets
+  if (NumBCelems > 0 && inletBCmap.size() > 0) {
+    Mesh *mesh_bc = vfes->GetMesh();
+    FaceElementTransformations *tr;
+
+    for (int i = 0; i < local_attr.Size(); i++) {
+      int attr = local_attr[i];
+      Array<int> list;
+      list.LoseData();
+
+      for (int el = 0; el < NumBCelems; el++) {
+        tr = mesh_bc->GetBdrFaceTransformations(el);
+        if (tr != NULL) {
+          // if( tr->Attribute==attr ) list.Append( tr->Elem1No );
+          if (tr->Attribute == attr) list.Append(el);
+        }
+      }
+      
+      std::unordered_map<int, BoundaryCondition *>::const_iterator ibc = inletBCmap.find(attr);
+      if (ibc != inletBCmap.end()) ibc->second->setElementList(list);
+    }
+  }
+  
+  
+  // Outlets
+  if (NumBCelems > 0 && outletBCmap.size() > 0) {
     Mesh *mesh_bc = vfes->GetMesh();
     FaceElementTransformations *tr;
 
@@ -137,36 +165,105 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
         }
       }
 
-      BCmap[attr]->setElementList(list);
+      std::unordered_map<int, BoundaryCondition *>::const_iterator obc = outletBCmap.find(attr);
+      if (obc != outletBCmap.end()) obc->second->setElementList(list);
     }
   }
+  
+  // Walls
+  if (NumBCelems > 0 && wallBCmap.size() > 0) {
+    Mesh *mesh_bc = vfes->GetMesh();
+    FaceElementTransformations *tr;
+
+    for (int i = 0; i < local_attr.Size(); i++) {
+      int attr = local_attr[i];
+      Array<int> list;
+      list.LoseData();
+
+      for (int el = 0; el < NumBCelems; el++) {
+        tr = mesh_bc->GetBdrFaceTransformations(el);
+        if (tr != NULL) {
+          // if( tr->Attribute==attr ) list.Append( tr->Elem1No );
+          if (tr->Attribute == attr) list.Append(el);
+        }
+      }
+
+      std::unordered_map<int, BoundaryCondition *>::const_iterator wbc = wallBCmap.find(attr);
+      if (wbc != wallBCmap.end()) wbc->second->setElementList(list);
+    }
+  }
+  
 }
 
 BCintegrator::~BCintegrator() {
-  for (auto bc = BCmap.begin(); bc != BCmap.end(); bc++) {
+  for (auto bc = inletBCmap.begin(); bc != inletBCmap.end(); bc++) {
+    delete bc->second;
+  }
+  
+  for (auto bc = outletBCmap.begin(); bc != outletBCmap.end(); bc++) {
+    delete bc->second;
+  }
+  
+  for (auto bc = wallBCmap.begin(); bc != wallBCmap.end(); bc++) {
     delete bc->second;
   }
 }
 
 void BCintegrator::initBCs() {
-  for (auto bc = BCmap.begin(); bc != BCmap.end(); bc++) {
+  for (auto bc = inletBCmap.begin(); bc != inletBCmap.end(); bc++) {
+    bc->second->initBCs();
+  }
+  
+  for (auto bc = outletBCmap.begin(); bc != outletBCmap.end(); bc++) {
+    bc->second->initBCs();
+  }
+  
+  for (auto bc = wallBCmap.begin(); bc != wallBCmap.end(); bc++) {
     bc->second->initBCs();
   }
 }
 
 void BCintegrator::computeBdrFlux(const int attr, Vector &normal, Vector &stateIn, DenseMatrix &gradState,
                                   double radius, Vector &bdrFlux) {
-  BCmap[attr]->computeBdrFlux(normal, stateIn, gradState, radius, bdrFlux);
+  std::unordered_map<int, BoundaryCondition *>::const_iterator ibc = inletBCmap.find(attr);
+  std::unordered_map<int, BoundaryCondition *>::const_iterator obc = outletBCmap.find(attr);
+  std::unordered_map<int, BoundaryCondition *>::const_iterator wbc = wallBCmap.find(attr);
+  
+  if (ibc != inletBCmap.end()) ibc->second->computeBdrFlux(normal, stateIn, gradState, radius, bdrFlux);
+  if (obc != outletBCmap.end()) obc->second->computeBdrFlux(normal, stateIn, gradState, radius, bdrFlux);
+  if (wbc != wallBCmap.end()) wbc->second->computeBdrFlux(normal, stateIn, gradState, radius, bdrFlux);
+  
+//   BCmap[attr]->computeBdrFlux(normal, stateIn, gradState, radius, bdrFlux);
 }
 
 void BCintegrator::updateBCMean(ParGridFunction *Up) {
-  for (auto bc = BCmap.begin(); bc != BCmap.end(); bc++) {
+  for (auto bc = inletBCmap.begin(); bc != inletBCmap.end(); bc++) {
+    bc->second->updateMean(intRules, Up);
+  }
+  
+  for (auto bc = outletBCmap.begin(); bc != outletBCmap.end(); bc++) {
+    bc->second->updateMean(intRules, Up);
+  }
+  
+  for (auto bc = wallBCmap.begin(); bc != wallBCmap.end(); bc++) {
     bc->second->updateMean(intRules, Up);
   }
 }
 
 void BCintegrator::integrateBCs(Vector &y, const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds) {
-  for (auto bc = BCmap.begin(); bc != BCmap.end(); bc++) {
+  for (auto bc = inletBCmap.begin(); bc != inletBCmap.end(); bc++) {
+    bc->second->integrationBC(y,  // output
+                              x, nodesIDs, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, maxIntPoints,
+                              maxDofs);
+  }
+  
+  for (auto bc = outletBCmap.begin(); bc != outletBCmap.end(); bc++) {
+    bc->second->integrationBC(y,  // output
+                              x, nodesIDs, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, maxIntPoints,
+                              maxDofs);
+  }
+  
+  for (auto bc = wallBCmap.begin(); bc != wallBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
                               x, nodesIDs, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, maxIntPoints,
                               maxDofs);

--- a/src/BCintegrator.hpp
+++ b/src/BCintegrator.hpp
@@ -80,7 +80,9 @@ class BCintegrator : public NonlinearFormIntegrator {
   const int &maxIntPoints;
   const int &maxDofs;
 
-  std::unordered_map<int, BoundaryCondition *> BCmap;
+  std::unordered_map<int, BoundaryCondition *> inletBCmap;
+  std::unordered_map<int, BoundaryCondition *> outletBCmap;
+  std::unordered_map<int, BoundaryCondition *> wallBCmap;
 
   // void calcMeanState();
   void computeBdrFlux(const int attr, Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius,

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -50,7 +50,7 @@ InletBC::InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rs
   for (int i = 0; i < inputState.Size(); i++) hinputState[i] = _inputData[i];
   auto dinputState = inputState.ReadWrite();
 
-  groupsMPI->setAsInlet(_patchNumber);
+  groupsMPI->setPatch(_patchNumber);
 
   localMeanUp.UseDevice(true);
   localMeanUp.SetSize(num_equation + 1);
@@ -278,7 +278,7 @@ void InletBC::initBCs() {
   if (!BCinit) {
     // placeholder to compute aggregate mass flow rate for inlets
 
-    MPI_Comm bcomm = groupsMPI->getInletComm();
+    MPI_Comm bcomm = groupsMPI->getComm(patchNumber);
     double area = aggregateArea(patchNumber, bcomm);
     int nfaces = aggregateBndryFaces(patchNumber, bcomm);
 
@@ -501,7 +501,7 @@ void InletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
   h_localMeanUp[num_equation] = static_cast<double>(totNbdr);
 
   double *h_sum = glob_sum.HostWrite();
-  MPI_Allreduce(h_localMeanUp, h_sum, num_equation + 1, MPI_DOUBLE, MPI_SUM, groupsMPI->getInletComm());
+  MPI_Allreduce(h_localMeanUp, h_sum, num_equation + 1, MPI_DOUBLE, MPI_SUM, groupsMPI->getComm(patchNumber));
 
   BoundaryCondition::copyValues(glob_sum, meanUp, 1. / h_sum[num_equation]);
 

--- a/src/mpi_groups.cpp
+++ b/src/mpi_groups.cpp
@@ -37,13 +37,13 @@ using namespace std;
 
 MPI_Groups::MPI_Groups(MPI_Session* _mpi) : mpi(_mpi) {
   patchList_.SetSize(0);
-  
+
   patchGroupMap_.clear();
 }
 
 MPI_Groups::~MPI_Groups() {
   for (auto pg = patchGroupMap_.begin(); pg != patchGroupMap_.end(); pg++) {
-    MPI_Comm_free( &(pg->second) );
+    MPI_Comm_free(&(pg->second));
   }
 }
 
@@ -63,18 +63,17 @@ int MPI_Groups::groupSize(MPI_Comm group_comm) {
 }
 
 void MPI_Groups::init() {
-  
   int localMaxPatch = 0;
   if (patchList_.Size() > 0) localMaxPatch = patchList_.Max();
   int globalMax = 0.;
   MPI_Allreduce(&localMaxPatch, &globalMax, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
-  
+
   for (int p = 0; p <= globalMax; p++) {
     int processContainsPatch = 0;
     for (int n = 0; n < patchList_.Size(); n++) {
       if (patchList_[n] == p) processContainsPatch = p;
     }
-    
+
     MPI_Comm_split(MPI_COMM_WORLD, processContainsPatch, mpi->WorldRank(), &patchGroupMap_[p]);
   }
 }

--- a/src/mpi_groups.cpp
+++ b/src/mpi_groups.cpp
@@ -36,13 +36,15 @@
 using namespace std;
 
 MPI_Groups::MPI_Groups(MPI_Session* _mpi) : mpi(_mpi) {
-  isInlet = 0;
-  isOutlet = 0;
+  patchList_.SetSize(0);
+  
+  patchGroupMap_.clear();
 }
 
 MPI_Groups::~MPI_Groups() {
-  MPI_Comm_free(&inlet_comm);
-  MPI_Comm_free(&outlet_comm);
+  for (auto pg = patchGroupMap_.begin(); pg != patchGroupMap_.end(); pg++) {
+    MPI_Comm_free( &(pg->second) );
+  }
 }
 
 bool MPI_Groups::isGroupRoot(MPI_Comm group_comm) {
@@ -61,11 +63,20 @@ int MPI_Groups::groupSize(MPI_Comm group_comm) {
 }
 
 void MPI_Groups::init() {
-  // create inlet communicator
-  MPI_Comm_split(MPI_COMM_WORLD, isInlet, mpi->WorldRank(), &inlet_comm);
-
-  // create outlet communicator
-  MPI_Comm_split(MPI_COMM_WORLD, isOutlet, mpi->WorldRank(), &outlet_comm);
+  
+  int localMaxPatch = 0;
+  if (patchList_.Size() > 0) localMaxPatch = patchList_.Max();
+  int globalMax = 0.;
+  MPI_Allreduce(&localMaxPatch, &globalMax, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  
+  for (int p = 0; p < globalMax+1; p++) {
+    int processContainsPatch = 0;
+    for (int n = 0; n < patchList_.Size(); n++) {
+      if (patchList_[n] == p) processContainsPatch = p;
+    }
+    
+    MPI_Comm_split(MPI_COMM_WORLD, processContainsPatch, mpi->WorldRank(), &patchGroupMap_[p]);
+  }
 }
 
 string MPI_Groups::getParallelName(string serialName) {

--- a/src/mpi_groups.cpp
+++ b/src/mpi_groups.cpp
@@ -69,7 +69,7 @@ void MPI_Groups::init() {
   int globalMax = 0.;
   MPI_Allreduce(&localMaxPatch, &globalMax, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
   
-  for (int p = 0; p < globalMax+1; p++) {
+  for (int p = 0; p <= globalMax; p++) {
     int processContainsPatch = 0;
     for (int n = 0; n < patchList_.Size(); n++) {
       if (patchList_[n] == p) processContainsPatch = p;

--- a/src/mpi_groups.hpp
+++ b/src/mpi_groups.hpp
@@ -43,10 +43,11 @@ using namespace mfem;
 class MPI_Groups {
  private:
   MPI_Session *mpi;
-  
-  Array<int> patchList_; // list of patches visible to process
-  
-  std::unordered_map<int, MPI_Comm> patchGroupMap_; // maps of all group communicators by patch, i.e. <patch, communicator_patch>
+
+  Array<int> patchList_;  // list of patches visible to process
+
+  std::unordered_map<int, MPI_Comm>
+      patchGroupMap_;  // maps of all group communicators by patch, i.e. <patch, communicator_patch>
 
  public:
   MPI_Groups(MPI_Session *mpi);

--- a/src/mpi_groups.hpp
+++ b/src/mpi_groups.hpp
@@ -43,12 +43,10 @@ using namespace mfem;
 class MPI_Groups {
  private:
   MPI_Session *mpi;
-
-  MPI_Comm inlet_comm;
-  MPI_Comm outlet_comm;
-
-  int isOutlet;
-  int isInlet;
+  
+  Array<int> patchList_; // list of patches visible to process
+  
+  std::unordered_map<int, MPI_Comm> patchGroupMap_; // maps of all group communicators by patch, i.e. <patch, communicator_patch>
 
  public:
   MPI_Groups(MPI_Session *mpi);
@@ -60,13 +58,11 @@ class MPI_Groups {
   // function that creates the groups
   void init();
 
-  void setAsInlet(int patchNum) { isInlet = patchNum + 1000; }
-  void setAsOutlet(int patchNum) { isOutlet = patchNum + 2000; }
+  void setPatch(int patchNum) { patchList_.Append(patchNum); }
 
   MPI_Session *getSession() { return mpi; }
 
-  MPI_Comm getInletComm() { return inlet_comm; }
-  MPI_Comm getOutletComm() { return outlet_comm; }
+  MPI_Comm getComm(int patch) { return patchGroupMap_[patch]; }
 
   std::string getParallelName(std::string name);
 };

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -45,7 +45,7 @@ OutletBC::OutletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_
       inputState(_inputData),
       maxIntPoints(_maxIntPoints),
       maxDofs(_maxDofs) {
-  groupsMPI->setAsOutlet(_patchNumber);
+  groupsMPI->setPatch(_patchNumber);
 
   meanUp.UseDevice(true);
   meanUp.SetSize(num_equation);
@@ -316,7 +316,7 @@ void OutletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &grad
 void OutletBC::computeParallelArea() {
   if (parallelAreaComputed) return;
 
-  MPI_Comm bcomm = groupsMPI->getOutletComm();
+  MPI_Comm bcomm = groupsMPI->getComm(patchNumber);
   area = aggregateArea(patchNumber, bcomm);
   int nfaces = aggregateBndryFaces(patchNumber, bcomm);
   parallelAreaComputed = true;
@@ -520,7 +520,7 @@ void OutletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
   h_localMeanUp[num_equation] = static_cast<double>(totNbdr);
 
   double *h_sum = glob_sum.HostWrite();
-  MPI_Allreduce(h_localMeanUp, h_sum, num_equation + 1, MPI_DOUBLE, MPI_SUM, groupsMPI->getOutletComm());
+  MPI_Allreduce(h_localMeanUp, h_sum, num_equation + 1, MPI_DOUBLE, MPI_SUM, groupsMPI->getComm(patchNumber));
 
   BoundaryCondition::copyValues(glob_sum, meanUp, 1. / h_sum[num_equation]);
 


### PR DESCRIPTION
Tries to solve the hang when multiple inlet/outlet BCs are shared with different processes with inlet having a higher patch number than outlet