### PR TITLE
Enable Tps Python solver interface 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Bootstrap
         run:  module restore tps-gpu; ./bootstrap
       - name: Configure
-        run: module restore tps-gpu; ./configure --enable-gpu-cuda CUDA_ARCH=sm_75
+        run: module restore tps-gpu; ./configure --enable-pybind11 --enable-gpu-cuda CUDA_ARCH=sm_75
       - name: Make
         run: module restore tps-gpu; make -j 2
       - name: Tests
@@ -113,7 +113,7 @@ jobs:
       - name: Bootstrap
         run:  module restore tps-gpu; ./bootstrap
       - name: Configure
-        run: module restore tps-gpu; ./configure --enable-gpu-hip HIP_ARCH=gfx803
+        run: module restore tps-gpu; ./configure -enable-pybind11 --enable-gpu-hip HIP_ARCH=gfx803
       - name: Make
         run: module restore tps-gpu; make -j 2
       - name: Tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
    style:
      runs-on: ubuntu-20.04
      container:
-       image: koomietx/mfem:4.3.tps.masa_mod
+       image: koomietx/mfem:4.3.tps.v2
        options: --user 1001 --privileged
      name: Code style
      steps:
@@ -34,7 +34,7 @@ jobs:
    build:
      runs-on: ubuntu-20.04
      container:
-       image: koomietx/mfem:4.3.tps.masa_mod
+       image: koomietx/mfem:4.3.tps.v2
        options: --user 1001 --privileged
      name: Build/CPU
      steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
    style:
      runs-on: ubuntu-20.04
      container:
-       image: koomietx/mfem:4.3.tps.v2
+       image: koomietx/mfem:4.3.tps.masa_mod
        options: --user 1001 --privileged
      name: Code style
      steps:
@@ -34,7 +34,7 @@ jobs:
    build:
      runs-on: ubuntu-20.04
      container:
-       image: koomietx/mfem:4.3.tps.v2
+       image: koomietx/mfem:4.3.tps.masa_mod
        options: --user 1001 --privileged
      name: Build/CPU
      steps:

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 SUBDIRS          = src test utils
 AUTOMAKE_OPTIONS = foreign
 ACLOCAL_AMFLAGS  = -I m4
-EXTRA_DIST       = CHANGES LICENSE dist_version m4/snarf_mfem.py m4/wrap_lines.py
+EXTRA_DIST       = CHANGES LICENSE dist_version m4/snarf_mfem.py m4/wrap_lines.py src/tps.py
 
 # --------------------------------------------------
 # Revision control support for external distribution

--- a/configure.ac
+++ b/configure.ac
@@ -10,18 +10,31 @@ AC_CONFIG_MACRO_DIRS([m4])
 AM_INIT_AUTOMAKE([subdir-objects])
 AM_EXTRA_RECURSIVE_TARGETS([style enforcestyle])
 
-# Checks for programs.
-AM_PATH_PYTHON([3.6.8])
-
 AX_SUMMARIZE_ENV
-#AC_PROG_CXX
+# MPI
 AX_PROG_CC_MPI
 AX_PROG_CXX_MPI
-
-# C++ 17 standard, just setting by hand
-#AX_CXX_COMPILE_STDCXX_17
-#CXXFLAGS="-std=c++17 $CXXFLAGS"
+# python binary
+AM_PATH_PYTHON([3.6.8])
+# python interface
+AC_ARG_ENABLE([pybind11],
+         [AS_HELP_STRING([--enable-pybind11],[enable python interface [default=no]])],
+	 [],[enable_pybind11=no])
+if test ${enable_pybind11} == "yes" ; then
+   AX_PYTHON_DEVEL
+   CPPFLAGS="$PYTHON_CPPFLAGS $CPPFLAGS"
+   AC_LANG_PUSH([C++])
+   AC_CHECK_HEADER([pybind11/pybind11.h],[],[found_pybind11_header=no])
+   if test "x${found_pybind11_header}" = "xno" ; then
+      AC_MSG_ERROR([pybind11 header not found. Please verify pybind11 is installed locally.])
+   fi
+   AC_LANG_POP([C++])
+   AM_CONDITIONAL(PYTHON_ENABLED,test x$enable_pybind11 = xyes)
+fi
+# enable c++11 standard
 CXXFLAGS="-std=c++11 $CXXFLAGS"
+# libtool
+AC_PROG_LIBTOOL
 
 # check for mpi-ext.h
 AH_TEMPLATE([HAVE_MPI_EXT],[Enable MPI extensions declared in mpi-ext.h])
@@ -30,19 +43,18 @@ if test "x${found_mpi_ext}" = "xyes" ; then
    AC_DEFINE([HAVE_MPI_EXT])
 fi
 
+#--------------------
 # 3rd party libraries
-
+#--------------------
 AX_PATH_GRVY([0.36], [yes])
 AX_PATH_HDF5([1.8.0],[yes])
 AX_PATH_OPENBLAS([no])
-
 ENABLE_MASA=no
 AX_PATH_MASA([0.50], [no])
 if test x$HAVE_MASA = x1 ; then
    ENABLE_MASA=yes
 fi
-
-AC_PROG_RANLIB
+dnl AC_PROG_RANLIB
 
 # Valgrind?
 AX_VALGRIND_CHECK()
@@ -72,6 +84,7 @@ if test "x$enable_slurm" != "xno" ; then
    fi
 fi
 AM_CONDITIONAL(SLURM_ENABLED,test x$ENABLE_SLURM = xyes)
+
 
 
 #-- GSLIB support in MFEM?
@@ -206,3 +219,4 @@ fi
 
 dnl Final summary
 AX_SUMMARIZE_CONFIG
+

--- a/configure.ac
+++ b/configure.ac
@@ -29,8 +29,10 @@ if test ${enable_pybind11} == "yes" ; then
       AC_MSG_ERROR([pybind11 header not found. Please verify pybind11 is installed locally.])
    fi
    AC_LANG_POP([C++])
-   AM_CONDITIONAL(PYTHON_ENABLED,test x$enable_pybind11 = xyes)
+
 fi
+AM_CONDITIONAL(PYTHON_ENABLED,test x$enable_pybind11 = xyes)
+
 # enable c++11 standard
 CXXFLAGS="-std=c++11 $CXXFLAGS"
 # libtool

--- a/configure.ac
+++ b/configure.ac
@@ -12,8 +12,9 @@ AM_EXTRA_RECURSIVE_TARGETS([style enforcestyle])
 
 AX_SUMMARIZE_ENV
 # MPI
-AX_PROG_CC_MPI
 AX_PROG_CXX_MPI
+# libtool/dynamic library support
+AC_PROG_LIBTOOL
 # python binary
 AM_PATH_PYTHON([3.6.8])
 # python interface
@@ -35,8 +36,6 @@ AM_CONDITIONAL(PYTHON_ENABLED,test x$enable_pybind11 = xyes)
 
 # enable c++11 standard
 CXXFLAGS="-std=c++11 $CXXFLAGS"
-# libtool
-AC_PROG_LIBTOOL
 
 # check for mpi-ext.h
 AH_TEMPLATE([HAVE_MPI_EXT],[Enable MPI extensions declared in mpi-ext.h])
@@ -162,8 +161,14 @@ AX_CHECK_CUDA
 AC_LANG_POP([C])
 
 CXX=$NVCC_PATH/nvcc
-CUDA_CXXFLAGS="-x=cu --expt-extended-lambda -arch=$CUDA_ARCH -ccbin mpicxx $CUDA_CXXFLAGS"
-CUDA_LDFLAGS="--expt-extended-lambda -arch=$CUDA_ARCH -ccbin mpicxx $CUDA_LDFLAGS"
+CUDA_CXXFLAGS="-Xcompiler=-fPIC -x=cu --expt-extended-lambda -arch=$CUDA_ARCH -ccbin mpicxx $CUDA_CXXFLAGS"
+CUDA_LDFLAGS="--expt-extended-lambda -arch=$CUDA_ARCH -ccbin mpicxx $CUDA_LDFLAGS -lcuda -lcudart"
+
+dnl CUDA does not support -fPIC, disable in libtool in favor of -Xcompiler option above
+_LT_TAGVAR(lt_prog_compiler_pic,)=''
+_LT_TAGVAR(lt_prog_compiler_pic,CXX)=''
+dnl CUDA aldo does not support -Wl linker option, replace with -Xlinker
+_LT_TAGVAR(lt_prog_compiler_wl,CXX)='-Xlinker '
 
 ENABLE_GPU=yes
 ENABLE_CUDA=yes

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -77,6 +77,7 @@ RUN yum -y install bc
 RUN yum -y install clang-tools-extra
 RUN yum -y install zlib-devel
 RUN yum -y install libcurl-devel
+RUN yum -y install python3-pybind11
 
 # Register new libs installed into /usr/local/lib with linker
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/class.conf

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -75,6 +75,8 @@ RUN yum -y install aspell
 RUN yum -y install cmake-ohpc
 RUN yum -y install bc
 RUN yum -y install clang-tools-extra
+RUN yum -y install zlib-devel
+RUN yum -y install libcurl-devel
 
 # Register new libs installed into /usr/local/lib with linker
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/class.conf

--- a/m4/ax_check_cuda.m4
+++ b/m4/ax_check_cuda.m4
@@ -67,7 +67,15 @@ AC_SUBST([CUDA_LDFLAGS])
 
 CUDA_CXXFLAGS="-I$cuda_prefix/include"
 CXXFLAGS="$CUDA_CXXFLAGS $CXXFLAGS"
-CUDA_LDFLAGS="-L$cuda_prefix/lib"
+
+# Check for lib directory
+CUDA_LDFLAGS=""
+if test -x "$cuda_prefix/lib"; then
+   CUDA_LDFLAGS="-L$cuda_prefix/lib"
+fi
+if test -x "$cuda_prefix/lib64"; then
+   CUDA_LDFLAGS="-L$cuda_prefix/lib64"
+fi
 LDFLAGS="$CUDA_LDFLAGS $LDFLAGS"
 
 # And the header and the lib

--- a/m4/ax_python_devel.m4
+++ b/m4/ax_python_devel.m4
@@ -1,0 +1,368 @@
+# ===========================================================================
+#     https://www.gnu.org/software/autoconf-archive/ax_python_devel.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PYTHON_DEVEL([version])
+#
+# DESCRIPTION
+#
+#   Note: Defines as a precious variable "PYTHON_VERSION". Don't override it
+#   in your configure.ac.
+#
+#   This macro checks for Python and tries to get the include path to
+#   'Python.h'. It provides the $(PYTHON_CPPFLAGS) and $(PYTHON_LIBS) output
+#   variables. It also exports $(PYTHON_EXTRA_LIBS) and
+#   $(PYTHON_EXTRA_LDFLAGS) for embedding Python in your code.
+#
+#   You can search for some particular version of Python by passing a
+#   parameter to this macro, for example ">= '2.3.1'", or "== '2.4'". Please
+#   note that you *have* to pass also an operator along with the version to
+#   match, and pay special attention to the single quotes surrounding the
+#   version number. Don't use "PYTHON_VERSION" for this: that environment
+#   variable is declared as precious and thus reserved for the end-user.
+#
+#   This macro should work for all versions of Python >= 2.1.0. As an end
+#   user, you can disable the check for the python version by setting the
+#   PYTHON_NOVERSIONCHECK environment variable to something else than the
+#   empty string.
+#
+#   If you need to use this macro for an older Python version, please
+#   contact the authors. We're always open for feedback.
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Sebastian Huber <sebastian-huber@web.de>
+#   Copyright (c) 2009 Alan W. Irwin
+#   Copyright (c) 2009 Rafael Laboissiere <rafael@laboissiere.net>
+#   Copyright (c) 2009 Andrew Collier
+#   Copyright (c) 2009 Matteo Settenvini <matteo@member.fsf.org>
+#   Copyright (c) 2009 Horst Knorr <hk_classes@knoda.org>
+#   Copyright (c) 2013 Daniel Mullner <muellner@math.stanford.edu>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 23
+
+AU_ALIAS([AC_PYTHON_DEVEL], [AX_PYTHON_DEVEL])
+AC_DEFUN([AX_PYTHON_DEVEL],[
+	#
+	# Allow the use of a (user set) custom python version
+	#
+	AC_ARG_VAR([PYTHON_VERSION],[The installed Python
+		version to use, for example '2.3'. This string
+		will be appended to the Python interpreter
+		canonical name.])
+
+	AC_PATH_PROG([PYTHON],[python[$PYTHON_VERSION]])
+	if test -z "$PYTHON"; then
+	   AC_MSG_ERROR([Cannot find python$PYTHON_VERSION in your system path])
+	   PYTHON_VERSION=""
+	fi
+
+	#
+	# Check for a version of Python >= 2.1.0
+	#
+	AC_MSG_CHECKING([for a version of Python >= '2.1.0'])
+	ac_supports_python_ver=`$PYTHON -c "import sys; \
+		ver = sys.version.split ()[[0]]; \
+		print (ver >= '2.1.0')"`
+	if test "$ac_supports_python_ver" != "True"; then
+		if test -z "$PYTHON_NOVERSIONCHECK"; then
+			AC_MSG_RESULT([no])
+			AC_MSG_FAILURE([
+This version of the AC@&t@_PYTHON_DEVEL macro
+doesn't work properly with versions of Python before
+2.1.0. You may need to re-run configure, setting the
+variables PYTHON_CPPFLAGS, PYTHON_LIBS, PYTHON_SITE_PKG,
+PYTHON_EXTRA_LIBS and PYTHON_EXTRA_LDFLAGS by hand.
+Moreover, to disable this check, set PYTHON_NOVERSIONCHECK
+to something else than an empty string.
+])
+		else
+			AC_MSG_RESULT([skip at user request])
+		fi
+	else
+		AC_MSG_RESULT([yes])
+	fi
+
+	#
+	# if the macro parameter ``version'' is set, honour it
+	#
+	if test -n "$1"; then
+		AC_MSG_CHECKING([for a version of Python $1])
+		ac_supports_python_ver=`$PYTHON -c "import sys; \
+			ver = sys.version.split ()[[0]]; \
+			print (ver $1)"`
+		if test "$ac_supports_python_ver" = "True"; then
+		   AC_MSG_RESULT([yes])
+		else
+			AC_MSG_RESULT([no])
+			AC_MSG_ERROR([this package requires Python $1.
+If you have it installed, but it isn't the default Python
+interpreter in your system path, please pass the PYTHON_VERSION
+variable to configure. See ``configure --help'' for reference.
+])
+			PYTHON_VERSION=""
+		fi
+	fi
+
+	#
+	# Check if you have distutils, else fail
+	#
+	AC_MSG_CHECKING([for the sysconfig Python package])
+	ac_sysconfig_result=`$PYTHON -c "import sysconfig" 2>&1`
+	if test $? -eq 0; then
+		AC_MSG_RESULT([yes])
+		IMPORT_SYSCONFIG="import sysconfig"
+	else
+		AC_MSG_RESULT([no])
+
+		AC_MSG_CHECKING([for the distutils Python package])
+		ac_sysconfig_result=`$PYTHON -c "from distutils import sysconfig" 2>&1`
+		if test $? -eq 0; then
+			AC_MSG_RESULT([yes])
+			IMPORT_SYSCONFIG="from distutils import sysconfig"
+		else
+			AC_MSG_ERROR([cannot import Python module "distutils".
+Please check your Python installation. The error was:
+$ac_sysconfig_result])
+			PYTHON_VERSION=""
+		fi
+	fi
+
+	#
+	# Check for Python include path
+	#
+	AC_MSG_CHECKING([for Python include path])
+	if test -z "$PYTHON_CPPFLAGS"; then
+		if test "$IMPORT_SYSCONFIG" = "import sysconfig"; then
+			# sysconfig module has different functions
+			python_path=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_path ('include'));"`
+			plat_python_path=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_path ('platinclude'));"`
+		else
+			# old distutils way
+			python_path=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_python_inc ());"`
+			plat_python_path=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_python_inc (plat_specific=1));"`
+		fi
+		if test -n "${python_path}"; then
+			if test "${plat_python_path}" != "${python_path}"; then
+				python_path="-I$python_path -I$plat_python_path"
+			else
+				python_path="-I$python_path"
+			fi
+		fi
+		PYTHON_CPPFLAGS=$python_path
+	fi
+	AC_MSG_RESULT([$PYTHON_CPPFLAGS])
+	AC_SUBST([PYTHON_CPPFLAGS])
+
+	#
+	# Check for Python library path
+	#
+	AC_MSG_CHECKING([for Python library path])
+	if test -z "$PYTHON_LIBS"; then
+		# (makes two attempts to ensure we've got a version number
+		# from the interpreter)
+		ac_python_version=`cat<<EOD | $PYTHON -
+
+# join all versioning strings, on some systems
+# major/minor numbers could be in different list elements
+from sysconfig import *
+e = get_config_var('VERSION')
+if e is not None:
+	print(e)
+EOD`
+
+		if test -z "$ac_python_version"; then
+			if test -n "$PYTHON_VERSION"; then
+				ac_python_version=$PYTHON_VERSION
+			else
+				ac_python_version=`$PYTHON -c "import sys; \
+					print (sys.version[[:3]])"`
+			fi
+		fi
+
+		# Make the versioning information available to the compiler
+		AC_DEFINE_UNQUOTED([HAVE_PYTHON], ["$ac_python_version"],
+                                   [If available, contains the Python version number currently in use.])
+
+		# First, the library directory:
+		ac_python_libdir=`cat<<EOD | $PYTHON -
+
+# There should be only one
+$IMPORT_SYSCONFIG
+e = sysconfig.get_config_var('LIBDIR')
+if e is not None:
+	print (e)
+EOD`
+
+		# Now, for the library:
+		ac_python_library=`cat<<EOD | $PYTHON -
+
+$IMPORT_SYSCONFIG
+c = sysconfig.get_config_vars()
+if 'LDVERSION' in c:
+	print ('python'+c[['LDVERSION']])
+else:
+	print ('python'+c[['VERSION']])
+EOD`
+
+		# This small piece shamelessly adapted from PostgreSQL python macro;
+		# credits goes to momjian, I think. I'd like to put the right name
+		# in the credits, if someone can point me in the right direction... ?
+		#
+		if test -n "$ac_python_libdir" -a -n "$ac_python_library"
+		then
+			# use the official shared library
+			ac_python_library=`echo "$ac_python_library" | sed "s/^lib//"`
+			PYTHON_LIBS="-L$ac_python_libdir -l$ac_python_library"
+		else
+			# old way: use libpython from python_configdir
+			ac_python_libdir=`$PYTHON -c \
+			  "from sysconfig import get_python_lib as f; \
+			  import os; \
+			  print (os.path.join(f(plat_specific=1, standard_lib=1), 'config'));"`
+			PYTHON_LIBS="-L$ac_python_libdir -lpython$ac_python_version"
+		fi
+
+		if test -z "PYTHON_LIBS"; then
+			AC_MSG_ERROR([
+  Cannot determine location of your Python DSO. Please check it was installed with
+  dynamic libraries enabled, or try setting PYTHON_LIBS by hand.
+			])
+		fi
+	fi
+	AC_MSG_RESULT([$PYTHON_LIBS])
+	AC_SUBST([PYTHON_LIBS])
+
+	#
+	# Check for site packages
+	#
+	AC_MSG_CHECKING([for Python site-packages path])
+	if test -z "$PYTHON_SITE_PKG"; then
+		if test "$IMPORT_SYSCONFIG" = "import sysconfig"; then
+			PYTHON_SITE_PKG=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_path('purelib'));"`
+		else
+			# distutils.sysconfig way
+			PYTHON_SITE_PKG=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_python_lib(0,0));"`
+		fi
+	fi
+	AC_MSG_RESULT([$PYTHON_SITE_PKG])
+	AC_SUBST([PYTHON_SITE_PKG])
+
+	#
+	# Check for platform-specific site packages
+	#
+	AC_MSG_CHECKING([for Python platform specific site-packages path])
+	if test -z "$PYTHON_SITE_PKG"; then
+		if test "$IMPORT_SYSCONFIG" = "import sysconfig"; then
+			PYTHON_PLATFORM_SITE_PKG=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_path('platlib'));"`
+		else
+			# distutils.sysconfig way
+			PYTHON_PLATFORM_SITE_PKG=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_python_lib(1,0));"`
+		fi
+	fi
+	AC_MSG_RESULT([$PYTHON_PLATFORM_SITE_PKG])
+	AC_SUBST([PYTHON_PLATFORM_SITE_PKG])
+
+	#
+	# libraries which must be linked in when embedding
+	#
+	AC_MSG_CHECKING(python extra libraries)
+	if test -z "$PYTHON_EXTRA_LIBS"; then
+	   PYTHON_EXTRA_LIBS=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+                conf = sysconfig.get_config_var; \
+                print (conf('LIBS') + ' ' + conf('SYSLIBS'))"`
+	fi
+	AC_MSG_RESULT([$PYTHON_EXTRA_LIBS])
+	AC_SUBST(PYTHON_EXTRA_LIBS)
+
+	#
+	# linking flags needed when embedding
+	#
+	AC_MSG_CHECKING(python extra linking flags)
+	if test -z "$PYTHON_EXTRA_LDFLAGS"; then
+		PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+			conf = sysconfig.get_config_var; \
+			print (conf('LINKFORSHARED'))"`
+	fi
+	AC_MSG_RESULT([$PYTHON_EXTRA_LDFLAGS])
+	AC_SUBST(PYTHON_EXTRA_LDFLAGS)
+
+	#
+	# final check to see if everything compiles alright
+	#
+	AC_MSG_CHECKING([consistency of all components of python development environment])
+	# save current global flags
+	ac_save_LIBS="$LIBS"
+	ac_save_LDFLAGS="$LDFLAGS"
+	ac_save_CPPFLAGS="$CPPFLAGS"
+	LIBS="$ac_save_LIBS $PYTHON_LIBS $PYTHON_EXTRA_LIBS $PYTHON_EXTRA_LIBS"
+	LDFLAGS="$ac_save_LDFLAGS $PYTHON_EXTRA_LDFLAGS"
+	CPPFLAGS="$ac_save_CPPFLAGS $PYTHON_CPPFLAGS"
+	AC_LANG_PUSH([C])
+	AC_LINK_IFELSE([
+		AC_LANG_PROGRAM([[#include <Python.h>]],
+				[[Py_Initialize();]])
+		],[pythonexists=yes],[pythonexists=no])
+	AC_LANG_POP([C])
+	# turn back to default flags
+	CPPFLAGS="$ac_save_CPPFLAGS"
+	LIBS="$ac_save_LIBS"
+	LDFLAGS="$ac_save_LDFLAGS"
+
+	AC_MSG_RESULT([$pythonexists])
+
+        if test ! "x$pythonexists" = "xyes"; then
+	   AC_MSG_FAILURE([
+  Could not link test program to Python. Maybe the main Python library has been
+  installed in some non-standard library path. If so, pass it to configure,
+  via the LIBS environment variable.
+  Example: ./configure LIBS="-L/usr/non-standard-path/python/lib"
+  ============================================================================
+   ERROR!
+   You probably have to install the development version of the Python package
+   for your distribution.  The exact name of this package varies among them.
+  ============================================================================
+	   ])
+	  PYTHON_VERSION=""
+	fi
+
+	#
+	# all done!
+	#
+])

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -49,14 +49,15 @@ echo [Additional Options]:
 echo
 echo SLURM support enabled....... : $ENABLE_SLURM
 echo Valgrind available.......... : $enable_valgrind
-
 echo MASA support enabled........ : $ENABLE_MASA
 if test "x$ENABLE_MASA" = "xyes"; then
 echo '  ' CXX flags................ : $MASA_CXXFLAGS
 echo '  ' LIBS..................... : $MASA_LIBS
 fi
-
-
+echo Python interface............ : $enable_pybind11
+if test "$enable_pybind11" = "yes"; then
+echo '   ' CXX flags............... : $PYTHON_CPPFLAGS
+fi
 echo GPU build enabled with CUDA. : $ENABLE_CUDA
 if test "$ENABLE_CUDA" = "yes"; then
 AS_ECHO("`$srcdir/m4/wrap_lines.py --maxWidth 110 --first 1 --remain 31 --prefix "   CUDA_CXXFLAGS............ :" \

--- a/m4/hdf5.m4
+++ b/m4/hdf5.m4
@@ -75,7 +75,7 @@ if test "${with_hdf5}" != no ; then
     CFLAGS="${HDF5_CFLAGS} ${CFLAGS}"
     CPPFLAGS="${HDF5_CFLAGS} ${CPPFLAGS}"
     LDFLAGS="${HDF5_LIBS} ${LDFLAGS}"
-    AC_LANG_PUSH([C])
+    AC_LANG_PUSH([C++])
     AC_CHECK_HEADER([hdf5.h],[found_header=yes],[found_header=no])
 
     #-----------------------
@@ -106,7 +106,7 @@ if test "${with_hdf5}" != no ; then
     # begin additional test(s) if header if available
 
     succeeded=no
-    AC_LANG_PUSH([C])
+    AC_LANG_PUSH([C++])
 
     if test "x${found_header}" = "xyes" ; then
         version_succeeded=no
@@ -128,7 +128,7 @@ if test "${with_hdf5}" != no ; then
             AC_MSG_RESULT(no)
         ])
 
-    	AC_LANG_POP([C])
+        AC_LANG_POP([C++])
 
     	if test "$version_succeeded" != "yes";then
        	   if test "$is_package_required" = yes; then	
@@ -145,7 +145,7 @@ if test "${with_hdf5}" != no ; then
     # Library availability
 
     AC_CHECK_LIB([hdf5],[H5Fopen],[found_library=yes],[found_library=no])
-    AC_LANG_POP([C])
+    AC_LANG_POP([C++])
 
     succeeded=no
     if test "$found_header" = yes; then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,27 +21,10 @@ tps_LDFLAGS=
 # C++ main solver binary
 bin_PROGRAMS         = tps
 tps_SOURCES          = main.cpp
-tps_LDADD            = libtps.a
-tps_LDADD           += $(HDF5_LIBS)
-tps_LDADD           += $(GRVY_LIBS)
-tps_LDADD           += $(MFEM_LIBS)
+tps_LDADD            = libtps.la
+tps_LDFLAGS         += $(PYTHON_LIBS)
 
-if SLURM_ENABLED
-tps_LDFLAGS         += -lslurm
-endif
 
-if CUDA_ENABLED
-tps_LDFLAGS         += $(CUDA_LDFLAGS) -lcuda -lcusparse
-endif
-
-if HIP_ENABLED
-tps_LDFLAGS         += $(HIP_LDFLAGS)
-endif
-
-if GSLIB_ENABLED
-tps_LDADD   += -lgs
-tps_LDFLAGS += -L$(GSLIB_LIB)
-endif
 
 if MASA_ENABLED
 tps_LDFLAGS += $(MASA_LIBS)
@@ -68,8 +51,30 @@ headers              = averaging_and_rms.hpp equation_of_state.hpp transport_pro
 
 mfem_extra_headers   = ../utils/mfem_extras/pfem_extras.hpp
 
-noinst_LIBRARIES     = libtps.a
-libtps_a_SOURCES     = $(cxx_sources) $(mfem_extra_sources) $(headers) $(mfem_extra_headers)
+## noinst_LIBRARIES     = libtps.a
+## libtps_a_SOURCES     = $(cxx_sources) $(mfem_extra_sources) $(headers) $(mfem_extra_headers)
+
+lib_LTLIBRARIES      = libtps.la
+libtps_la_SOURCES    = $(cxx_sources) $(mfem_extra_sources) $(headers) $(mfem_extra_headers)
+libtps_la_LIBADD     = $(MFEM_LIBS)
+libtps_la_LIBADD    += $(HDF5_LIBS)
+libtps_la_LIBADD    += $(GRVY_LIBS)
+
+if SLURM_ENABLED
+libtps_la_LIBADD    += -lslurm
+endif
+
+if CUDA_ENABLED
+libtps_la_LIBADD    += $(CUDA_LDFLAGS) -lcuda -lcusparse
+endif
+
+if HIP_ENABLED
+libtps_la_LIBADD    += $(HIP_LDFLAGS)
+endif
+
+if GSLIB_ENABLED
+libtps_la_LIBADD    += -L$(GSLIB_LIB) -lgs
+endif
 
 # Python wrapper for C++ solver library
 ### pyexec_LTLIBRARIES   = pytps.la

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -65,6 +65,7 @@ libtps_la_LIBADD    += -lslurm
 endif
 
 if CUDA_ENABLED
+tps_LDFLAGS         += $(CUDA_LDFLAGS)
 libtps_la_LIBADD    += $(CUDA_LDFLAGS) -lcuda -lcusparse
 endif
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,7 +22,7 @@ tps_LDFLAGS=
 bin_PROGRAMS         = tps
 tps_SOURCES          = main.cpp
 tps_LDADD            = libtps.la
-tps_LDFLAGS         += $(PYTHON_LIBS)
+tps_LDFLAGS         += $(PYTHON_LIBS) $(MFEM_LIBS)
 
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,7 @@
 #include "tps.hpp"
 
 int main(int argc, char *argv[]) {
-  TPS::Tps tps(argc, argv);
+  TPS::Tps tps;
 
   tps.parseCommandLineArgs(argc, argv);
   tps.parseInput();

--- a/src/tps.hpp
+++ b/src/tps.hpp
@@ -113,7 +113,7 @@ class Tps {
   }
   void printHeader();
   void parseCommandLineArgs(int argc, char *argv[]);
-  void parseArgs(std::vector<std::string> argv);
+  void parseArgs(std::vector<std::string> argv); // used in python interface
   void parseInput();
 
   mfem::MPI_Session &getMPISession() { return mpi_; }

--- a/src/tps.hpp
+++ b/src/tps.hpp
@@ -112,8 +112,8 @@ class Tps {
     return;
   }
   void printHeader();
-  void parseCommandLineArgs(int argc, char *argv[]);
-  void parseArgs(std::vector<std::string> argv); // used in python interface
+  void parseCommandLineArgs(int argc, char *argv[]);  // variant used in C++ interface
+  void parseArgs(std::vector<std::string> argv);      // variant used in python interface
   void parseInput();
 
   mfem::MPI_Session &getMPISession() { return mpi_; }

--- a/src/tps.hpp
+++ b/src/tps.hpp
@@ -76,7 +76,7 @@ class Tps {
   TPS::Solver *solver_ = NULL;
 
  public:
-  Tps(int argc, char *argv[]);     // constructor
+  Tps();                           // constructor
   ~Tps();                          // destructor
   GRVY::GRVY_Input_Class iparse_;  // runtime input parser
 
@@ -113,6 +113,7 @@ class Tps {
   }
   void printHeader();
   void parseCommandLineArgs(int argc, char *argv[]);
+  void parseArgs(std::vector<std::string> argv);
   void parseInput();
 
   mfem::MPI_Session &getMPISession() { return mpi_; }

--- a/src/tps.py
+++ b/src/tps.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import sys
+import os
+
+# set path to C++ TPS library
+path = os.path.abspath(os.path.dirname(sys.argv[0]))
+sys.path.append(path + "/.libs")
+import libtps as tps
+
+# TPS solver
+tps = tps.Tps()
+
+tps.parseCommandLineArgs(sys.argv)
+tps.parseInput()
+tps.chooseDevices()
+tps.chooseSolver()
+tps.solve()
+
+sys.exit (tps.getStatus())

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -39,8 +39,13 @@ TESTS += cyl3d.gpu.test \
 	 cyl3d.mflow.gpu.test \
 	 wedge.gpu.test \
 	 averages.gpu.test
+
+if PYTHON_ENABLED
+TESTS += cyl3d.python.gpu.test
+endif
+
 else
-TESTS += cyl3d.test \
+TESTS += cyl3d.test
 	 cyl3d.mflow.test \
 	 cyl3d.dtconst.test \
 	 averages.test \
@@ -56,6 +61,11 @@ TESTS += cyl3d.test \
 	 diffusion_wall.test \
 	 reaction.test \
 	 inflow_outflow.test
+
+if PYTHON_ENABLED
+TESTS += cyl3d.python.test
+endif
+
 endif
 
 if GSLIB_ENABLED

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -97,82 +97,46 @@ endif
 
 if !GPU_ENABLED
 
-check_PROGRAMS += perfect_mixture_test
+check_PROGRAMS               += perfect_mixture_test
 perfect_mixture_test_SOURCES  = test_perfect_mixture.cpp
-perfect_mixture_test_LDADD    = ../src/libtps.a
-perfect_mixture_test_LDADD    += $(HDF5_LIBS)
-perfect_mixture_test_LDADD    += $(GRVY_LIBS)
-perfect_mixture_test_LDADD    += $(MFEM_LIBS)
+perfect_mixture_test_LDADD    = ../src/libtps.la
+perfect_mixture_test_LDADD   += $(HDF5_LIBS)
+perfect_mixture_test_LDADD   += $(GRVY_LIBS)
+perfect_mixture_test_LDFLAGS  = $(PYTHON_LIBS) $(MFEM_LIBS)
 
-perfect_mixture_test_LDFLAGS  =
-# perfect_mixture_test_LDFLAGS += $(HDF5_LIBS)
-# perfect_mixture_test_LDFLAGS += -L$(HYPRE_LIB) -lHYPRE
-# perfect_mixture_test_LDFLAGS += -L$(OPENBLAS_LIB) -lopenblas
-# perfect_mixture_test_LDFLAGS += -L$(METIS_LIB) -lmetis
-# perfect_mixture_test_LDFLAGS += $(GRVY_LIBS)
-# perfect_mixture_test_LDFLAGS += -L$(SUPERLU_DIST_LIB) -lsuperlu_dist
-# perfect_mixture_test_LDFLAGS += -L$(NETCDF_LIB) -lnetcdf
-# perfect_mixture_test_LDFLAGS += -L$(GSLIB_LIB) -lgs
 if MASA_ENABLED
 perfect_mixture_test_LDFLAGS += $(MASA_LIBS)
 endif
 
-check_PROGRAMS += test_speed_of_sound
-test_speed_of_sound_SOURCES  = test_speed_of_sound.cpp
-test_speed_of_sound_LDADD    = ../src/libtps.a
-test_speed_of_sound_LDADD    += $(HDF5_LIBS)
-test_speed_of_sound_LDADD    += $(GRVY_LIBS)
-test_speed_of_sound_LDADD    += $(MFEM_LIBS)
+check_PROGRAMS               += test_speed_of_sound
+test_speed_of_sound_SOURCES   = test_speed_of_sound.cpp
+test_speed_of_sound_LDADD     = ../src/libtps.la
+test_speed_of_sound_LDADD     += $(HDF5_LIBS)
+test_speed_of_sound_LDADD     += $(GRVY_LIBS)
+test_speed_of_sound_LDFLAGS   = $(PYTHON_LIBS) $(MFEM_LIBS)
 
-test_speed_of_sound_LDFLAGS  =
-# test_speed_of_sound_LDFLAGS += $(HDF5_LIBS)
-# test_speed_of_sound_LDFLAGS += -L$(HYPRE_LIB) -lHYPRE
-# test_speed_of_sound_LDFLAGS += -L$(OPENBLAS_LIB) -lopenblas
-# test_speed_of_sound_LDFLAGS += -L$(METIS_LIB) -lmetis
-# test_speed_of_sound_LDFLAGS += $(GRVY_LIBS)
-# test_speed_of_sound_LDFLAGS += -L$(SUPERLU_DIST_LIB) -lsuperlu_dist
-# test_speed_of_sound_LDFLAGS += -L$(NETCDF_LIB) -lnetcdf
-# test_speed_of_sound_LDFLAGS += -L$(GSLIB_LIB) -lgs
 if MASA_ENABLED
-test_speed_of_sound_LDFLAGS += $(MASA_LIBS)
+test_speed_of_sound_LDFLAGS  += $(MASA_LIBS)
 endif
 
-check_PROGRAMS += test_collision
-test_collision_SOURCES  = test_collision_integral.cpp
-test_collision_LDADD    = ../src/libtps.a
-test_collision_LDADD    += $(HDF5_LIBS)
-test_collision_LDADD    += $(GRVY_LIBS)
-test_collision_LDADD    += $(MFEM_LIBS)
+check_PROGRAMS               += test_collision
+test_collision_SOURCES        = test_collision_integral.cpp
+test_collision_LDADD          = ../src/libtps.la
+test_collision_LDADD         += $(HDF5_LIBS)
+test_collision_LDADD         += $(GRVY_LIBS)
+test_collision_LDFLAGS        = $(PYTHON_LIBS) $(MFEM_LIBS)
 
-test_collision_LDFLAGS  =
-# test_collision_LDFLAGS += $(HDF5_LIBS)
-# test_collision_LDFLAGS += -L$(HYPRE_LIB) -lHYPRE
-# test_collision_LDFLAGS += -L$(OPENBLAS_LIB) -lopenblas
-# test_collision_LDFLAGS += -L$(METIS_LIB) -lmetis
-# test_collision_LDFLAGS += $(GRVY_LIBS)
-# test_collision_LDFLAGS += -L$(SUPERLU_DIST_LIB) -lsuperlu_dist
-# test_collision_LDFLAGS += -L$(NETCDF_LIB) -lnetcdf
-# test_collision_LDFLAGS += -L$(GSLIB_LIB) -lgs
 if MASA_ENABLED
-test_collision_LDFLAGS += $(MASA_LIBS)
+test_collision_LDFLAGS       += $(MASA_LIBS)
 endif
 
-check_PROGRAMS += test_argon_minimal
-test_argon_minimal_SOURCES  = test_argon_minimal.cpp
-test_argon_minimal_LDADD    = ../src/libtps.a
-test_argon_minimal_LDADD    += $(HDF5_LIBS)
-test_argon_minimal_LDADD    += $(GRVY_LIBS)
-test_argon_minimal_LDADD    += $(MFEM_LIBS)
+check_PROGRAMS               += test_argon_minimal
+test_argon_minimal_SOURCES    = test_argon_minimal.cpp
+test_argon_minimal_LDADD      = ../src/libtps.la
+test_argon_minimal_LDADD     += $(HDF5_LIBS)
+test_argon_minimal_LDADD     += $(GRVY_LIBS)
+test_argon_minimal_LDFLAGS    = $(PYTHON_LIBS) $(MFEM_LIBS)
 
-test_argon_minimal_LDFLAGS  =
-# test_argon_minimal_LDFLAGS += $(HDF5_LIBS)
-# test_argon_minimal_LDFLAGS += -L$(HYPRE_LIB) -lHYPRE
-# test_argon_minimal_LDFLAGS += -L$(OPENBLAS_LIB) -lopenblas
-# test_argon_minimal_LDFLAGS += -L$(METIS_LIB) -lmetis
-# test_argon_minimal_LDFLAGS += $(GRVY_LIBS)
-# test_argon_minimal_LDFLAGS += -L$(SUPERLU_DIST_LIB) -lsuperlu_dist
-# test_argon_minimal_LDFLAGS += -L$(NETCDF_LIB) -lnetcdf
-# test_argon_minimal_LDFLAGS += -L$(GSLIB_LIB) -lgs
 if MASA_ENABLED
 test_argon_minimal_LDFLAGS += $(MASA_LIBS)
 endif

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -45,7 +45,7 @@ TESTS += cyl3d.gpu.python.test
 endif
 
 else
-TESTS += cyl3d.test
+TESTS += cyl3d.test \
 	 cyl3d.mflow.test \
 	 cyl3d.dtconst.test \
 	 averages.test \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -41,7 +41,7 @@ TESTS += cyl3d.gpu.test \
 	 averages.gpu.test
 
 if PYTHON_ENABLED
-TESTS += cyl3d.python.gpu.test
+TESTS += cyl3d.gpu.python.test
 endif
 
 else

--- a/test/cyl3d.gpu.python.test
+++ b/test/cyl3d.gpu.python.test
@@ -1,0 +1,149 @@
+#!./bats
+# -*- mode: sh -*-
+
+TEST="cyl3d.gpu"
+RUNFILE="inputs/input.dtconst.cyl.ini"
+RUNFILE_HEAT="inputs/input.dtconst.cyl.heatSource.ini"
+OPTS=""
+EXE="../src/tps.py"
+
+setup() {
+    SOLN_FILE=restart_output.sol.h5
+    REF_FILE=ref_solns/cyl3d.dtconst.cpu.h5
+    REF_FILE_HEAT=ref_solns/cyl3d.dtconst.heatSource.cpu.h5
+
+    # various GPU card detections
+    SKIP="ASPEED"
+    NUM_GPUS=`/sbin/lspci | grep "VGA compatible controller" | grep -v $SKIP | wc -l`
+    if [ $NUM_GPUS -eq 0 ];then
+	NUM_GPUS=`/sbin/lspci | grep "controller: NVIDIA" | wc -l`
+    fi
+}
+
+@test "[$TEST] check for input file $RUNFILE" {
+    test -s $RUNFILE
+}
+
+@test "[$TEST] run tps with input -> $RUNFILE" {
+    rm -f $SOLN_FILE
+    $EXE --runFile $RUNFILE
+
+    test -s $SOLN_FILE
+}
+
+@test "[$TEST] verify tps output with input -> $RUNFILE" {
+    test -s $SOLN_FILE
+    test -s $REF_FILE
+    ./soln_differ $SOLN_FILE $REF_FILE
+}
+
+@test "[$TEST] verify git sha in HDF5 file" {
+
+    test -s $SOLN_FILE
+    run h5dump  -a revision restart_output.sol.h5
+    [[ "${status}" -eq 0 ]]
+}
+
+@test "[$TEST] verify exit code if restart files missing" {
+    RUNFILE=inputs/input.dtconst.restart.cyl.ini
+
+    rm -f $SOLN_FILE
+
+    # following should exit with error
+    run $EXE --runFile $RUNFILE $OPTS
+    [[ "${status}" -eq 1 ]]
+    [[ "${output}" =~ "Unable to access desired restart file" ]]
+}
+
+@test "[$TEST] verify consistent solution with restart from 2 iters" {
+    RUNFILE=inputs/input.dtconst.2iters.cyl.ini
+
+    rm -f $SOLN_FILE
+    test -s $RUNFILE
+    $EXE --runFile $RUNFILE $OPTS
+    test -s $SOLN_FILE
+
+    run h5dump  -a iteration  restart_output.sol.h5
+    [ "${lines[5]}" = "   (0): 2" ]
+
+    RUNFILE=inputs/input.dtconst.restart.cyl.ini
+    $EXE --runFile $RUNFILE $OPTS
+    ./soln_differ $SOLN_FILE $REF_FILE
+}
+
+@test "[$TEST] verify tps output after variable p restart" {
+
+    rm -f $SOLN_FILE
+    test -s $RUNFILE
+    $EXE --runFile $RUNFILE $OPTS
+    test -s $SOLN_FILE
+
+    run h5dump  -a iteration  restart_output.sol.h5
+    [ "${lines[5]}" = "   (0): 4" ]
+
+    run h5dump  -a order  restart_output.sol.h5
+    [ "${lines[5]}" = "   (0): 1" ]
+
+     VARPLOG=varp.log
+     rm -f $VARPLOG
+     RUNFILE=inputs/input.dtconst.8iters.newp.cyl.ini
+     $EXE --runFile $RUNFILE $OPTS >& $VARPLOG
+
+     #intErr=$(cat $VARPLOG | grep "interpolation error" | awk '{print $6}')
+     # Line grabs the printed interpolation error norm, which I'd like
+     # to compare against a tolerance.  But bc isn't available in
+     # current container it seems, so I'm not doing this now.
+     
+     run h5dump  -a iteration  restart_output.sol.h5
+     [ "${lines[5]}" = "   (0): 8" ]
+     
+     run h5dump  -a order  restart_output.sol.h5
+     [ "${lines[5]}" = "   (0): 2" ]
+     
+     REF_FILE=ref_solns/cyl3d.dtconst.gpu.varp.h5
+     test -s $REF_FILE
+     ./soln_differ $SOLN_FILE $REF_FILE
+}
+
+@test "[$TEST] verify tps output from 2 mpi tasks with input -> $RUNFILE" {
+
+    [ $NUM_GPUS -ge 2 ] || skip "Two GPUs not available"
+
+    SOLN_FILE_0=restart_output.sol.0.h5
+    SOLN_FILE_1=restart_output.sol.1.h5
+
+    REF_FILE_0=ref_solns/cyl.r0.p2.iter4.h5
+    REF_FILE_1=ref_solns/cyl.r1.p2.iter4.h5
+
+    mpirun -np 2 $EXE --runFile $RUNFILE $OPTS
+
+    test -s $SOLN_FILE_0
+    test -s $REF_FILE_0
+    ./soln_differ $SOLN_FILE_0 $REF_FILE_0
+
+    test -s $SOLN_FILE_1
+    test -s $REF_FILE_1
+    ./soln_differ $SOLN_FILE_1 $REF_FILE_1
+}
+
+@test "[$TEST] verify tps output with input heat source <enabled> -> $RUNFILE_HEAT" {
+
+    test -s $RUNFILE_HEAT
+    $EXE -run $RUNFILE_HEAT
+    
+    test -s $SOLN_FILE
+    test -s $REF_FILE_HEAT
+    ./soln_differ $SOLN_FILE $REF_FILE_HEAT
+}
+
+@test "[$TEST] verify tps output with one input heat source <disabled> -> $RUNFILE_HEAT" {
+
+    runFileDisabled="inputs/input.dtconst.cyl.heatSource.disabled.ini"
+    test -s $runFileDisabled
+    $EXE -run $runFileDisabled
+    
+    test -s $SOLN_FILE
+    test -s $REF_FILE
+    ./soln_differ $SOLN_FILE $REF_FILE
+}
+

--- a/test/cyl3d.gpu.python.test
+++ b/test/cyl3d.gpu.python.test
@@ -44,14 +44,14 @@ setup() {
     [[ "${status}" -eq 0 ]]
 }
 
-@test "[$TEST] verify exit code if restart files missing" {
+@test "[$TEST] verify non-zero exit code if restart files missing" {
     RUNFILE=inputs/input.dtconst.restart.cyl.ini
 
     rm -f $SOLN_FILE
 
     # following should exit with error
     run $EXE --runFile $RUNFILE $OPTS
-    [[ "${status}" -eq 1 ]]
+    [[ "${status}" -ne 0 ]]
     [[ "${output}" =~ "Unable to access desired restart file" ]]
 }
 

--- a/test/cyl3d.python.test
+++ b/test/cyl3d.python.test
@@ -1,0 +1,330 @@
+#!./bats
+# -*- mode: sh -*-
+
+TEST="cyl3d"
+RUNFILE="inputs/input.4iters.cyl"
+RUNFILE="inputs/input.4iters.cyl.ini"
+EXE="../src/tps.py"
+
+setup() {
+    SOLN_FILE=restart_output.sol.h5
+    REF_FILE=ref_solns/cyl3d_coarse.4iters.h5
+}
+
+@test "[$TEST] check for input file $RUNFILE" {
+    test -s $RUNFILE
+}
+
+@test "[$TEST] run tps with input -> $RUNFILE" {
+    rm -f $SOLN_FILE
+    touch DIE
+    $EXE --runFile $RUNFILE
+
+    test -s $SOLN_FILE
+    test ! -e DIE
+}
+
+@test "[$TEST] verify tps output with input -> $RUNFILE" {
+
+    test -s $SOLN_FILE
+    test -s $REF_FILE
+    ./soln_differ $SOLN_FILE $REF_FILE
+}
+
+@test "[$TEST] verify git sha in HDF5 file" {
+
+    test -s $SOLN_FILE
+    run h5dump  -a revision restart_output.sol.h5
+    [[ "${status}" -eq 0 ]]
+
+    # disabling following bit since developer may be testing prior to commit
+#     hdf_dump=$output
+#
+#     run git log -1 --format="%h"
+#     if [ $? -eq 0 ];then
+# 	sha=${lines[0]}
+# 	[[ "${hdf_dump}" =~ "\"$sha\"" ]]
+#     fi
+}
+
+@test "[$TEST] verify exit code if restart files missing" {
+    RUNFILE=inputs/input.4iters.restart.cyl.ini
+
+    rm -f $SOLN_FILE
+
+    # following should exit with error
+    run $EXE --runFile $RUNFILE
+    [[ "${status}" -eq 1 ]]
+    [[ "${output}" =~ "Unable to access desired restart file" ]]
+}
+
+@test "[$TEST] verify consistent solution with restart from 2 iters" {
+    RUNFILE=inputs/input.2iters.cyl.ini
+
+    rm -f $SOLN_FILE
+    test -s $RUNFILE
+    $EXE --runFile $RUNFILE
+    test -s $SOLN_FILE
+
+    run h5dump  -a iteration  restart_output.sol.h5
+    [ "${lines[5]}" = "   (0): 2" ]
+
+    RUNFILE=inputs/input.4iters.restart.cyl.ini
+    $EXE --runFile $RUNFILE
+    ./soln_differ $SOLN_FILE $REF_FILE
+}
+
+@test "[$TEST] verify tps output after variable p restart" {
+    RUNFILE=inputs/input.4iters.cyl.ini
+
+    rm -f $SOLN_FILE
+    test -s $RUNFILE
+    $EXE --runFile $RUNFILE
+    test -s $SOLN_FILE
+
+    run h5dump  -a iteration  restart_output.sol.h5
+    [ "${lines[5]}" = "   (0): 4" ]
+
+    run h5dump  -a order  restart_output.sol.h5
+    [ "${lines[5]}" = "   (0): 1" ]
+
+    VARPLOG=varp.log
+    rm -f $VARPLOG
+    RUNFILE=inputs/input.8iters.restart.newp.cyl.ini
+    $EXE --runFile $RUNFILE >& $VARPLOG
+
+    #intErr=$(cat $VARPLOG | grep "interpolation error" | awk '{print $6}')
+    # Line grabs the printed interpolation error norm, which I'd like
+    # to compare against a tolerance.  But bc isn't available in
+    # current container it seems, so I'm not doing this now.
+
+    run h5dump  -a iteration  restart_output.sol.h5
+    [ "${lines[5]}" = "   (0): 8" ]
+
+    run h5dump  -a order  restart_output.sol.h5
+    [ "${lines[5]}" = "   (0): 2" ]
+
+    REF_FILE=ref_solns/cyl3d_coarse.8iters.varp.h5
+    test -s $REF_FILE
+    ./soln_differ $SOLN_FILE $REF_FILE
+}
+
+@test "[$TEST] verify serial restart consistency using 2 mpi tasks" {
+    RUNFILE=inputs/input.4iters.cyl.ini
+    RUNFILE_PART=${RUNFILE}.part
+    SOLN_FILE=restart_output.sol.h5
+
+    rm -f $RUNFILE_PART
+    rm -f $SOLN_FILE
+
+    # copy the run file, b/c I want to edit it
+    test -s $RUNFILE
+    cp $RUNFILE $RUNFILE_PART
+
+    # request single file restart
+    echo "[io]" >> $RUNFILE_PART
+    echo "restartMode = singleFileWrite" >> $RUNFILE_PART
+
+    # run 2 tasks
+    mpirun -np 2 $EXE --runFile $RUNFILE_PART
+    test -s $SOLN_FILE_SERIAL
+
+    ./soln_differ $SOLN_FILE $REF_FILE
+
+    # clean up if we got this far
+    rm -f $RUNFILE_PART
+    rm -f restart_output.sol.*.h5
+}
+
+@test "[$TEST] verify serial restart consistency using 4 mpi tasks" {
+    RUNFILE=inputs/input.4iters.cyl.ini
+    RUNFILE_PART=${RUNFILE}.part
+    SOLN_FILE=restart_output.sol.h5
+
+    rm -f $RUNFILE_PART
+    rm -f $SOLN_FILE
+
+    # copy the run file, b/c I want to edit it
+    test -s $RUNFILE
+    cp $RUNFILE $RUNFILE_PART
+
+    # add partition info to the runfile
+    echo "[io]" >> $RUNFILE_PART
+    echo "restartMode = singleFileWrite" >> $RUNFILE_PART
+
+    # run 4 tasks
+    mpirun -np 4 $EXE --runFile $RUNFILE_PART
+    test -s $SOLN_FILE_SERIAL
+
+    ./soln_differ $SOLN_FILE $REF_FILE
+
+    # clean up if we got this far
+    rm -f $RUNFILE_PART
+    rm -f restart_output.sol.*.h5
+}
+
+@test "[$TEST] verify serialized restart switching processors from 2 -> 4 mpi tasks" {
+    RUNFILE=inputs/input.2iters.cyl.ini
+    SOLFILE_BASE=restart_output.sol
+
+    RUNFILE_MOD=input.serialized.mod
+    TMPDIR=tmp_serialized_restart
+
+    rm -f  restart_output.sol*.h5
+    rm -f  partition.*.h5
+    rm -f  $RUNFILE_MOD
+    rm -rf $TMPDIR
+
+    # run 2 iterations using 2 tasks and save serialized restart file
+
+    test -s $RUNFILE
+    cp $RUNFILE $RUNFILE_MOD
+    echo "[io]" >> $RUNFILE_MOD
+    echo "restartMode = singleFileWrite" >> $RUNFILE_MOD
+    
+    mpirun -np 2 $EXE --runFile $RUNFILE_MOD
+    test -s ${SOLFILE_BASE}.h5
+    test -s partition.2p.h5
+
+    run h5dump  -a iteration  ${SOLFILE_BASE}.h5
+    [ "${lines[5]}" = "   (0): 2" ]
+
+    # now, restart from serialized restart at 2 iters, and run with 4 procs till 4 iterations
+    RUNFILE=inputs/input.4iters.cyl.ini
+    cp $RUNFILE $RUNFILE_MOD
+    echo "[io]" >> $RUNFILE_MOD
+    echo "restartMode   = singleFileRead" >> $RUNFILE_MOD
+    echo "enableRestart = true" >> $RUNFILE_MOD
+
+    mpirun -np 4 $EXE --runFile $RUNFILE_MOD
+    test -s partition.4p.h5
+
+    mkdir $TMPDIR
+
+    for i in `seq 0 3`; do
+	test -s ${SOLFILE_BASE}.$i.h5
+	run h5dump  -a iteration  ${SOLFILE_BASE}.$i.h5
+	[ "${lines[5]}" = "   (0): 4" ]
+	mv ${SOLFILE_BASE}.$i.h5 $TMPDIR
+    done
+
+    # finally, run a normal 4 proc case for 4 iterations and compare against above solution
+    rm -f  restart_output.sol*.h5
+    mpirun -np 4 $EXE --runFile $RUNFILE
+
+    for i in `seq 0 3`; do
+	test -s ${SOLFILE_BASE}.$i.h5
+	run h5dump  -a iteration  ${SOLFILE_BASE}.$i.h5
+	[ "${lines[5]}" = "   (0): 4" ]
+	./soln_differ ${SOLFILE_BASE}.$i.h5 ${TMPDIR}/${SOLFILE_BASE}.$i.h5 
+    done
+
+    rm -rf $TMPDIR
+}
+
+@test "[$TEST] verify restart from partitioned files to generate a serialized output (2 mpi tasks)" {
+    RUNFILE=inputs/input.2iters.cyl.ini
+    SOLFILE_BASE=restart_output.sol
+
+    RUNFILE_MOD=input.serialized.mod
+
+    rm -f  restart_output.sol*.h5
+    rm -f  partition.*.h5
+    rm -f  $RUNFILE_MOD
+    rm -rf $TMPDIR
+
+    # run 2 iterations using 2 tasks and save partitioned restart files
+    test -s $RUNFILE
+    mpirun -np 2 $EXE --runFile $RUNFILE
+    test -s ${SOLFILE_BASE}.0.h5
+    test -s ${SOLFILE_BASE}.1.h5
+    test -s partition.2p.h5
+
+    run h5dump  -a iteration  ${SOLFILE_BASE}.0.h5
+    [ "${lines[5]}" = "   (0): 2" ]
+    run h5dump  -a iteration  ${SOLFILE_BASE}.1.h5
+    [ "${lines[5]}" = "   (0): 2" ]
+
+    # verify we have global number of dofs correctly included
+    run h5dump  -a dofs_global  ${SOLFILE_BASE}.0.h5
+    [ "${lines[5]}" = "   (0): 24612" ]
+    run h5dump  -a dofs_global  ${SOLFILE_BASE}.1.h5
+    [ "${lines[5]}" = "   (0): 24612" ]
+
+    # now, start from partitioned restart files at 2 iters, and save serialized output at 4 iters
+    RUNFILE=inputs/input.4iters.cyl.ini
+    cp $RUNFILE $RUNFILE_MOD
+    echo "[io]" >> $RUNFILE_MOD
+    echo "restartMode   = singleFileWrite" >> $RUNFILE_MOD
+    echo "enableRestart = true" >> $RUNFILE_MOD
+
+    mpirun -np 2 $EXE --runFile $RUNFILE_MOD
+    test -s partition.2p.h5
+    test -s ${SOLFILE_BASE}.h5
+    run h5dump  -a iteration  ${SOLFILE_BASE}.h5
+    [ "${lines[5]}" = "   (0): 4" ]
+
+    ./soln_differ ${SOLFILE_BASE}.h5 $REF_FILE
+}
+
+@test "[$TEST] verify two back to back (partitioned) restarts using 2 tasks" {
+    RUNFILE=inputs/input.4iters.cyl.ini
+    SOLFILE_BASE=restart_output.sol
+
+    RUNFILE_MOD=${RUNFILE}.mod
+    TMPDIR=tmp_multi_restarts
+
+    rm -f  restart_output.sol*.h5
+    rm -f  partition.*.h5
+    rm -f  $RUNFILE_MOD
+    rm -rf $TMPDIR
+
+    # run 2 iterations using 2 tasks
+    sed  's/maxIters = 4/maxIters = 2/' $RUNFILE > $RUNFILE_MOD
+
+    test -s $RUNFILE
+    mpirun -np 2 $EXE --runFile $RUNFILE_MOD
+    test -s ${SOLFILE_BASE}.0.h5
+    test -s ${SOLFILE_BASE}.1.h5
+    test -s partition.2p.h5
+
+    run h5dump  -a iteration  ${SOLFILE_BASE}.0.h5
+    [ "${lines[5]}" = "   (0): 2" ]
+    run h5dump  -a iteration  ${SOLFILE_BASE}.1.h5
+    [ "${lines[5]}" = "   (0): 2" ]
+
+    # now, restart and run 1 additional iteration
+    sed  's/maxIters = 4/maxIters = 3/' $RUNFILE > $RUNFILE_MOD
+    run mpirun -np 2 $EXE --runFile $RUNFILE_MOD
+
+    run h5dump  -a iteration  ${SOLFILE_BASE}.0.h5
+    [ "${lines[5]}" = "   (0): 3" ]
+
+    run h5dump  -a iteration  ${SOLFILE_BASE}.1.h5
+    [ "${lines[5]}" = "   (0): 3" ]
+
+    # now, repeat and run 1 additional iteration
+    run mpirun -np 2 $EXE --runFile $RUNFILE
+
+    mkdir $TMPDIR
+
+    for i in `seq 0 1`; do
+	test -s ${SOLFILE_BASE}.$i.h5
+	run h5dump  -a iteration  ${SOLFILE_BASE}.$i.h5
+	[ "${lines[5]}" = "   (0): 4" ]
+	mv ${SOLFILE_BASE}.$i.h5 $TMPDIR
+    done
+
+    # finally, run a normal 2 proc case for 4 iterations and compare against above solution
+   rm -f  restart_output.sol*.h5
+   mpirun -np 2 $EXE --runFile $RUNFILE
+
+   for i in `seq 0 1`; do
+	test -s ${SOLFILE_BASE}.$i.h5
+	run h5dump  -a iteration  ${SOLFILE_BASE}.$i.h5
+	[ "${lines[5]}" = "   (0): 4" ]
+	./soln_differ ${SOLFILE_BASE}.$i.h5 ${TMPDIR}/${SOLFILE_BASE}.$i.h5
+   done
+
+   rm -rf $TMPDIR
+}

--- a/test/cyl3d.test
+++ b/test/cyl3d.test
@@ -4,6 +4,7 @@
 TEST="cyl3d"
 RUNFILE="inputs/input.4iters.cyl"
 RUNFILE="inputs/input.4iters.cyl.ini"
+EXE="../src/tps"
 
 setup() {
     SOLN_FILE=restart_output.sol.h5
@@ -17,7 +18,7 @@ setup() {
 @test "[$TEST] run tps with input -> $RUNFILE" {
     rm -f $SOLN_FILE
     touch DIE
-    ../src/tps --runFile $RUNFILE
+    $EXE --runFile $RUNFILE
 
     test -s $SOLN_FILE
     test ! -e DIE
@@ -52,7 +53,7 @@ setup() {
     rm -f $SOLN_FILE
 
     # following should exit with error
-    run ../src/tps --runFile $RUNFILE
+    run $EXE --runFile $RUNFILE
     [[ "${status}" -eq 1 ]]
     [[ "${output}" =~ "Unable to access desired restart file" ]]
 }
@@ -62,14 +63,14 @@ setup() {
 
     rm -f $SOLN_FILE
     test -s $RUNFILE
-    ../src/tps --runFile $RUNFILE
+    $EXE --runFile $RUNFILE
     test -s $SOLN_FILE
 
     run h5dump  -a iteration  restart_output.sol.h5
     [ "${lines[5]}" = "   (0): 2" ]
 
     RUNFILE=inputs/input.4iters.restart.cyl.ini
-    ../src/tps --runFile $RUNFILE
+    $EXE --runFile $RUNFILE
     ./soln_differ $SOLN_FILE $REF_FILE
 }
 
@@ -78,7 +79,7 @@ setup() {
 
     rm -f $SOLN_FILE
     test -s $RUNFILE
-    ../src/tps --runFile $RUNFILE
+    $EXE --runFile $RUNFILE
     test -s $SOLN_FILE
 
     run h5dump  -a iteration  restart_output.sol.h5
@@ -90,7 +91,7 @@ setup() {
     VARPLOG=varp.log
     rm -f $VARPLOG
     RUNFILE=inputs/input.8iters.restart.newp.cyl.ini
-    ../src/tps --runFile $RUNFILE >& $VARPLOG
+    $EXE --runFile $RUNFILE >& $VARPLOG
 
     #intErr=$(cat $VARPLOG | grep "interpolation error" | awk '{print $6}')
     # Line grabs the printed interpolation error norm, which I'd like
@@ -125,7 +126,7 @@ setup() {
     echo "restartMode = singleFileWrite" >> $RUNFILE_PART
 
     # run 2 tasks
-    mpirun -np 2 ../src/tps --runFile $RUNFILE_PART
+    mpirun -np 2 $EXE --runFile $RUNFILE_PART
     test -s $SOLN_FILE_SERIAL
 
     ./soln_differ $SOLN_FILE $REF_FILE
@@ -152,7 +153,7 @@ setup() {
     echo "restartMode = singleFileWrite" >> $RUNFILE_PART
 
     # run 4 tasks
-    mpirun -np 4 ../src/tps --runFile $RUNFILE_PART
+    mpirun -np 4 $EXE --runFile $RUNFILE_PART
     test -s $SOLN_FILE_SERIAL
 
     ./soln_differ $SOLN_FILE $REF_FILE
@@ -181,7 +182,7 @@ setup() {
     echo "[io]" >> $RUNFILE_MOD
     echo "restartMode = singleFileWrite" >> $RUNFILE_MOD
     
-    mpirun -np 2 ../src/tps --runFile $RUNFILE_MOD
+    mpirun -np 2 $EXE --runFile $RUNFILE_MOD
     test -s ${SOLFILE_BASE}.h5
     test -s partition.2p.h5
 
@@ -195,7 +196,7 @@ setup() {
     echo "restartMode   = singleFileRead" >> $RUNFILE_MOD
     echo "enableRestart = true" >> $RUNFILE_MOD
 
-    mpirun -np 4 ../src/tps --runFile $RUNFILE_MOD
+    mpirun -np 4 $EXE --runFile $RUNFILE_MOD
     test -s partition.4p.h5
 
     mkdir $TMPDIR
@@ -209,7 +210,7 @@ setup() {
 
     # finally, run a normal 4 proc case for 4 iterations and compare against above solution
     rm -f  restart_output.sol*.h5
-    mpirun -np 4 ../src/tps --runFile $RUNFILE
+    mpirun -np 4 $EXE --runFile $RUNFILE
 
     for i in `seq 0 3`; do
 	test -s ${SOLFILE_BASE}.$i.h5
@@ -234,7 +235,7 @@ setup() {
 
     # run 2 iterations using 2 tasks and save partitioned restart files
     test -s $RUNFILE
-    mpirun -np 2 ../src/tps --runFile $RUNFILE
+    mpirun -np 2 $EXE --runFile $RUNFILE
     test -s ${SOLFILE_BASE}.0.h5
     test -s ${SOLFILE_BASE}.1.h5
     test -s partition.2p.h5
@@ -257,7 +258,7 @@ setup() {
     echo "restartMode   = singleFileWrite" >> $RUNFILE_MOD
     echo "enableRestart = true" >> $RUNFILE_MOD
 
-    mpirun -np 2 ../src/tps --runFile $RUNFILE_MOD
+    mpirun -np 2 $EXE --runFile $RUNFILE_MOD
     test -s partition.2p.h5
     test -s ${SOLFILE_BASE}.h5
     run h5dump  -a iteration  ${SOLFILE_BASE}.h5
@@ -282,7 +283,7 @@ setup() {
     sed  's/maxIters = 4/maxIters = 2/' $RUNFILE > $RUNFILE_MOD
 
     test -s $RUNFILE
-    mpirun -np 2 ../src/tps --runFile $RUNFILE_MOD
+    mpirun -np 2 $EXE --runFile $RUNFILE_MOD
     test -s ${SOLFILE_BASE}.0.h5
     test -s ${SOLFILE_BASE}.1.h5
     test -s partition.2p.h5
@@ -294,7 +295,7 @@ setup() {
 
     # now, restart and run 1 additional iteration
     sed  's/maxIters = 4/maxIters = 3/' $RUNFILE > $RUNFILE_MOD
-    run mpirun -np 2 ../src/tps --runFile $RUNFILE_MOD
+    run mpirun -np 2 $EXE --runFile $RUNFILE_MOD
 
     run h5dump  -a iteration  ${SOLFILE_BASE}.0.h5
     [ "${lines[5]}" = "   (0): 3" ]
@@ -303,7 +304,7 @@ setup() {
     [ "${lines[5]}" = "   (0): 3" ]
 
     # now, repeat and run 1 additional iteration
-    run mpirun -np 2 ../src/tps --runFile $RUNFILE
+    run mpirun -np 2 $EXE --runFile $RUNFILE
 
     mkdir $TMPDIR
 
@@ -316,7 +317,7 @@ setup() {
 
     # finally, run a normal 2 proc case for 4 iterations and compare against above solution
    rm -f  restart_output.sol*.h5
-   mpirun -np 2 ../src/tps --runFile $RUNFILE
+   mpirun -np 2 $EXE --runFile $RUNFILE
 
    for i in `seq 0 1`; do
 	test -s ${SOLFILE_BASE}.$i.h5

--- a/test/test_argon_minimal.cpp
+++ b/test/test_argon_minimal.cpp
@@ -42,7 +42,7 @@ Array<int> readTable(const string fileName, const string datasetName, DenseMatri
 
 int main (int argc, char *argv[])
 {
-  TPS::Tps tps(argc, argv);
+  TPS::Tps tps;
   tps.parseCommandLineArgs(argc, argv);
   tps.parseInput();
   tps.chooseDevices();

--- a/test/test_perfect_mixture.cpp
+++ b/test/test_perfect_mixture.cpp
@@ -76,7 +76,7 @@ void getRandomDirection(const Vector &velocity, Vector &direction) {
 
 int main (int argc, char *argv[])
 {
-  TPS::Tps tps(argc, argv);
+  TPS::Tps tps;
   tps.parseCommandLineArgs(argc, argv);
   tps.parseInput();
   tps.chooseDevices();

--- a/test/test_speed_of_sound.cpp
+++ b/test/test_speed_of_sound.cpp
@@ -10,7 +10,7 @@ using namespace std;
 
 int main (int argc, char *argv[])
 {
-  TPS::Tps tps(argc, argv);
+  TPS::Tps tps;
   tps.parseCommandLineArgs(argc, argv);
   tps.parseInput();
   tps.chooseDevices();

--- a/tps_config.h.in
+++ b/tps_config.h.in
@@ -18,6 +18,9 @@
 /* Git revision */
 #undef BUILD_VERSION
 
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#undef HAVE_DLFCN_H
+
 /* Define if GRVY is available */
 #undef HAVE_GRVY
 
@@ -51,6 +54,9 @@
 /* Define if OPENBLAS is available */
 #undef HAVE_OPENBLAS
 
+/* If available, contains the Python version number currently in use. */
+#undef HAVE_PYTHON
+
 /* Enable SLURM resource manager support */
 #undef HAVE_SLURM
 
@@ -74,6 +80,9 @@
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#undef LT_OBJDIR
 
 /* Path to nvcc binary */
 #undef NVCC_PATH

--- a/utils/L2_diff.cpp
+++ b/utils/L2_diff.cpp
@@ -9,7 +9,7 @@ using namespace std;
 
 int main (int argc, char *argv[])
 {
-  TPS::Tps tps(argc, argv);
+  TPS::Tps tps;
   tps.parseCommandLineArgs(argc, argv);
   tps.parseInput();
   tps.chooseDevices();

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -1,7 +1,4 @@
-# AM_CPPFLAGS          = -g -I../src -I$(MFEM_INC) -I$(MFEM_INC)/mfem
 AM_CPPFLAGS          = -g -I$(top_srcdir)/src $(MFEM_CXXFLAGS) $(HDF5_CFLAGS) $(GRVY_CFLAGS)
-# AM_CPPFLAGS         += -I$(HYPRE_INC) $(HDF5_CFLAGS) $(GRVY_CFLAGS)
-# AM_CPPFLAGS         += -I$(PETSC_INC)
 EXTRA_DIST           = bats cpplint
 
 if CUDA_ENABLED
@@ -30,18 +27,8 @@ beam_mesh_SOURCES  = beam_mesh.cpp
 beam_mesh_LDADD    =
 beam_mesh_LDADD    += $(HDF5_LIBS)
 beam_mesh_LDADD    += $(GRVY_LIBS)
-beam_mesh_LDADD    += $(MFEM_LIBS)
+beam_mesh_LDFLAGS   = $(PYTHON_LIBS) $(MFEM_LIBS)
 
-beam_mesh_LDFLAGS  =
-# #beam_mesh_LDFLAGS += -L$(PETSC_LIB) -lpetsc
-# beam_mesh_LDFLAGS += $(HDF5_LIBS)
-# beam_mesh_LDFLAGS += -L$(HYPRE_LIB) -lHYPRE
-# beam_mesh_LDFLAGS += -L$(OPENBLAS_LIB) -lopenblas
-# beam_mesh_LDFLAGS += -L$(METIS_LIB) -lmetis
-# beam_mesh_LDFLAGS += $(GRVY_LIBS)
-# beam_mesh_LDFLAGS += -L$(SUPERLU_DIST_LIB) -lsuperlu_dist
-# beam_mesh_LDFLAGS += -L$(NETCDF_LIB) -lnetcdf
-# beam_mesh_LDFLAGS += -L$(GSLIB_LIB) -lgs
 if MASA_ENABLED
 beam_mesh_LDFLAGS += $(MASA_LIBS)
 endif
@@ -63,12 +50,11 @@ endif
 if GSLIB_ENABLED
 bin_PROGRAMS   += interp
 interp_SOURCES  = pfield_interpolate.cpp
-interp_LDADD    = ../src/libtps.a
+interp_LDADD    = ../src/libtps.la
 interp_LDADD    += $(HDF5_LIBS)
 interp_LDADD    += $(GRVY_LIBS)
-interp_LDADD    += $(MFEM_LIBS)
-
-interp_LDFLAGS  =
+#interp_LDADD    += $(MFEM_LIBS)
+interp_LDFLAGS  = $(PYTHON_LIBS) $(MFEM_LIBS)
 # interp_LDFLAGS += $(HDF5_LIBS)
 # interp_LDFLAGS += -L$(HYPRE_LIB) -lHYPRE
 # interp_LDFLAGS += -L$(OPENBLAS_LIB) -lopenblas
@@ -84,92 +70,55 @@ endif
 
 bin_PROGRAMS += binaryic
 binaryic_SOURCES  = binary_mixture_ic.cpp
-binaryic_LDADD    = ../src/libtps.a
-binaryic_LDADD    += $(HDF5_LIBS)
-binaryic_LDADD    += $(GRVY_LIBS)
-binaryic_LDADD    += $(MFEM_LIBS)
+binaryic_LDADD    = ../src/libtps.la
+binaryic_LDADD   += $(HDF5_LIBS)
+binaryic_LDADD   += $(GRVY_LIBS)
+binaryic_LDFLAGS  = $(PYTHON_LIBS) $(MFEM_LIBS)
 
-binaryic_LDFLAGS  =
-# binaryic_LDFLAGS += $(HDF5_LIBS)
-# binaryic_LDFLAGS += -L$(HYPRE_LIB) -lHYPRE
-# binaryic_LDFLAGS += -L$(OPENBLAS_LIB) -lopenblas
-# binaryic_LDFLAGS += -L$(METIS_LIB) -lmetis
-# binaryic_LDFLAGS += $(GRVY_LIBS)
-# binaryic_LDFLAGS += -L$(SUPERLU_DIST_LIB) -lsuperlu_dist
-# binaryic_LDFLAGS += -L$(NETCDF_LIB) -lnetcdf
-# binaryic_LDFLAGS += -L$(GSLIB_LIB) -lgs
 if MASA_ENABLED
 binaryic_LDFLAGS += $(MASA_LIBS)
 endif
 
-bin_PROGRAMS += tanhic
-tanhic_SOURCES  = tanh_ic.cpp
-tanhic_LDADD    = ../src/libtps.a -lmfem
-tanhic_LDADD    += $(HDF5_LIBS)
-tanhic_LDADD    += $(GRVY_LIBS)
-tanhic_LDADD    += $(MFEM_LIBS)
+bin_PROGRAMS     += tanhic
+tanhic_SOURCES    = tanh_ic.cpp
+tanhic_LDADD      = ../src/libtps.la -lmfem
+tanhic_LDADD     += $(HDF5_LIBS)
+tanhic_LDADD     += $(GRVY_LIBS)
+tanhic_LDFLAGS    = $(PYTHON_LIBS) $(MFEM_LIBS)
 
-tanhic_LDFLAGS  =
-# tanhic_LDFLAGS += $(HDF5_LIBS)
-# tanhic_LDFLAGS += -L$(HYPRE_LIB) -lHYPRE
-# tanhic_LDFLAGS += -L$(OPENBLAS_LIB) -lopenblas
-# tanhic_LDFLAGS += -L$(METIS_LIB) -lmetis
-# tanhic_LDFLAGS += $(GRVY_LIBS)
-# tanhic_LDFLAGS += -L$(SUPERLU_DIST_LIB) -lsuperlu_dist
-# tanhic_LDFLAGS += -L$(NETCDF_LIB) -lnetcdf
-# tanhic_LDFLAGS += -L$(GSLIB_LIB) -lgs
 if MASA_ENABLED
 tanhic_LDFLAGS += $(MASA_LIBS)
 endif
 
-bin_PROGRAMS += sineic
-sineic_SOURCES  = sine_ic.cpp
-sineic_LDADD    = ../src/libtps.a -lmfem
+bin_PROGRAMS    += sineic
+sineic_SOURCES   = sine_ic.cpp
+sineic_LDADD     = ../src/libtps.la -lmfem
 sineic_LDADD    += $(HDF5_LIBS)
 sineic_LDADD    += $(GRVY_LIBS)
-sineic_LDADD    += $(MFEM_LIBS)
+sineic_LDFLAGS   = $(PYTHON_LIBS) $(MFEM_LIBS)
 
-sineic_LDFLAGS  =
-# sineic_LDFLAGS += $(HDF5_LIBS)
-# sineic_LDFLAGS += -L$(HYPRE_LIB) -lHYPRE
-# sineic_LDFLAGS += -L$(OPENBLAS_LIB) -lopenblas
-# sineic_LDFLAGS += -L$(METIS_LIB) -lmetis
-# sineic_LDFLAGS += $(GRVY_LIBS)
-# sineic_LDFLAGS += -L$(SUPERLU_DIST_LIB) -lsuperlu_dist
-# sineic_LDFLAGS += -L$(NETCDF_LIB) -lnetcdf
-# sineic_LDFLAGS += -L$(GSLIB_LIB) -lgs
 if MASA_ENABLED
 sineic_LDFLAGS += $(MASA_LIBS)
 endif
 
-bin_PROGRAMS += l2diff
-l2diff_SOURCES  = L2_diff.cpp
-l2diff_LDADD    = ../src/libtps.a -lmfem
-l2diff_LDADD    += $(HDF5_LIBS)
-l2diff_LDADD    += $(GRVY_LIBS)
-l2diff_LDADD    += $(MFEM_LIBS)
+bin_PROGRAMS     += l2diff
+l2diff_SOURCES    = L2_diff.cpp
+l2diff_LDADD      = ../src/libtps.la -lmfem
+l2diff_LDADD     += $(HDF5_LIBS)
+l2diff_LDADD     += $(GRVY_LIBS)
+l2diff_LDFLAGS    = $(PYTHON_LIBS) $(MFEM_LIBS)
 
-l2diff_LDFLAGS  =
-# l2diff_LDFLAGS += $(HDF5_LIBS)
-# l2diff_LDFLAGS += -L$(HYPRE_LIB) -lHYPRE
-# l2diff_LDFLAGS += -L$(OPENBLAS_LIB) -lopenblas
-# l2diff_LDFLAGS += -L$(METIS_LIB) -lmetis
-# l2diff_LDFLAGS += $(GRVY_LIBS)
-# l2diff_LDFLAGS += -L$(SUPERLU_DIST_LIB) -lsuperlu_dist
-# l2diff_LDFLAGS += -L$(NETCDF_LIB) -lnetcdf
-# l2diff_LDFLAGS += -L$(GSLIB_LIB) -lgs
 if MASA_ENABLED
 l2diff_LDFLAGS += $(MASA_LIBS)
 endif
 
-bin_PROGRAMS += compute_rhs
+bin_PROGRAMS        += compute_rhs
 compute_rhs_SOURCES  = compute_rhs.cpp
-compute_rhs_LDADD    = ../src/libtps.a -lmfem
-compute_rhs_LDADD    += $(HDF5_LIBS)
-compute_rhs_LDADD    += $(GRVY_LIBS)
-compute_rhs_LDADD    += $(MFEM_LIBS)
+compute_rhs_LDADD    = ../src/libtps.la -lmfem
+compute_rhs_LDADD   += $(HDF5_LIBS)
+compute_rhs_LDADD   += $(GRVY_LIBS)
+compute_rhs_LDFLAGS  = $(PYTHON_LIBS) $(MFEM_LIBS)
 
-compute_rhs_LDFLAGS  =
 if MASA_ENABLED
 compute_rhs_LDFLAGS += $(MASA_LIBS)
 endif

--- a/utils/binary_mixture_ic.cpp
+++ b/utils/binary_mixture_ic.cpp
@@ -9,7 +9,7 @@ using namespace std;
 
 int main (int argc, char *argv[])
 {
-  TPS::Tps tps(argc, argv);
+  TPS::Tps tps;
   tps.parseCommandLineArgs(argc, argv);
   tps.parseInput();
   tps.chooseDevices();

--- a/utils/compute_rhs.cpp
+++ b/utils/compute_rhs.cpp
@@ -9,7 +9,7 @@ using namespace std;
 
 int main (int argc, char *argv[])
 {
-  TPS::Tps tps(argc, argv);
+  TPS::Tps tps;
   tps.parseCommandLineArgs(argc, argv);
   tps.parseInput();
   tps.chooseDevices();

--- a/utils/sine_ic.cpp
+++ b/utils/sine_ic.cpp
@@ -9,7 +9,7 @@ using namespace std;
 
 int main (int argc, char *argv[])
 {
-  TPS::Tps tps(argc, argv);
+  TPS::Tps tps;
   tps.parseCommandLineArgs(argc, argv);
   tps.parseInput();
   tps.chooseDevices();

--- a/utils/tanh_ic.cpp
+++ b/utils/tanh_ic.cpp
@@ -9,7 +9,7 @@ using namespace std;
 
 int main (int argc, char *argv[])
 {
-  TPS::Tps tps(argc, argv);
+  TPS::Tps tps;
   tps.parseCommandLineArgs(argc, argv);
   tps.parseInput();
   tps.chooseDevices();


### PR DESCRIPTION
Introduces an optional configuration (`--enable-pybind11`) to enable building of a python interface for a subset of the `TPS::Tps` C++ class that drives the main solver.  Interface is built using [pybind11](--enable-pybind11).  Build system refactored to produce a dynamic libtps.so instead of static library we had previously (needed to be able import the results into python).

A companion `tps.py` driver script is added which provides the same functionality as the current C++ main.