### PR TITLE
Multi-species support for axisymmetric case

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -259,17 +259,17 @@ void M2ulPhyS::initVariables() {
   switch (config.GetWorkingFluid()) {
     // TODO(kevin): GasMixture should take both dim and nvel, to avoid confusion in future.
     case WorkingFluid::DRY_AIR:
-      mixture = new DryAir(config, nvel);
+      mixture = new DryAir(config, dim, nvel);
       transportPtr = new DryAirTransport(mixture, config);
       break;
     case WorkingFluid::TEST_BINARY_AIR:
-      mixture = new TestBinaryAir(config, nvel);
+      mixture = new TestBinaryAir(config, dim, nvel);
       transportPtr = new TestBinaryAirTransport(mixture, config);
       break;
     case WorkingFluid::USER_DEFINED:
       switch (config.GetGasModel()) {
         case GasModel::PERFECT_MIXTURE:
-          mixture = new PerfectMixture(config, nvel);
+          mixture = new PerfectMixture(config, dim, nvel);
           break;
       }
       switch (config.GetTranportModel()) {

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -2226,21 +2226,23 @@ void M2ulPhyS::parseSolverOptions2() {
           tpsP->getRequiredInput((base + "/pressure").c_str(), hup[4]);  // P
 
           // For multi-component gas, require (numActiveSpecies)-more inputs.
-          if ((config.workFluid != DRY_AIR) && (config.numSpecies > 1)) {
-            grvy_printf(GRVY_INFO, "\nInlet mass fraction of background species will not be used. \n");
-            if (config.ambipolar) grvy_printf(GRVY_INFO, "\nInlet mass fraction of electron will not be used. \n");
+          if (config.workFluid != DRY_AIR) {
+            if (config.numSpecies > 1) {
+              grvy_printf(GRVY_INFO, "\nInlet mass fraction of background species will not be used. \n");
+              if (config.ambipolar) grvy_printf(GRVY_INFO, "\nInlet mass fraction of electron will not be used. \n");
 
-            for (int sp = 1; sp <= config.numSpecies; sp++) {
-              // read mass fraction of species as listed in the input file.
-              std::string speciesBasePath(base + "/mass_fraction/species" + std::to_string(sp));
-              tpsP->getRequiredInput(speciesBasePath.c_str(), hup[4 + sp]);
+              for (int sp = 1; sp <= config.numSpecies; sp++) {
+                // read mass fraction of species as listed in the input file.
+                std::string speciesBasePath(base + "/mass_fraction/species" + std::to_string(sp));
+                tpsP->getRequiredInput(speciesBasePath.c_str(), hup[4 + sp]);
+              }
             }
-          }
 
-          if (config.twoTemperature) {
-            tpsP->getInput((base + "/single_temperature").c_str(), config.spongeData_[sz].singleTemperature, false);
-            if (!config.spongeData_[sz].singleTemperature) {
-              tpsP->getRequiredInput((base + "/electron_temperature").c_str(), hup[5 + config.numSpecies]);  // P
+            if (config.twoTemperature) {
+              tpsP->getInput((base + "/single_temperature").c_str(), config.spongeData_[sz].singleTemperature, false);
+              if (!config.spongeData_[sz].singleTemperature) {
+                tpsP->getRequiredInput((base + "/electron_temperature").c_str(), hup[5 + config.numSpecies]);  // P
+              }
             }
           }
 

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -107,8 +107,8 @@ void ArgonMinimalTransport::ComputeFluxTransportProperties(const Vector &state, 
   double nTotal = 0.0;
   for (int sp = 0; sp < numSpecies; sp++) nTotal += n_sp(sp);
 
-  double Te = (twoTemperature_) ? primitiveState[num_equation - 1] : primitiveState[dim + 1];
-  double Th = primitiveState[dim + 1];
+  double Te = (twoTemperature_) ? primitiveState[num_equation - 1] : primitiveState[nvel_ + 1];
+  double Th = primitiveState[nvel_ + 1];
   // std::cout << "temp: " << Th << ",\t" << Te << std::endl;
 
   // Add Xeps to avoid zero number density case.
@@ -164,8 +164,11 @@ void ArgonMinimalTransport::ComputeFluxTransportProperties(const Vector &state, 
   DenseMatrix gradX(numSpecies, dim);
   mixture->ComputeMoleFractionGradient(n_sp, gradUp, gradX);
 
-  diffusionVelocity.SetSize(numSpecies, dim);
+  // NOTE: diffusion has nvel components, as E-field can have azimuthal component.
+  diffusionVelocity.SetSize(numSpecies, nvel_);
+  diffusionVelocity = 0.0;
   for (int sp = 0; sp < numSpecies; sp++) {
+    // concentration-driven diffusion only determines the first dim-components.
     for (int d = 0; d < dim; d++) {
       double DgradX = diffusivity(sp) * gradX(sp, d);
       // NOTE: we'll have to handle small X case.
@@ -182,6 +185,7 @@ void ArgonMinimalTransport::ComputeFluxTransportProperties(const Vector &state, 
   double charSpeed = 0.0;
   for (int sp = 0; sp < numActiveSpecies; sp++) {
     double speciesSpeed = 0.0;
+    // azimuthal component does not participate in flux.
     for (int d = 0; d < dim; d++) speciesSpeed += diffusionVelocity(sp, d) * diffusionVelocity(sp, d);
     speciesSpeed = sqrt(speciesSpeed);
     if (speciesSpeed > charSpeed) charSpeed = speciesSpeed;
@@ -246,8 +250,8 @@ void ArgonMinimalTransport::computeMixtureAverageDiffusivity(const Vector &state
   double nTotal = 0.0;
   for (int sp = 0; sp < numSpecies; sp++) nTotal += n_sp(sp);
 
-  double Te = (twoTemperature_) ? primitiveState[num_equation - 1] : primitiveState[dim + 1];
-  double Th = primitiveState[dim + 1];
+  double Te = (twoTemperature_) ? primitiveState[num_equation - 1] : primitiveState[nvel_ + 1];
+  double Th = primitiveState[nvel_ + 1];
 
   // Add Xeps to avoid zero number density case.
   double nOverT = (n_sp(electronIndex_) + Xeps_) / Te + (n_sp(ionIndex_) + Xeps_) / Th;
@@ -286,8 +290,8 @@ void ArgonMinimalTransport::ComputeSourceTransportProperties(const Vector &state
   double nTotal = 0.0;
   for (int sp = 0; sp < numSpecies; sp++) nTotal += n_sp(sp);
 
-  double Te = (twoTemperature_) ? Up[num_equation - 1] : Up[dim + 1];
-  double Th = Up[dim + 1];
+  double Te = (twoTemperature_) ? Up[num_equation - 1] : Up[nvel_ + 1];
+  double Th = Up[nvel_ + 1];
 
   // Add Xeps to avoid zero number density case.
   double nOverT = (n_sp(electronIndex_) + Xeps_) / Te + (n_sp(ionIndex_) + Xeps_) / Th;
@@ -322,8 +326,11 @@ void ArgonMinimalTransport::ComputeSourceTransportProperties(const Vector &state
   DenseMatrix gradX(numSpecies, dim);
   mixture->ComputeMoleFractionGradient(n_sp, gradUp, gradX);
 
-  diffusionVelocity.SetSize(numSpecies, dim);
+  // NOTE: diffusion has nvel components, as E-field can have azimuthal component.
+  diffusionVelocity.SetSize(numSpecies, nvel_);
+  diffusionVelocity = 0.0;
   for (int sp = 0; sp < numSpecies; sp++) {
+    // concentration-driven diffusion only determines the first dim-components.
     for (int d = 0; d < dim; d++) {
       double DgradX = diffusivity(sp) * gradX(sp, d);
       // NOTE: we'll have to handle small X case.
@@ -348,6 +355,7 @@ void ArgonMinimalTransport::ComputeSourceTransportProperties(const Vector &state
   double charSpeed = 0.0;
   for (int sp = 0; sp < numActiveSpecies; sp++) {
     double speciesSpeed = 0.0;
+    // azimuthal component does not participate in flux.
     for (int d = 0; d < dim; d++) speciesSpeed += diffusionVelocity(sp, d) * diffusionVelocity(sp, d);
     speciesSpeed = sqrt(speciesSpeed);
     if (speciesSpeed > charSpeed) charSpeed = speciesSpeed;

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -364,8 +364,8 @@ void ArgonMinimalTransport::ComputeSourceTransportProperties(const Vector &state
   // std::cout << "max diff. vel: " << charSpeed << std::endl;
 }
 
-void ArgonMinimalTransport::GetViscosities(const Vector &conserved, const Vector &primitive,
-                                           double &visc, double &bulkVisc) {
+void ArgonMinimalTransport::GetViscosities(const Vector &conserved, const Vector &primitive, double &visc,
+                                           double &bulkVisc) {
   Vector n_sp(3), X_sp(3), Y_sp(3);
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
   double nTotal = 0.0;

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -363,3 +363,36 @@ void ArgonMinimalTransport::ComputeSourceTransportProperties(const Vector &state
   }
   // std::cout << "max diff. vel: " << charSpeed << std::endl;
 }
+
+void ArgonMinimalTransport::GetViscosities(const Vector &conserved, const Vector &primitive,
+                                           double &visc, double &bulkVisc) {
+  Vector n_sp(3), X_sp(3), Y_sp(3);
+  mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
+  double nTotal = 0.0;
+  for (int sp = 0; sp < numSpecies; sp++) nTotal += n_sp(sp);
+
+  double Te = (twoTemperature_) ? primitive[num_equation - 1] : primitive[nvel_ + 1];
+  double Th = primitive[nvel_ + 1];
+
+  // Add Xeps to avoid zero number density case.
+  double nOverT = (n_sp(electronIndex_) + Xeps_) / Te + (n_sp(ionIndex_) + Xeps_) / Th;
+  double debyeLength = sqrt(debyeFactor_ / AVOGADRONUMBER / nOverT);
+  double debyeCircle = PI_ * debyeLength * debyeLength;
+
+  double nondimTe = debyeLength * 4.0 * PI_ * debyeFactor_ * Te;
+  double nondimTh = debyeLength * 4.0 * PI_ * debyeFactor_ * Th;
+
+  Vector speciesViscosity(3);
+  speciesViscosity(ionIndex_) =
+      viscosityFactor_ * sqrt(mw_(ionIndex_) * Th) / (collision::charged::rep22(nondimTh) * debyeCircle);
+  speciesViscosity(neutralIndex_) = viscosityFactor_ * sqrt(mw_(neutralIndex_) * Th) / collision::argon::ArAr22(Th);
+  speciesViscosity(electronIndex_) = 0.0;
+
+  visc = 0.0;
+  for (int sp = 0; sp < numSpecies; sp++) {
+    visc += X_sp(sp) * speciesViscosity(sp);
+  }
+  bulkVisc = 0.0;
+
+  return;
+}

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -105,8 +105,8 @@ class ArgonMinimalTransport : public TransportProperties {
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp);
 
-  // TODO(kevin): only for AxisymmetricSource
-  virtual double GetViscosityFromPrimitive(const Vector &state) {}
+  // NOTE(kevin): only for AxisymmetricSource
+  virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);
 
   double computeThirdOrderElectronThermalConductivity(const Vector &X_sp, const double debyeLength, const double Te,
                                                       const double nondimTe);

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -34,9 +34,10 @@
 
 // EquationOfState::EquationOfState() {}
 
-GasMixture::GasMixture(WorkingFluid _fluid, int _dim) {
+GasMixture::GasMixture(WorkingFluid _fluid, int _dim, int nvel) {
   fluid = _fluid;
   dim = _dim;
+  nvel_ = nvel;
 }
 
 void GasMixture::UpdatePressureGridFunction(ParGridFunction *press, const ParGridFunction *Up) {
@@ -62,14 +63,14 @@ void GasMixture::computeStagnationState(const mfem::Vector &stateIn, mfem::Vecto
   stagnationState = stateIn;
 
   // momentum = 0.;
-  for (int d = 0; d < dim; d++) stagnationState(1 + d) = 0.;
+  for (int d = 0; d < nvel_; d++) stagnationState(1 + d) = 0.;
 
   // compute total energy
   double kineticEnergy = 0.0;
-  for (int d = 0; d < dim; d++) {
+  for (int d = 0; d < nvel_; d++) {
     kineticEnergy += 0.5 * stateIn(1 + d) * stateIn(1 + d) / stateIn(0);
   }
-  stagnationState(1 + dim) = stateIn(1 + dim) - kineticEnergy;
+  stagnationState(1 + nvel_) = stateIn(1 + nvel_) - kineticEnergy;
 
   // NOTE: electron energy is purely internal energy, so no change.
 }
@@ -78,7 +79,7 @@ void GasMixture::computeStagnationState(const mfem::Vector &stateIn, mfem::Vecto
 //////// Dry Air mixture
 //////////////////////////////////////////////////////
 
-DryAir::DryAir(RunConfiguration &_runfile, int _dim) : GasMixture(WorkingFluid::DRY_AIR, _dim) {
+DryAir::DryAir(RunConfiguration &_runfile, int _dim, int nvel) : GasMixture(WorkingFluid::DRY_AIR, _dim, nvel) {
   numSpecies = (_runfile.GetEquationSystem() == NS_PASSIVE) ? 2 : 1;
   ambipolar = false;
   twoTemperature_ = false;
@@ -124,24 +125,24 @@ DryAir::DryAir() {
 #endif
 }
 
-DryAir::DryAir(int _dim, int _num_equation) {
-  gas_constant = 287.058;
-  // gas_constant = 1.; // for comparison against ex18
-  specific_heat_ratio = 1.4;
-// TODO(kevin): GPU routines are not yet fully gas-agnostic. Need to be removed.
-#ifdef _GPU_
-  visc_mult = 1.;
-  Pr = 0.71;
-  cp_div_pr = specific_heat_ratio * gas_constant / (Pr * (specific_heat_ratio - 1.));
-  Sc = 0.71;
-#endif
-
-  dim = _dim;
-  num_equation = _num_equation;
-}
+// DryAir::DryAir(int _dim, int _num_equation) {
+//   gas_constant = 287.058;
+//   // gas_constant = 1.; // for comparison against ex18
+//   specific_heat_ratio = 1.4;
+// // TODO(kevin): GPU routines are not yet fully gas-agnostic. Need to be removed.
+// #ifdef _GPU_
+//   visc_mult = 1.;
+//   Pr = 0.71;
+//   cp_div_pr = specific_heat_ratio * gas_constant / (Pr * (specific_heat_ratio - 1.));
+//   Sc = 0.71;
+// #endif
+//
+//   dim = _dim;
+//   num_equation = _num_equation;
+// }
 
 void DryAir::setNumEquations() {
-  Nconservative = dim + 2;
+  Nconservative = nvel_ + 2;
   Nprimitive = Nconservative;
   num_equation = Nconservative;
 }
@@ -172,8 +173,8 @@ void DryAir::computeSpeciesEnthalpies(const Vector &state, Vector &speciesEnthal
 
 bool DryAir::StateIsPhysical(const mfem::Vector &state) {
   const double den = state(0);
-  const Vector den_vel(state.GetData() + 1, dim);
-  const double den_energy = state(1 + dim);
+  const Vector den_vel(state.GetData() + 1, nvel_);
+  const double den_energy = state(1 + nvel_);
 
   if (den < 0) {
     cout << "Negative density: ";
@@ -193,7 +194,7 @@ bool DryAir::StateIsPhysical(const mfem::Vector &state) {
   }
 
   double den_vel2 = 0;
-  for (int i = 0; i < dim; i++) {
+  for (int i = 0; i < nvel_; i++) {
     den_vel2 += den_vel(i) * den_vel(i);
   }
   den_vel2 /= den;
@@ -216,10 +217,10 @@ bool DryAir::StateIsPhysical(const mfem::Vector &state) {
 // Compute the maximum characteristic speed.
 double DryAir::ComputeMaxCharSpeed(const Vector &state) {
   const double den = state(0);
-  const Vector den_vel(state.GetData() + 1, dim);
+  const Vector den_vel(state.GetData() + 1, nvel_);
 
   double den_vel2 = 0;
-  for (int d = 0; d < dim; d++) {
+  for (int d = 0; d < nvel_; d++) {
     den_vel2 += den_vel(d) * den_vel(d);
   }
   den_vel2 /= den;
@@ -235,17 +236,17 @@ void DryAir::GetConservativesFromPrimitives(const Vector &primit, Vector &conser
   conserv = primit;
 
   double v2 = 0.;
-  for (int d = 0; d < dim; d++) {
+  for (int d = 0; d < nvel_; d++) {
     v2 += primit[1 + d] * primit[1 + d];
     conserv[1 + d] *= primit[0];
   }
   // total energy
-  conserv[1 + dim] = gas_constant * primit[0] * primit[1 + dim] / (specific_heat_ratio - 1.) + 0.5 * primit[0] * v2;
+  conserv[1 + nvel_] = gas_constant * primit[0] * primit[1 + nvel_] / (specific_heat_ratio - 1.) + 0.5 * primit[0] * v2;
 
   // case of passive scalar
-  if (num_equation > dim + 2) {
-    for (int n = 0; n < num_equation - dim - 2; n++) {
-      conserv[dim + 2 + n] *= primit[0];
+  if (num_equation > nvel_ + 2) {
+    for (int n = 0; n < num_equation - nvel_ - 2; n++) {
+      conserv[nvel_ + 2 + n] *= primit[0];
     }
   }
 }
@@ -254,14 +255,14 @@ void DryAir::GetPrimitivesFromConservatives(const Vector &conserv, Vector &primi
   double T = ComputeTemperature(conserv);
   primit = conserv;
 
-  for (int d = 0; d < dim; d++) primit[1 + d] /= conserv[0];
+  for (int d = 0; d < nvel_; d++) primit[1 + d] /= conserv[0];
 
-  primit[dim + 1] = T;
+  primit[nvel_ + 1] = T;
 
   // case of passive scalar
-  if (num_equation > dim + 2) {
-    for (int n = 0; n < num_equation - dim - 2; n++) {
-      primit[dim + 2 + n] /= primit[0];
+  if (num_equation > nvel_ + 2) {
+    for (int n = 0; n < num_equation - nvel_ - 2; n++) {
+      primit[nvel_ + 2 + n] /= primit[0];
     }
   }
 }
@@ -270,7 +271,7 @@ double DryAir::ComputeSpeedOfSound(const mfem::Vector &Uin, bool primitive) {
   double T;
 
   if (primitive) {
-    T = Uin[1 + dim];
+    T = Uin[1 + nvel_];
   } else {
     // conservatives passed in
     T = ComputeTemperature(Uin);
@@ -282,15 +283,15 @@ double DryAir::ComputeSpeedOfSound(const mfem::Vector &Uin, bool primitive) {
 double DryAir::ComputePressureDerivative(const Vector &dUp_dx, const Vector &Uin, bool primitive) {
   double T, p;
   if (primitive) {
-    T = Uin[1 + dim];
+    T = Uin[1 + nvel_];
   } else {
     T = ComputeTemperature(Uin);
   }
 
-  return gas_constant * (T * dUp_dx[0] + Uin[0] * dUp_dx[1 + dim]);
+  return gas_constant * (T * dUp_dx[0] + Uin[0] * dUp_dx[1 + nvel_]);
 }
 
-double DryAir::ComputePressureFromPrimitives(const mfem::Vector &Up) { return gas_constant * Up[0] * Up[1 + dim]; }
+double DryAir::ComputePressureFromPrimitives(const mfem::Vector &Up) { return gas_constant * Up[0] * Up[1 + nvel_]; }
 
 void DryAir::computeStagnationState(const mfem::Vector &stateIn, mfem::Vector &stagnationState) {
   const double p = ComputePressure(stateIn);
@@ -299,19 +300,19 @@ void DryAir::computeStagnationState(const mfem::Vector &stateIn, mfem::Vector &s
   stagnationState = stateIn;
 
   // zero momentum
-  for (int d = 0; d < dim; d++) stagnationState(1 + d) = 0.;
+  for (int d = 0; d < nvel_; d++) stagnationState(1 + d) = 0.;
 
   // total energy
-  stagnationState(1 + dim) = p / (specific_heat_ratio - 1.);
+  stagnationState(1 + nvel_) = p / (specific_heat_ratio - 1.);
 }
 
 void DryAir::computeStagnantStateWithTemp(const mfem::Vector &stateIn, const double Temp, mfem::Vector &stateOut) {
   stateOut.SetSize(num_equation);
   stateOut = stateIn;
 
-  for (int d = 0; d < dim; d++) stateOut(1 + d) = 0.;
+  for (int d = 0; d < nvel_; d++) stateOut(1 + d) = 0.;
 
-  stateOut(1 + dim) = gas_constant / (specific_heat_ratio - 1.) * stateIn(0) * Temp;
+  stateOut(1 + nvel_) = gas_constant / (specific_heat_ratio - 1.) * stateIn(0) * Temp;
 }
 
 // NOTE: modifyElectronEnergy will not be used for DryAir.
@@ -321,10 +322,10 @@ void DryAir::modifyEnergyForPressure(const mfem::Vector &stateIn, mfem::Vector &
   stateOut = stateIn;
 
   double ke = 0.;
-  for (int d = 0; d < dim; d++) ke += stateIn(1 + d) * stateIn(1 + d);
+  for (int d = 0; d < nvel_; d++) ke += stateIn(1 + d) * stateIn(1 + d);
   ke *= 0.5 / stateIn(0);
 
-  stateOut(1 + dim) = p / (specific_heat_ratio - 1.) + ke;
+  stateOut(1 + nvel_) = p / (specific_heat_ratio - 1.) + ke;
 }
 
 // TODO(kevin): check if this works for axisymmetric case.
@@ -333,20 +334,27 @@ void DryAir::computeConservedStateFromConvectiveFlux(const Vector &meanNormalFlu
   const double gamma = specific_heat_ratio;
 
   double temp = 0.;
+  // For axisymmetric case, normal[2] = 0.0. For-loop only includes up to d < dim = 2.
   for (int d = 0; d < dim; d++) temp += meanNormalFluxes[1 + d] * normal[d];
   double A = 1. - 2. * gamma / (gamma - 1.);
   double B = 2 * temp / (gamma - 1.);
-  double C = -2. * meanNormalFluxes[0] * meanNormalFluxes[1 + dim];
-  for (int d = 0; d < dim; d++) C += meanNormalFluxes[1 + d] * meanNormalFluxes[1 + d];
+  double C = -2. * meanNormalFluxes[0] * meanNormalFluxes[1 + nvel_];
+  for (int d = 0; d < nvel_; d++) C += meanNormalFluxes[1 + d] * meanNormalFluxes[1 + d];
   //   double p = (-B+sqrt(B*B-4.*A*C))/(2.*A);
   double p = (-B - sqrt(B * B - 4. * A * C)) / (2. * A);  // real solution
 
   Vector Up(num_equation);
   Up[0] = meanNormalFluxes[0] * meanNormalFluxes[0] / (temp - p);
-  Up[1 + dim] = Temperature(&Up[0], &p, 1);
+  Up[1 + nvel_] = Temperature(&Up[0], &p, 1);
   //   Up[1+dim] = p;
 
-  for (int d = 0; d < dim; d++) Up[1 + d] = (meanNormalFluxes[1 + d] - p * normal[d]) / meanNormalFluxes[0];
+  for (int d = 0; d < nvel_; d++) {
+    if (d < dim) {
+      Up[1 + d] = (meanNormalFluxes[1 + d] - p * normal[d]) / meanNormalFluxes[0];
+    } else { // azimuthal direction for axisymmetric case.
+      Up[1 + d] = meanNormalFluxes[1 + d] / meanNormalFluxes[0];
+    }
+  }
 
   GetConservativesFromPrimitives(Up, conservedState);
 }
@@ -381,7 +389,7 @@ double EquationOfState::pressure( double *state,
 //////////////////////////////////////////////////////
 //////// Test Binary Air mixture
 //////////////////////////////////////////////////////
-TestBinaryAir::TestBinaryAir(RunConfiguration &_runfile, int _dim) : GasMixture(WorkingFluid::TEST_BINARY_AIR, _dim) {
+TestBinaryAir::TestBinaryAir(RunConfiguration &_runfile, int _dim, int nvel) : GasMixture(WorkingFluid::TEST_BINARY_AIR, _dim, nvel) {
   numSpecies = 2;
   ambipolar = false;
   twoTemperature_ = false;
@@ -606,7 +614,7 @@ void TestBinaryAir::ComputeMoleFractionGradient(const Vector &numberDensities, c
 ////// Perfect Mixture GasMixture                     ////////////////////
 //////////////////////////////////////////////////////////////////////////
 
-PerfectMixture::PerfectMixture(RunConfiguration &_runfile, int _dim) : GasMixture(WorkingFluid::USER_DEFINED, _dim) {
+PerfectMixture::PerfectMixture(RunConfiguration &_runfile, int _dim, int nvel) : GasMixture(WorkingFluid::USER_DEFINED, _dim, nvel) {
   numSpecies = _runfile.GetNumSpecies();
   backgroundInputIndex_ = _runfile.backgroundIndex;
   assert((backgroundInputIndex_ > 0) && (backgroundInputIndex_ <= numSpecies));
@@ -732,15 +740,15 @@ void PerfectMixture::GetPrimitivesFromConservatives(const Vector &conserv, Vecto
   // compute its gradient only.
   // Conversion from grad n to grad X or grad Y will be provided.
   // Conversion routines will benefit from expanding Up with all X, Y and n.
-  for (int sp = 0; sp < numActiveSpecies; sp++) primit[dim + 2 + sp] = n_sp[sp];
+  for (int sp = 0; sp < numActiveSpecies; sp++) primit[nvel_ + 2 + sp] = n_sp[sp];
 
   primit[0] = conserv[0];
-  for (int d = 0; d < dim; d++) primit[d + 1] = conserv[d + 1] / conserv[0];
+  for (int d = 0; d < nvel_; d++) primit[d + 1] = conserv[d + 1] / conserv[0];
 
   double T_h, T_e;
   computeTemperaturesBase(conserv, &n_sp[0], n_sp[numSpecies - 2], n_sp[numSpecies - 1], T_h, T_e);
 
-  primit[dim + 1] = T_h;
+  primit[nvel_ + 1] = T_h;
 
   if (twoTemperature_)  // electron temperature as primitive variable.
     primit[num_equation - 1] = T_e;
@@ -748,43 +756,43 @@ void PerfectMixture::GetPrimitivesFromConservatives(const Vector &conserv, Vecto
 
 void PerfectMixture::GetConservativesFromPrimitives(const Vector &primit, Vector &conserv) {
   conserv[0] = primit[0];
-  for (int d = 0; d < dim; d++) conserv[d + 1] = primit[d + 1] * primit[0];
+  for (int d = 0; d < nvel_; d++) conserv[d + 1] = primit[d + 1] * primit[0];
 
   // Convert species rhoY first.
   for (int sp = 0; sp < numActiveSpecies; sp++) {
-    conserv[dim + 2 + sp] = primit[dim + 2 + sp] * gasParams(sp, GasParams::SPECIES_MW);
+    conserv[nvel_ + 2 + sp] = primit[nvel_ + 2 + sp] * gasParams(sp, GasParams::SPECIES_MW);
   }
 
   // NOTE: For now, we do not include all species number densities into Up.
   // This requires us to re-evaluate electron/background-species number density.
   double n_e = 0.0;
   if (ambipolar) {
-    n_e = computeAmbipolarElectronNumberDensity(&primit[dim + 2]);
+    n_e = computeAmbipolarElectronNumberDensity(&primit[nvel_ + 2]);
   } else {
-    n_e = primit[dim + 2 + numSpecies - 2];
+    n_e = primit[nvel_ + 2 + numSpecies - 2];
   }
-  double rhoB = computeBackgroundMassDensity(primit[0], &primit[dim + 2], n_e, true);
+  double rhoB = computeBackgroundMassDensity(primit[0], &primit[nvel_ + 2], n_e, true);
   double nB = rhoB / gasParams(numSpecies - 1, GasParams::SPECIES_MW);
 
   if (twoTemperature_) conserv[num_equation - 1] = n_e * molarCV_(numSpecies - 2) * primit[num_equation - 1];
 
   // compute mixture heat capacity.
-  double totalHeatCapacity = computeHeaviesHeatCapacity(&primit[dim + 2], nB);
+  double totalHeatCapacity = computeHeaviesHeatCapacity(&primit[nvel_ + 2], nB);
   if (!twoTemperature_) totalHeatCapacity += n_e * molarCV_(numSpecies - 2);
 
   double totalEnergy = 0.0;
-  for (int d = 0; d < dim; d++) totalEnergy += primit[d + 1] * primit[d + 1];
+  for (int d = 0; d < nvel_; d++) totalEnergy += primit[d + 1] * primit[d + 1];
   totalEnergy *= 0.5 * primit[0];
-  totalEnergy += totalHeatCapacity * primit[dim + 1];
+  totalEnergy += totalHeatCapacity * primit[nvel_ + 1];
   if (twoTemperature_) {
     totalEnergy += conserv[num_equation - 1];
   }
 
   for (int sp = 0; sp < numSpecies - 2; sp++) {
-    totalEnergy += primit[dim + 2 + sp] * gasParams(sp, GasParams::FORMATION_ENERGY);
+    totalEnergy += primit[nvel_ + 2 + sp] * gasParams(sp, GasParams::FORMATION_ENERGY);
   }
 
-  conserv[dim + 1] = totalEnergy;
+  conserv[nvel_ + 1] = totalEnergy;
 }
 
 // NOTE: Almost for sure ambipolar will remain true, then we have to always compute at least both Y and n.
@@ -802,7 +810,7 @@ void PerfectMixture::computeSpeciesPrimitives(const Vector &conservedState, Vect
   double n_e = 0.0;
   double n = 0.0;
   for (int sp = 0; sp < numActiveSpecies; sp++) {
-    n_sp[sp] = conservedState[dim + 2 + sp] / gasParams(sp, GasParams::SPECIES_MW);
+    n_sp[sp] = conservedState[nvel_ + 2 + sp] / gasParams(sp, GasParams::SPECIES_MW);
     n += n_sp[sp];
     if (ambipolar) n_e += gasParams(sp, GasParams::SPECIES_CHARGES) * n_sp[sp];
   }  // Background species doesn't have to be included due to its neutral charge.
@@ -813,7 +821,7 @@ void PerfectMixture::computeSpeciesPrimitives(const Vector &conservedState, Vect
 
   double Yb = 1.;
   for (int sp = 0; sp < numActiveSpecies; sp++) {
-    Y_sp[sp] = conservedState[dim + 2 + sp] / conservedState[0];
+    Y_sp[sp] = conservedState[nvel_ + 2 + sp] / conservedState[0];
     Yb -= Y_sp[sp];
   }
 
@@ -844,7 +852,7 @@ void PerfectMixture::computeNumberDensities(const Vector &conservedState, Vector
 
   double n_e = 0.0;
   for (int sp = 0; sp < numActiveSpecies; sp++) {
-    n_sp[sp] = conservedState[dim + 2 + sp] / gasParams(sp, GasParams::SPECIES_MW);
+    n_sp[sp] = conservedState[nvel_ + 2 + sp] / gasParams(sp, GasParams::SPECIES_MW);
   }
   if (ambipolar) {
     n_e = computeAmbipolarElectronNumberDensity(&n_sp[0]);
@@ -860,21 +868,21 @@ double PerfectMixture::ComputePressureFromPrimitives(const mfem::Vector &Up) {
   // This requires us to re-evaluate electron/background-species number density.
   double n_e = 0.0;
   if (ambipolar) {
-    n_e = computeAmbipolarElectronNumberDensity(&Up[dim + 2]);
+    n_e = computeAmbipolarElectronNumberDensity(&Up[nvel_ + 2]);
   } else {
-    n_e = Up[dim + 2 + numSpecies - 2];
+    n_e = Up[nvel_ + 2 + numSpecies - 2];
   }
-  double rhoB = computeBackgroundMassDensity(Up[0], &Up[dim + 2], n_e, true);
+  double rhoB = computeBackgroundMassDensity(Up[0], &Up[nvel_ + 2], n_e, true);
   double nB = rhoB / gasParams(numSpecies - 1, GasParams::SPECIES_MW);
 
-  double T_h = Up[dim + 1];
+  double T_h = Up[nvel_ + 1];
   double T_e;
   if (twoTemperature_) {
     T_e = Up[num_equation - 1];
   } else {
-    T_e = Up[dim + 1];
+    T_e = Up[nvel_ + 1];
   }
-  double p = computePressureBase(&Up[dim + 2], n_e, nB, T_h, T_e);
+  double p = computePressureBase(&Up[nvel_ + 2], n_e, nB, T_h, T_e);
 
   return p;
 }
@@ -923,7 +931,7 @@ bool PerfectMixture::StateIsPhysical(const Vector &state) {
     cout << "Negative density! " << endl;
     physical = false;
   }
-  if (state(dim + 1) <= 0) {
+  if (state(nvel_ + 1) <= 0) {
     cout << "Negative energy! " << endl;
     physical = false;
   }
@@ -931,8 +939,8 @@ bool PerfectMixture::StateIsPhysical(const Vector &state) {
   /* TODO(kevin): take primitive variables as input for physicality check. */
   // Vector primitiveState(num_equation);
   // GetPrimitivesFromConservatives(state, primitiveState);
-  // if (primitiveState(dim+1) < 0) {
-  //   cout << "Negative pressure: " << primitiveState(dim+1) << "! " << endl;
+  // if (primitiveState(nvel_+1) < 0) {
+  //   cout << "Negative pressure: " << primitiveState(nvel_+1) << "! " << endl;
   //   physical = false;
   // }
   // if (primitiveState(num_equation-1) <= 0) {
@@ -986,14 +994,14 @@ void PerfectMixture::computeTemperaturesBase(const Vector &conservedState, const
   double totalHeatCapacity = computeHeaviesHeatCapacity(&n_sp[0], n_B);
   if (!twoTemperature_) totalHeatCapacity += n_e * molarCV_(numSpecies - 2);
 
-  double totalEnergy = conservedState[dim + 1];
+  double totalEnergy = conservedState[nvel_ + 1];
   for (int sp = 0; sp < numSpecies - 2; sp++) {
     totalEnergy -= n_sp[sp] * gasParams(sp, GasParams::FORMATION_ENERGY);
   }
 
   // Comptue heavy-species temperature. If not two temperature, then this works as the unique temperature.
   T_h = 0.0;
-  for (int d = 0; d < dim; d++) T_h -= conservedState[d + 1] * conservedState[d + 1];
+  for (int d = 0; d < nvel_; d++) T_h -= conservedState[d + 1] * conservedState[d + 1];
   T_h *= 0.5 / conservedState[0];
   T_h += totalEnergy;
   if (twoTemperature_) T_h -= conservedState[num_equation - 1];
@@ -1034,53 +1042,55 @@ double PerfectMixture::ComputePressureDerivative(const Vector &dUp_dx, const Vec
   }
 }
 
+// NOTE(kevin): normal-vector-related parts are already handled.
 double PerfectMixture::computePressureDerivativeFromPrimitives(const Vector &dUp_dx, const Vector &Uin) {
   double pressureGradient = 0.0;
 
   double n_e = 0.0;
   double dne_dx = 0.0;
   if (ambipolar) {
-    n_e = computeAmbipolarElectronNumberDensity(&Uin[dim + 2]);
+    n_e = computeAmbipolarElectronNumberDensity(&Uin[nvel_ + 2]);
     for (int sp = 0; sp < numActiveSpecies; sp++) {
-      dne_dx += dUp_dx[dim + 2 + sp] * gasParams(sp, GasParams::SPECIES_CHARGES);
+      dne_dx += dUp_dx[nvel_ + 2 + sp] * gasParams(sp, GasParams::SPECIES_CHARGES);
     }
   } else {
-    n_e = Uin[dim + 2 + numSpecies - 2];
-    dne_dx = dUp_dx[dim + 2 + numSpecies - 2];
+    n_e = Uin[nvel_ + 2 + numSpecies - 2];
+    dne_dx = dUp_dx[nvel_ + 2 + numSpecies - 2];
   }
 
-  double rhoB = computeBackgroundMassDensity(Uin[0], &Uin[dim + 2], n_e, true);
+  double rhoB = computeBackgroundMassDensity(Uin[0], &Uin[nvel_ + 2], n_e, true);
   double nB = rhoB / gasParams(numSpecies - 1, GasParams::SPECIES_MW);
 
   double n_h = 0.0;
   for (int sp = 0; sp < numActiveSpecies; sp++) {
     if (sp == numSpecies - 2) continue;
-    n_h += Uin[dim + 2 + sp];
+    n_h += Uin[nvel_ + 2 + sp];
   }
   n_h += nB;
-  pressureGradient += n_h * dUp_dx[dim + 1];
+  pressureGradient += n_h * dUp_dx[nvel_ + 1];
 
   double numDenGrad = dUp_dx[0] / gasParams(numSpecies - 1, GasParams::SPECIES_MW);
   for (int sp = 0; sp < numActiveSpecies; sp++) {
     if (sp == numSpecies - 2) continue;
-    numDenGrad += dUp_dx[dim + 2 + sp] *
+    numDenGrad += dUp_dx[nvel_ + 2 + sp] *
                   (1.0 - gasParams(sp, GasParams::SPECIES_MW) / gasParams(numSpecies - 1, GasParams::SPECIES_MW));
   }
   // Kevin: this electron-related term comes from background species.
   numDenGrad -=
       dne_dx * gasParams(numSpecies - 2, GasParams::SPECIES_MW) / gasParams(numSpecies - 1, GasParams::SPECIES_MW);
-  pressureGradient += numDenGrad * Uin[dim + 1];
+  pressureGradient += numDenGrad * Uin[nvel_ + 1];
 
   if (twoTemperature_) {
     pressureGradient += n_e * dUp_dx[num_equation - 1] + dne_dx * Uin[num_equation - 1];
   } else {
-    pressureGradient += n_e * dUp_dx[dim + 1] + dne_dx * Uin[dim + 1];
+    pressureGradient += n_e * dUp_dx[nvel_ + 1] + dne_dx * Uin[nvel_ + 1];
   }
 
   pressureGradient *= UNIVERSALGASCONSTANT;
   return pressureGradient;
 }
 
+// NOTE(kevin): normal-vector-related parts are already handled.
 double PerfectMixture::computePressureDerivativeFromConservatives(const Vector &dUp_dx, const Vector &Uin) {
   double pressureGradient = 0.0;
 
@@ -1089,10 +1099,10 @@ double PerfectMixture::computePressureDerivativeFromConservatives(const Vector &
   double dne_dx = 0.0;
   if (ambipolar) {
     for (int sp = 0; sp < numActiveSpecies; sp++) {
-      dne_dx += dUp_dx[dim + 2 + sp] * gasParams(sp, GasParams::SPECIES_CHARGES);
+      dne_dx += dUp_dx[nvel_ + 2 + sp] * gasParams(sp, GasParams::SPECIES_CHARGES);
     }
   } else {
-    dne_dx = dUp_dx[dim + 2 + numSpecies - 2];
+    dne_dx = dUp_dx[nvel_ + 2 + numSpecies - 2];
   }
 
   double T_h, T_e;
@@ -1103,12 +1113,12 @@ double PerfectMixture::computePressureDerivativeFromConservatives(const Vector &
     if (sp == numSpecies - 2) continue;
     n_h += n_sp[sp];
   }
-  pressureGradient += n_h * dUp_dx[dim + 1];
+  pressureGradient += n_h * dUp_dx[nvel_ + 1];
 
   double numDenGrad = dUp_dx[0] / gasParams(numSpecies - 1, GasParams::SPECIES_MW);
   for (int sp = 0; sp < numActiveSpecies; sp++) {
     if (sp == numSpecies - 2) continue;
-    numDenGrad += dUp_dx[dim + 2 + sp] *
+    numDenGrad += dUp_dx[nvel_ + 2 + sp] *
                   (1.0 - gasParams(sp, GasParams::SPECIES_MW) / gasParams(numSpecies - 1, GasParams::SPECIES_MW));
   }
   // Kevin: this electron-related term comes from background species.
@@ -1119,7 +1129,7 @@ double PerfectMixture::computePressureDerivativeFromConservatives(const Vector &
   if (twoTemperature_) {
     pressureGradient += n_sp[numSpecies - 2] * dUp_dx[num_equation - 1] + dne_dx * T_e;
   } else {
-    pressureGradient += n_sp[numSpecies - 2] * dUp_dx[dim + 1] + dne_dx * T_h;
+    pressureGradient += n_sp[numSpecies - 2] * dUp_dx[nvel_ + 1] + dne_dx * T_h;
   }
 
   pressureGradient *= UNIVERSALGASCONSTANT;
@@ -1158,10 +1168,10 @@ double PerfectMixture::computeSpeedOfSoundBase(const double *n_sp, const double 
 // Compute the maximum characteristic speed.
 double PerfectMixture::ComputeMaxCharSpeed(const Vector &state) {
   const double den = state(0);
-  const Vector den_vel(state.GetData() + 1, dim);
+  const Vector den_vel(state.GetData() + 1, nvel_);
 
   double den_vel2 = 0;
-  for (int d = 0; d < dim; d++) {
+  for (int d = 0; d < nvel_; d++) {
     den_vel2 += den_vel(d) * den_vel(d);
   }
   den_vel2 /= den;
@@ -1176,17 +1186,17 @@ double PerfectMixture::ComputeSpeedOfSound(const mfem::Vector &Uin, bool primiti
   if (primitive) {
     double n_e = 0.0;
     if (ambipolar) {
-      n_e = computeAmbipolarElectronNumberDensity(&Uin[dim + 2]);
+      n_e = computeAmbipolarElectronNumberDensity(&Uin[nvel_ + 2]);
     } else {
-      n_e = Uin[dim + 2 + numSpecies - 2];
+      n_e = Uin[nvel_ + 2 + numSpecies - 2];
     }
-    double rhoB = computeBackgroundMassDensity(Uin[0], &Uin[dim + 2], n_e, true);
+    double rhoB = computeBackgroundMassDensity(Uin[0], &Uin[nvel_ + 2], n_e, true);
     double nB = rhoB / gasParams(numSpecies - 1, GasParams::SPECIES_MW);
 
-    double T_e = (twoTemperature_) ? Uin[num_equation - 1] : Uin[dim + 1];
-    double p = computePressureBase(&Uin[dim + 2], n_e, nB, Uin[dim + 1], T_e);
+    double T_e = (twoTemperature_) ? Uin[num_equation - 1] : Uin[nvel_ + 1];
+    double p = computePressureBase(&Uin[nvel_ + 2], n_e, nB, Uin[nvel_ + 1], T_e);
 
-    return computeSpeedOfSoundBase(&Uin[dim + 2], nB, Uin[0], p);
+    return computeSpeedOfSoundBase(&Uin[nvel_ + 2], nB, Uin[0], p);
 
   } else {
     Vector n_sp;
@@ -1202,13 +1212,14 @@ double PerfectMixture::ComputeSpeedOfSound(const mfem::Vector &Uin, bool primiti
 }
 
 // NOTE: numberDensities have all species number density.
+// NOTE(kevin): for axisymmetric case, this handles only r- and z-direction.
 void PerfectMixture::ComputeMassFractionGradient(const double rho, const Vector &numberDensities,
                                                  const DenseMatrix &gradUp, DenseMatrix &massFractionGrad) {
   massFractionGrad.SetSize(numSpecies, dim);
   massFractionGrad = 0.0;
   for (int sp = 0; sp < numActiveSpecies; sp++) {  // if not ambipolar, electron is included.
     for (int d = 0; d < dim; d++) {
-      massFractionGrad(sp, d) = gradUp(dim + 2 + sp, d) / rho - numberDensities(sp) / rho / rho * gradUp(0, d);
+      massFractionGrad(sp, d) = gradUp(nvel_ + 2 + sp, d) / rho - numberDensities(sp) / rho / rho * gradUp(0, d);
       massFractionGrad(sp, d) *= gasParams(sp, GasParams::SPECIES_MW);
     }
   }
@@ -1217,7 +1228,7 @@ void PerfectMixture::ComputeMassFractionGradient(const double rho, const Vector 
   neGrad = 0.0;
   if (ambipolar) {
     for (int sp = 0; sp < numActiveSpecies; sp++) {
-      for (int d = 0; d < dim; d++) neGrad(d) += gradUp(dim + 2 + sp, d) * gasParams(sp, GasParams::SPECIES_CHARGES);
+      for (int d = 0; d < dim; d++) neGrad(d) += gradUp(nvel_ + 2 + sp, d) * gasParams(sp, GasParams::SPECIES_CHARGES);
     }
     for (int d = 0; d < dim; d++) {
       massFractionGrad(numSpecies - 2, d) =
@@ -1229,7 +1240,7 @@ void PerfectMixture::ComputeMassFractionGradient(const double rho, const Vector 
   Vector mGradN(dim);
   mGradN = 0.0;
   for (int sp = 0; sp < numActiveSpecies; sp++) {
-    for (int d = 0; d < dim; d++) mGradN(d) += gradUp(dim + 2 + sp, d) * gasParams(sp, GasParams::SPECIES_MW);
+    for (int d = 0; d < dim; d++) mGradN(d) += gradUp(nvel_ + 2 + sp, d) * gasParams(sp, GasParams::SPECIES_MW);
   }
   if (ambipolar) {
     for (int d = 0; d < dim; d++) mGradN(d) += neGrad(d) * gasParams(numSpecies - 2, GasParams::SPECIES_MW);
@@ -1240,6 +1251,7 @@ void PerfectMixture::ComputeMassFractionGradient(const double rho, const Vector 
   }
 }
 
+// NOTE(kevin): for axisymmetric case, this handles only r- and z-direction.
 void PerfectMixture::ComputeMoleFractionGradient(const Vector &numberDensities, const DenseMatrix &gradUp,
                                                  DenseMatrix &moleFractionGrad) {
   moleFractionGrad.SetSize(numSpecies, dim);
@@ -1251,14 +1263,14 @@ void PerfectMixture::ComputeMoleFractionGradient(const Vector &numberDensities, 
   neGrad = 0.0;
   if (ambipolar) {
     for (int sp = 0; sp < numActiveSpecies; sp++) {
-      for (int d = 0; d < dim; d++) neGrad(d) += gradUp(dim + 2 + sp, d) * gasParams(sp, GasParams::SPECIES_CHARGES);
+      for (int d = 0; d < dim; d++) neGrad(d) += gradUp(nvel_ + 2 + sp, d) * gasParams(sp, GasParams::SPECIES_CHARGES);
     }
   }
 
   Vector nBGrad(dim);
   for (int d = 0; d < dim; d++) nBGrad(d) = gradUp(0, d);
   for (int sp = 0; sp < numActiveSpecies; sp++) {
-    for (int d = 0; d < dim; d++) nBGrad(d) -= gradUp(dim + 2 + sp, d) * gasParams(sp, GasParams::SPECIES_MW);
+    for (int d = 0; d < dim; d++) nBGrad(d) -= gradUp(nvel_ + 2 + sp, d) * gasParams(sp, GasParams::SPECIES_MW);
   }
   if (ambipolar) {
     // nBGrad -= gasParams(numSpecies - 2, GasParams::SPECIES_MW) / gasParams(numSpecies - 1, GasParams::SPECIES_MW) *
@@ -1271,7 +1283,7 @@ void PerfectMixture::ComputeMoleFractionGradient(const Vector &numberDensities, 
   totalNGrad.SetSize(dim);
   totalNGrad = 0.0;
   for (int sp = 0; sp < numActiveSpecies; sp++) {  // if not ambipolar, electron is included.
-    for (int d = 0; d < dim; d++) totalNGrad(d) += gradUp(dim + 2 + sp, d);
+    for (int d = 0; d < dim; d++) totalNGrad(d) += gradUp(nvel_ + 2 + sp, d);
   }
   if (ambipolar) totalNGrad += neGrad;
   totalNGrad += nBGrad;
@@ -1279,7 +1291,7 @@ void PerfectMixture::ComputeMoleFractionGradient(const Vector &numberDensities, 
   for (int sp = 0; sp < numActiveSpecies; sp++) {
     for (int d = 0; d < dim; d++) {
       moleFractionGrad(sp, d) =
-          gradUp(dim + 2 + sp, d) / totalN - numberDensities(sp) / totalN / totalN * totalNGrad(d);
+          gradUp(nvel_ + 2 + sp, d) / totalN - numberDensities(sp) / totalN / totalN * totalNGrad(d);
     }
   }
   if (ambipolar) {
@@ -1302,7 +1314,7 @@ void PerfectMixture::computeStagnantStateWithTemp(const mfem::Vector &stateIn, c
   stateOut = stateIn;
 
   // momentum = 0.;
-  for (int d = 0; d < dim; d++) stateOut(1 + d) = 0.;
+  for (int d = 0; d < nvel_; d++) stateOut(1 + d) = 0.;
 
   // compute total energy
   Vector n_sp(numSpecies);
@@ -1312,7 +1324,7 @@ void PerfectMixture::computeStagnantStateWithTemp(const mfem::Vector &stateIn, c
   // assuming electrons also have wall temperature
   double Ue = n_sp[numSpecies - 2] * molarCV_(numSpecies - 2) * Temp;
 
-  stateOut(1 + dim) = Ch * Temp + Ue;
+  stateOut(1 + nvel_) = Ch * Temp + Ue;
 
   if (twoTemperature_) {
     stateOut(num_equation - 1) = Ue;
@@ -1320,7 +1332,7 @@ void PerfectMixture::computeStagnantStateWithTemp(const mfem::Vector &stateIn, c
 
   // Kevin: added formation energies.
   for (int sp = 0; sp < numSpecies - 2; sp++)
-    stateOut(1 + dim) += n_sp(sp) * gasParams(sp, GasParams::FORMATION_ENERGY);
+    stateOut(1 + nvel_) += n_sp(sp) * gasParams(sp, GasParams::FORMATION_ENERGY);
 }
 
 // At Inlet BC, for two-temperature, electron temperature is set to be equal to gas temperature, where the total
@@ -1364,10 +1376,10 @@ void PerfectMixture::modifyEnergyForPressure(const mfem::Vector &stateIn, mfem::
   }
   rE += electronEnergy;
 
-  for (int d = 0; d < dim; d++) rE += 0.5 * stateIn[d + 1] * stateIn[d + 1] / stateIn[0];
+  for (int d = 0; d < nvel_; d++) rE += 0.5 * stateIn[d + 1] * stateIn[d + 1] / stateIn[0];
 
   // double nB = stateIn(0);  // background species
-  // for (int sp = 0; sp < numActiveSpecies; sp++) nB -= stateIn(2 + dim + sp);
+  // for (int sp = 0; sp < numActiveSpecies; sp++) nB -= stateIn(2 + nvel_ + sp);
   //
   // if (ambipolar) nB -= ne * gasParams(numSpecies - 2, GasParams::SPECIES_MW);
   // nB /= gasParams(numSpecies - 1, GasParams::SPECIES_MW);
@@ -1375,14 +1387,14 @@ void PerfectMixture::modifyEnergyForPressure(const mfem::Vector &stateIn, mfem::
   // double Th = 0., Te = 0.;
   // if (twoTemperature) {
   //   Te = stateIn(num_equation - 1) / ne / molarCV_(numSpecies - 2);
-  //   double pe = stateIn(2 + dim + numSpecies - 2) / GetGasParams(numSpecies - 2, GasParams::SPECIES_MW) *
+  //   double pe = stateIn(2 + nvel_ + numSpecies - 2) / GetGasParams(numSpecies - 2, GasParams::SPECIES_MW) *
   //               UNIVERSALGASCONSTANT * Te;
   //
   //   for (int sp = 0; sp < numActiveSpecies; sp++) Th += n_s(sp);
   //   Th += nB;
   //   Th = (p - pe) / (Th * UNIVERSALGASCONSTANT);
   // } else {
-  //   for (int sp = 0; sp < numActiveSpecies; sp++) Th += stateIn(2 + dim + sp) / gasParams(sp, GasParams::SPECIES_MW);
+  //   for (int sp = 0; sp < numActiveSpecies; sp++) Th += stateIn(2 + nvel_ + sp) / gasParams(sp, GasParams::SPECIES_MW);
   //   if (ambipolar) Th += ne;
   //   Th += nB;
   //   Th = p / (Th * UNIVERSALGASCONSTANT);
@@ -1397,7 +1409,7 @@ void PerfectMixture::modifyEnergyForPressure(const mfem::Vector &stateIn, mfem::
   // Kevin: added formation energies.
   for (int sp = 0; sp < numSpecies - 2; sp++) rE += n_sp(sp) * gasParams(sp, GasParams::FORMATION_ENERGY);
 
-  stateOut(1 + dim) = rE;
+  stateOut(1 + nvel_) = rE;
 }
 
 // TODO(kevin): check if this works for axisymmetric case.
@@ -1409,9 +1421,9 @@ void PerfectMixture::computeConservedStateFromConvectiveFlux(const Vector &meanN
   double formEnergyFlux = 0.0;
   double nBFlux = meanNormalFluxes(0);  // background species number density flux.
   for (int sp = 0; sp < numActiveSpecies; sp++) {
-    numberDensityFluxes(sp) = meanNormalFluxes(dim + 2 + sp) / gasParams(sp, GasParams::SPECIES_MW);
+    numberDensityFluxes(sp) = meanNormalFluxes(nvel_ + 2 + sp) / gasParams(sp, GasParams::SPECIES_MW);
     formEnergyFlux += numberDensityFluxes(sp) * gasParams(sp, GasParams::FORMATION_ENERGY);
-    nBFlux -= meanNormalFluxes(dim + 2 + sp);
+    nBFlux -= meanNormalFluxes(nvel_ + 2 + sp);
   }
   double neFlux = 0.0;
   if (ambipolar) {
@@ -1447,11 +1459,12 @@ void PerfectMixture::computeConservedStateFromConvectiveFlux(const Vector &meanN
   cpMix /= nMix;
 
   double temp = 0.;
+  // NOTE(kevin): for axisymmetric case, normal[2] = 0.0. for-loop only includes up to d < dim = 2.
   for (int d = 0; d < dim; d++) temp += meanNormalFluxes[1 + d] * normal[d];
   double A = 1. - 2. * cpMix / UNIVERSALGASCONSTANT;
   double B = 2. * temp * (cpMix / UNIVERSALGASCONSTANT - 1.);
-  double C = -2. * meanNormalFluxes[0] * meanNormalFluxes[1 + dim];
-  for (int d = 0; d < dim; d++) C += meanNormalFluxes[1 + d] * meanNormalFluxes[1 + d];
+  double C = -2. * meanNormalFluxes[0] * meanNormalFluxes[1 + nvel_];
+  for (int d = 0; d < nvel_; d++) C += meanNormalFluxes[1 + d] * meanNormalFluxes[1 + d];
   if (twoTemperature_) C += 2.0 * meanNormalFluxes[0] * neFlux * (molarCP_(numSpecies - 2) - cpMix) * Te;
   C += 2.0 * meanNormalFluxes[0] * formEnergyFlux;
   //   double p = (-B+sqrt(B*B-4.*A*C))/(2.*A);
@@ -1462,17 +1475,23 @@ void PerfectMixture::computeConservedStateFromConvectiveFlux(const Vector &meanN
   Th /= nMix;
 
   Up[0] = meanNormalFluxes[0] * meanNormalFluxes[0] / (temp - p);
-  for (int d = 0; d < dim; d++) Up[1 + d] = (meanNormalFluxes[1 + d] - p * normal[d]) / meanNormalFluxes[0];
-  Up[1 + dim] = Th;
+  for (int d = 0; d < nvel_; d++) {
+    if (d < dim) {
+      Up[1 + d] = (meanNormalFluxes[1 + d] - p * normal[d]) / meanNormalFluxes[0];
+    } else { // For axisymmetric case.
+      Up[1 + d] = meanNormalFluxes[1 + d] / meanNormalFluxes[0];
+    }
+  }
+  Up[1 + nvel_] = Th;
 
   for (int sp = 0; sp < numActiveSpecies; sp++) {
-    Up[2 + dim + sp] = numberDensityFluxes(sp) * meanNormalFluxes[0] / (temp - p);
+    Up[2 + nvel_ + sp] = numberDensityFluxes(sp) * meanNormalFluxes[0] / (temp - p);
   }
 
   GetConservativesFromPrimitives(Up, conservedState);
 }
 
-// TODO(kevin): check if this works for axisymmetric case.
+// NOTE(kevin): for axisymmetric case, this handles only r- and z-direction.
 void PerfectMixture::computeElectronPressureGrad(const double n_e, const double T_e, const DenseMatrix &gradUp,
                                                  Vector &gradPe) {
   gradPe.SetSize(dim);
@@ -1482,10 +1501,10 @@ void PerfectMixture::computeElectronPressureGrad(const double n_e, const double 
   neGrad = 0.0;
   if (ambipolar) {
     for (int sp = 0; sp < numActiveSpecies; sp++) {
-      for (int d = 0; d < dim; d++) neGrad(d) += gradUp(dim + 2 + sp, d) * gasParams(sp, GasParams::SPECIES_CHARGES);
+      for (int d = 0; d < dim; d++) neGrad(d) += gradUp(nvel_ + 2 + sp, d) * gasParams(sp, GasParams::SPECIES_CHARGES);
     }
   } else {
-    for (int d = 0; d < dim; d++) neGrad(d) = gradUp(dim + numSpecies, d);  // dim + 2 + (numSpecies - 2)
+    for (int d = 0; d < dim; d++) neGrad(d) = gradUp(nvel_ + numSpecies, d);  // nvel_ + 2 + (numSpecies - 2)
   }
 
   for (int d = 0; d < dim; d++)

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -351,7 +351,7 @@ void DryAir::computeConservedStateFromConvectiveFlux(const Vector &meanNormalFlu
   for (int d = 0; d < nvel_; d++) {
     if (d < dim) {
       Up[1 + d] = (meanNormalFluxes[1 + d] - p * normal[d]) / meanNormalFluxes[0];
-    } else { // azimuthal direction for axisymmetric case.
+    } else {  // azimuthal direction for axisymmetric case.
       Up[1 + d] = meanNormalFluxes[1 + d] / meanNormalFluxes[0];
     }
   }
@@ -389,7 +389,8 @@ double EquationOfState::pressure( double *state,
 //////////////////////////////////////////////////////
 //////// Test Binary Air mixture
 //////////////////////////////////////////////////////
-TestBinaryAir::TestBinaryAir(RunConfiguration &_runfile, int _dim, int nvel) : GasMixture(WorkingFluid::TEST_BINARY_AIR, _dim, nvel) {
+TestBinaryAir::TestBinaryAir(RunConfiguration &_runfile, int _dim, int nvel)
+    : GasMixture(WorkingFluid::TEST_BINARY_AIR, _dim, nvel) {
   numSpecies = 2;
   ambipolar = false;
   twoTemperature_ = false;
@@ -614,7 +615,8 @@ void TestBinaryAir::ComputeMoleFractionGradient(const Vector &numberDensities, c
 ////// Perfect Mixture GasMixture                     ////////////////////
 //////////////////////////////////////////////////////////////////////////
 
-PerfectMixture::PerfectMixture(RunConfiguration &_runfile, int _dim, int nvel) : GasMixture(WorkingFluid::USER_DEFINED, _dim, nvel) {
+PerfectMixture::PerfectMixture(RunConfiguration &_runfile, int _dim, int nvel)
+    : GasMixture(WorkingFluid::USER_DEFINED, _dim, nvel) {
   numSpecies = _runfile.GetNumSpecies();
   backgroundInputIndex_ = _runfile.backgroundIndex;
   assert((backgroundInputIndex_ > 0) && (backgroundInputIndex_ <= numSpecies));
@@ -1394,10 +1396,8 @@ void PerfectMixture::modifyEnergyForPressure(const mfem::Vector &stateIn, mfem::
   //   Th += nB;
   //   Th = (p - pe) / (Th * UNIVERSALGASCONSTANT);
   // } else {
-  //   for (int sp = 0; sp < numActiveSpecies; sp++) Th += stateIn(2 + nvel_ + sp) / gasParams(sp, GasParams::SPECIES_MW);
-  //   if (ambipolar) Th += ne;
-  //   Th += nB;
-  //   Th = p / (Th * UNIVERSALGASCONSTANT);
+  //   for (int sp = 0; sp < numActiveSpecies; sp++) Th += stateIn(2 + nvel_ + sp) / gasParams(sp,
+  //   GasParams::SPECIES_MW); if (ambipolar) Th += ne; Th += nB; Th = p / (Th * UNIVERSALGASCONSTANT);
   // }
   //
   // // compute total energy with the modified temperature of heavies
@@ -1478,7 +1478,7 @@ void PerfectMixture::computeConservedStateFromConvectiveFlux(const Vector &meanN
   for (int d = 0; d < nvel_; d++) {
     if (d < dim) {
       Up[1 + d] = (meanNormalFluxes[1 + d] - p * normal[d]) / meanNormalFluxes[0];
-    } else { // For axisymmetric case.
+    } else {  // For axisymmetric case.
       Up[1 + d] = meanNormalFluxes[1 + d] / meanNormalFluxes[0];
     }
   }

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -63,7 +63,7 @@ class GasMixture {
   WorkingFluid fluid;
   int num_equation;
   int dim;
-  int nvel_; // number of velocity, which differs from dim for axisymmetric case.
+  int nvel_;  // number of velocity, which differs from dim for axisymmetric case.
 
   int numSpecies;
   int numActiveSpecies;

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -63,6 +63,7 @@ class GasMixture {
   WorkingFluid fluid;
   int num_equation;
   int dim;
+  int nvel_; // number of velocity, which differs from dim for axisymmetric case.
 
   int numSpecies;
   int numActiveSpecies;
@@ -106,11 +107,11 @@ class GasMixture {
   void SetNumActiveSpecies() { numActiveSpecies = ambipolar ? (numSpecies - 2) : (numSpecies - 1); }
   // Add electron energy equation if two temperature.
   void SetNumEquations() {
-    num_equation = twoTemperature_ ? (dim + 3 + numActiveSpecies) : (dim + 2 + numActiveSpecies);
+    num_equation = twoTemperature_ ? (nvel_ + 3 + numActiveSpecies) : (nvel_ + 2 + numActiveSpecies);
   }
 
  public:
-  GasMixture(WorkingFluid _fluid, int _dim);
+  GasMixture(WorkingFluid _fluid, int _dim, int nvel);
   GasMixture() {}
 
   ~GasMixture() {}
@@ -159,8 +160,7 @@ class GasMixture {
   virtual bool StateIsPhysical(const Vector &state) = 0;
 
   // Compute X, Y gradients from number density gradient.
-  // TODO(kevin): Fluxes class should take Up as input variable.
-  // Currently cannot receive Up inside Fluxes class.
+  // NOTE(kevin): for axisymmetric case, these handle only r- and z-direction.
   virtual void ComputeMassFractionGradient(const double rho, const Vector &numberDensities, const DenseMatrix &gradUp,
                                            DenseMatrix &massFractionGrad) = 0;
   virtual void ComputeMoleFractionGradient(const Vector &numberDensities, const DenseMatrix &gradUp,
@@ -211,7 +211,7 @@ class GasMixture {
 
   virtual double computeElectronEnergy(const double n_e, const double T_e) = 0;
   virtual double computeElectronPressure(const double n_e, const double T_e) = 0;
-  // TODO(kevin): check if this works for axisymmetric case.
+  // NOTE(kevin): for axisymmetric case, this handles only r- and z-direction.
   virtual void computeElectronPressureGrad(const double n_e, const double T_e, const DenseMatrix &gradUp,
                                            Vector &gradPe) = 0;
 };
@@ -228,9 +228,9 @@ class DryAir : public GasMixture {
   virtual void setNumEquations();
 
  public:
-  DryAir(RunConfiguration &_runfile, int _dim);
+  DryAir(RunConfiguration &_runfile, int _dim, int nvel);
   DryAir();  // this will only be usefull to get air constants
-  DryAir(int dim, int num_equation);
+  // DryAir(int dim, int num_equation);
 
   ~DryAir() {}
 
@@ -427,7 +427,7 @@ class TestBinaryAir : public GasMixture {
 
   // virtual void SetNumEquations();
  public:
-  TestBinaryAir(RunConfiguration &_runfile, int _dim);
+  TestBinaryAir(RunConfiguration &_runfile, int _dim, int nvel);
   // TestBinaryAir(); //this will only be usefull to get air constants
 
   ~TestBinaryAir() {}
@@ -510,7 +510,7 @@ class PerfectMixture : public GasMixture {
 
   // virtual void SetNumEquations();
  public:
-  PerfectMixture(RunConfiguration &_runfile, int _dim);
+  PerfectMixture(RunConfiguration &_runfile, int _dim, int nvel);
   // TestBinaryAir(); //this will only be usefull to get air constants
 
   ~PerfectMixture() {}

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -117,7 +117,7 @@ void Fluxes::ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp
   // const double k = mixture->GetThermalConductivity(state);
 
   // TODO(kevin): update E-field with EM coupling.
-  Vector Efield(dim);
+  Vector Efield(nvel);
   Efield = 0.0;
 
   const int numSpecies = mixture->GetNumSpecies();
@@ -128,7 +128,8 @@ void Fluxes::ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp
   mixture->computeSpeciesEnthalpies(state, speciesEnthalpies);
 
   Vector transportBuffer;
-  DenseMatrix diffusionVelocity(numSpecies, dim);
+  // NOTE(kevin): in flux, only dim-components of diffusionVelocity will be used.
+  DenseMatrix diffusionVelocity(numSpecies, nvel);
   transport->ComputeFluxTransportProperties(state, gradUp, Efield, transportBuffer, diffusionVelocity);
   const double visc = transportBuffer[FluxTrns::VISCOSITY];
   double bulkViscosity = transportBuffer[FluxTrns::BULK_VISCOSITY];
@@ -209,7 +210,8 @@ void Fluxes::ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp
   // }
   // NOTE: NS_PASSIVE will not be needed (automatically incorporated).
   for (int sp = 0; sp < numActiveSpecies; sp++) {
-    // NOTE: diffusionVelocity is set to be (numSpecies,dim)-matrix.
+    // NOTE: diffusionVelocity is set to be (numSpecies,nvel)-matrix.
+    // however only dim-components are used for flux.
     for (int d = 0; d < dim; d++) flux(nvel + 2 + sp, d) = -state[nvel + 2 + sp] * diffusionVelocity(sp, d);
   }
 }

--- a/src/forcing_terms.hpp
+++ b/src/forcing_terms.hpp
@@ -32,6 +32,7 @@
 #ifndef FORCING_TERMS_HPP_
 #define FORCING_TERMS_HPP_
 
+#include <grvy.h>
 #include <tps_config.h>
 
 #include <mfem.hpp>
@@ -89,14 +90,14 @@ class ConstantPressureGradient : public ForcingTerms {
  private:
   // RunConfiguration &config;
   Vector pressGrad;
-  GasMixture *mixture;
+  GasMixture *mixture_;
 
  public:
   ConstantPressureGradient(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                            IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U,
                            ParGridFunction *_Up, ParGridFunction *_gradUp, const volumeFaceIntegrationArrays &gpuArrays,
-                           RunConfiguration &_config);
-  ~ConstantPressureGradient();
+                           RunConfiguration &_config, GasMixture *mixture);
+  ~ConstantPressureGradient() {}
 
   // Terms do not need updating
   virtual void updateTerms(Vector &in);

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -585,6 +585,7 @@ void InletBC::subsonicNonReflectingDensityVelocity(Vector &normal, Vector &state
   Vector normGrad(num_equation);
   normGrad = 0.;
   for (int eq = 0; eq < num_equation; eq++) {
+    // NOTE(kevin): for axisymmetric case, azimuthal normal component will be always zero.
     for (int d = 0; d < dim; d++) normGrad[eq] += unitNorm[d] * gradState(eq, d);
   }
   // gradient of pressure in normal direction

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -88,7 +88,7 @@ InletBC::InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rs
     hmeanUp[num_equation - 1] = 0.;
   } else if (numActiveSpecies_ > 0) {
     for (int sp = 0; sp < numActiveSpecies_; sp++) {
-      hmeanUp[dim + 2 + sp] = 0.0;
+      hmeanUp[nvel + 2 + sp] = 0.0;
     }
   }
 
@@ -637,7 +637,7 @@ void InletBC::subsonicNonReflectingDensityVelocity(Vector &normal, Vector &state
   if (nvel == 3) bdrFlux[3] = meanVel[2] * d1 + meanUp[0] * d4;
   bdrFlux[1 + nvel] = meanUp[0] * meanVel[0] * d2;
   bdrFlux[1 + nvel] += meanUp[0] * meanVel[1] * d3;
-  if (nvel == 3) bdrFlux[1 + dim] += meanUp[0] * meanVel[2] * d4;
+  if (nvel == 3) bdrFlux[1 + nvel] += meanUp[0] * meanVel[2] * d4;
   bdrFlux[1 + nvel] += meanK * d1 + d5 / (gamma - 1.);
 
   // flux gradients in other directions

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -298,7 +298,6 @@ void OutletBC::initBCs() {
 }
 
 void OutletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector &bdrFlux) {
-
   switch (outletType) {
     case SUB_P:
       subsonicReflectingPressure(normal, stateIn, bdrFlux);

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -298,22 +298,6 @@ void OutletBC::initBCs() {
 }
 
 void OutletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector &bdrFlux) {
-// {
-//   std::cout << "stateIn." << std::endl;
-//   for (int eq = 0; eq < num_equation; eq++) {
-//     std::cout << stateIn(eq) << ",\t";
-//   }
-//   std::cout << std::endl;
-//
-//   std::cout << "gradState." << std::endl;
-//   for (int eq = 0; eq < num_equation; eq++) {
-//     for (int d = 0; d < dim; d++) {
-//       std::cout << gradState(eq, d) << ",\t";
-//     }
-//     std::cout << std::endl;
-//   }
-//   exit(-1);
-// }
   switch (outletType) {
     case SUB_P:
       subsonicReflectingPressure(normal, stateIn, bdrFlux);

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -607,6 +607,7 @@ void OutletBC::subsonicNonReflectingPressure(Vector &normal, Vector &stateIn, De
   Vector normGrad(num_equation);
   normGrad = 0.;
   for (int eq = 0; eq < num_equation; eq++) {
+    // NOTE(kevin): for axisymmetric case, azimuthal normal component will be always zero.
     for (int d = 0; d < dim; d++) normGrad[eq] += unitNorm[d] * gradState(eq, d);
   }
   // gradient of pressure in normal direction
@@ -770,6 +771,7 @@ void OutletBC::subsonicNonRefMassFlow(Vector &normal, Vector &stateIn, DenseMatr
   Vector normGrad(num_equation);
   normGrad = 0.;
   for (int eq = 0; eq < num_equation; eq++) {
+    // NOTE(kevin): for axisymmetric case, azimuthal normal component will be always zero.
     for (int d = 0; d < dim; d++) normGrad[eq] += unitNorm[d] * gradState(eq, d);
   }
   // gradient of pressure in normal direction
@@ -924,6 +926,7 @@ void OutletBC::subsonicNonRefPWMassFlow(Vector &normal, Vector &stateIn, DenseMa
   Vector normGrad(num_equation);
   normGrad = 0.;
   for (int eq = 0; eq < num_equation; eq++) {
+    // NOTE(kevin): for axisymmetric case, azimuthal normal component will be always zero.
     for (int d = 0; d < dim; d++) normGrad[eq] += unitNorm[d] * gradState(eq, d);
   }
   // gradient of pressure in normal direction

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -97,7 +97,7 @@ RHSoperator::RHSoperator(int &_iter, const int _dim, const int &_num_equation, c
 
   if (_config.thereIsForcing()) {
     forcing.Append(new ConstantPressureGradient(dim, num_equation, _order, intRuleType, intRules, vfes, U_, Up, gradUp,
-                                                gpuArrays, _config));
+                                                gpuArrays, _config, mixture));
   }
   if (_config.GetPassiveScalarData().Size() > 0)
     forcing.Append(new PassiveScalar(dim, num_equation, _order, intRuleType, intRules, vfes, mixture, U_, Up, gradUp,

--- a/src/source_term.cpp
+++ b/src/source_term.cpp
@@ -127,6 +127,8 @@ void SourceTerm::updateTerms(mfem::Vector &in) {
       }
     }
 
+    // TODO(kevin): may move axisymmetric source terms to here.
+
     // TODO(kevin): energy sink for radiative reaction.
 
     if (twoTemperature_) {

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -35,6 +35,7 @@
 TransportProperties::TransportProperties(GasMixture *_mixture) : mixture(_mixture) {
   numSpecies = mixture->GetNumSpecies();
   dim = mixture->GetDimension();
+  nvel_ = mixture->GetNumVels();
   numActiveSpecies = mixture->GetNumActiveSpecies();
   ambipolar = mixture->IsAmbipolar();
   twoTemperature_ = mixture->IsTwoTemperature();

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -95,7 +95,7 @@ class TransportProperties {
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp) = 0;
   // NOTE: only for AxisymmetricSource
-  virtual double GetViscosityFromPrimitive(const Vector &state) = 0;
+  virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc) = 0;
 
   // For mixture-averaged diffusion, correct for mass conservation.
   void correctMassDiffusionFlux(const Vector &Y_sp, DenseMatrix &diffusionVelocity);
@@ -140,12 +140,14 @@ class DryAirTransport : public TransportProperties {
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp) {}
 
-  virtual double GetViscosityFromPrimitive(const Vector &state);
+  virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);
 };
 
-inline double DryAirTransport::GetViscosityFromPrimitive(const Vector &state) {
-  double temp = state[1 + nvel_];
-  return (1.458e-6 * visc_mult * pow(temp, 1.5) / (temp + 110.4));
+inline void DryAirTransport::GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc) {
+  double temp = primitive[1 + nvel_];
+  visc = (1.458e-6 * visc_mult * pow(temp, 1.5) / (temp + 110.4));
+  bulkVisc = bulk_visc_mult * visc;
+  return;
 }
 
 //////////////////////////////////////////////////////
@@ -198,7 +200,15 @@ class ConstantTransport : public TransportProperties {
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp);
 
-  virtual double GetViscosityFromPrimitive(const Vector &state) {}
+  virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);
 };
+
+
+inline void ConstantTransport::GetViscosities(const Vector &conserved, const Vector &primitive,
+                                              double &visc, double &bulkVisc) {
+  visc = viscosity_;
+  bulkVisc = bulkViscosity_;
+  return;
+}
 
 #endif  // TRANSPORT_PROPERTIES_HPP_

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -53,6 +53,7 @@ class TransportProperties {
  protected:
   int num_equation;
   int dim;
+  int nvel_;
   int numSpecies;
   int numActiveSpecies;
   bool ambipolar;
@@ -143,7 +144,7 @@ class DryAirTransport : public TransportProperties {
 };
 
 inline double DryAirTransport::GetViscosityFromPrimitive(const Vector &state) {
-  double temp = state[1 + dim];
+  double temp = state[1 + nvel_];
   return (1.458e-6 * visc_mult * pow(temp, 1.5) / (temp + 110.4));
 }
 

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -143,7 +143,8 @@ class DryAirTransport : public TransportProperties {
   virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);
 };
 
-inline void DryAirTransport::GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc) {
+inline void DryAirTransport::GetViscosities(const Vector &conserved, const Vector &primitive, double &visc,
+                                            double &bulkVisc) {
   double temp = primitive[1 + nvel_];
   visc = (1.458e-6 * visc_mult * pow(temp, 1.5) / (temp + 110.4));
   bulkVisc = bulk_visc_mult * visc;
@@ -203,9 +204,8 @@ class ConstantTransport : public TransportProperties {
   virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);
 };
 
-
-inline void ConstantTransport::GetViscosities(const Vector &conserved, const Vector &primitive,
-                                              double &visc, double &bulkVisc) {
+inline void ConstantTransport::GetViscosities(const Vector &conserved, const Vector &primitive, double &visc,
+                                              double &bulkVisc) {
   visc = viscosity_;
   bulkVisc = bulkViscosity_;
   return;

--- a/test/inputs/mms.ternary_plasma.2d.ini
+++ b/test/inputs/mms.ternary_plasma.2d.ini
@@ -4,7 +4,7 @@
 type = flow    # options are [flow, em, coupled (TODO)]
 
 [flow]
-mesh = beam-quad-o3-s1-r2-p.mesh
+mesh = beam-quad-o3-s1-r1-p.mesh
 order = 2
 integrationRule = 1
 basisType = 1

--- a/test/inputs/mms.ternary_plasma.2d.wall.ini
+++ b/test/inputs/mms.ternary_plasma.2d.wall.ini
@@ -4,7 +4,7 @@
 type = flow    # options are [flow, em, coupled (TODO)]
 
 [flow]
-mesh = beam-quad-o3-s1-r2-xp.mesh
+mesh = beam-quad-o3-s1-r1-xp.mesh
 order = 2
 integrationRule = 1
 basisType = 1

--- a/test/mms.ternary_2d.test
+++ b/test/mms.ternary_2d.test
@@ -6,7 +6,7 @@ RUNFILE="inputs/mms.ternary_plasma.2d.ini"
 
 setup() {
     SOLN_FILE=restart_argon_output.sol.h5
-    MESH_FILE=beam-quad-o3-s1-r2-p.mesh
+    MESH_FILE=beam-quad-o3-s1-r1-p.mesh
     TOL=2e-4
 }
 
@@ -15,7 +15,7 @@ setup() {
 }
 
 @test "[$TEST] create a mesh file" {
-    ../utils/beam_mesh -nx 1 -nt 5 -b 5 -rs 2
+    ../utils/beam_mesh -nx 1 -nt 5 -b 5 -rs 1
 
     test -s $MESH_FILE
 }
@@ -27,35 +27,35 @@ setup() {
 @test "[$TEST] check if the relative error is similar to the reported value" {
     while IFS=$'\t' read -r nx e0 e1 e2 e3 e4 e5;
     do
-      test $nx -eq 400
-      # empirically observed error 3.8993e-4
-      check_lo=$(awk 'BEGIN{print ('$e0'>3.8e-4)?1:0}')
-      check_hi=$(awk 'BEGIN{print ('$e0'<3.94e-4)?1:0}')
+      test $nx -eq 100
+      # empirically observed error 2.297e-3
+      check_lo=$(awk 'BEGIN{print ('$e0'>2.25e-3)?1:0}')
+      check_hi=$(awk 'BEGIN{print ('$e0'<2.35e-3)?1:0}')
       test $check_lo -eq 1
       test $check_hi -eq 1
-      # empirically observed error 0.1479
-      check_lo=$(awk 'BEGIN{print ('$e1'>0.147)?1:0}')
-      check_hi=$(awk 'BEGIN{print ('$e1'<0.148)?1:0}')
+      # empirically observed error 0.6949
+      check_lo=$(awk 'BEGIN{print ('$e1'>0.69)?1:0}')
+      check_hi=$(awk 'BEGIN{print ('$e1'<0.70)?1:0}')
       test $check_lo -eq 1
       test $check_hi -eq 1
-      # empirically observed error 0.2293
-      check_lo=$(awk 'BEGIN{print ('$e2'>0.22)?1:0}')
-      check_hi=$(awk 'BEGIN{print ('$e2'<0.23)?1:0}')
+      # empirically observed error 0.8811
+      check_lo=$(awk 'BEGIN{print ('$e2'>0.875)?1:0}')
+      check_hi=$(awk 'BEGIN{print ('$e2'<0.885)?1:0}')
       test $check_lo -eq 1
       test $check_hi -eq 1
-      # empirically observed error 4.6527e-4
-      check_lo=$(awk 'BEGIN{print ('$e3'>4.6e-4)?1:0}')
-      check_hi=$(awk 'BEGIN{print ('$e3'<4.7e-4)?1:0}')
+      # empirically observed error 2.097e-3
+      check_lo=$(awk 'BEGIN{print ('$e3'>2.05e-3)?1:0}')
+      check_hi=$(awk 'BEGIN{print ('$e3'<2.15e-3)?1:0}')
       test $check_lo -eq 1
       test $check_hi -eq 1
-      # empirically observed error 4.2047e-4
-      check_lo=$(awk 'BEGIN{print ('$e4'>4.1e-4)?1:0}')
-      check_hi=$(awk 'BEGIN{print ('$e4'<4.3e-4)?1:0}')
+      # empirically observed error 3.014e-3
+      check_lo=$(awk 'BEGIN{print ('$e4'>2.95e-3)?1:0}')
+      check_hi=$(awk 'BEGIN{print ('$e4'<3.05e-3)?1:0}')
       test $check_lo -eq 1
       test $check_hi -eq 1
-      # empirically observed error 6.3578e-4
-      check_lo=$(awk 'BEGIN{print ('$e5'>6.3e-4)?1:0}')
-      check_hi=$(awk 'BEGIN{print ('$e5'<6.4e-4)?1:0}')
+      # empirically observed error 5.1071e-3
+      check_lo=$(awk 'BEGIN{print ('$e5'>5.05e-3)?1:0}')
+      check_hi=$(awk 'BEGIN{print ('$e5'<5.15e-3)?1:0}')
       test $check_lo -eq 1
       test $check_hi -eq 1
     done < ternary_2d_2t_periodic_ambipolar.rel_error.txt

--- a/test/mms.ternary_2d_wall.test
+++ b/test/mms.ternary_2d_wall.test
@@ -6,7 +6,7 @@ RUNFILE="inputs/mms.ternary_plasma.2d.wall.ini"
 
 setup() {
     SOLN_FILE=restart_argon_output.sol.h5
-    MESH_FILE=beam-quad-o3-s1-r2-xp.mesh
+    MESH_FILE=beam-quad-o3-s1-r1-xp.mesh
 }
 
 @test "[$TEST] check for input file $RUNFILE" {
@@ -14,7 +14,7 @@ setup() {
 }
 
 @test "[$TEST] create a mesh file" {
-    ../utils/beam_mesh -nx 1 -nt 5 -b 5 -rs 2 -dir 0
+    ../utils/beam_mesh -nx 1 -nt 5 -b 5 -rs 1 -dir 0
 
     test -s $MESH_FILE
 }
@@ -26,35 +26,35 @@ setup() {
 @test "[$TEST] check if the relative error is similar to the reported value" {
     while IFS=$'\t' read -r nx e0 e1 e2 e3 e4 e5;
     do
-      test $nx -eq 400
-      # empirically observed error 3.9019e-4
-      check_lo=$(awk 'BEGIN{print ('$e0'>3.90e-4)?1:0}')
-      check_hi=$(awk 'BEGIN{print ('$e0'<3.91e-4)?1:0}')
+      test $nx -eq 100
+      # empirically observed error 1.922e-3
+      check_lo=$(awk 'BEGIN{print ('$e0'>1.92e-3)?1:0}')
+      check_hi=$(awk 'BEGIN{print ('$e0'<1.93e-3)?1:0}')
       test $check_lo -eq 1
       test $check_hi -eq 1
-      # empirically observed error 0.1620
-      check_lo=$(awk 'BEGIN{print ('$e1'>0.16)?1:0}')
-      check_hi=$(awk 'BEGIN{print ('$e1'<0.17)?1:0}')
+      # empirically observed error 0.7603
+      check_lo=$(awk 'BEGIN{print ('$e1'>0.755)?1:0}')
+      check_hi=$(awk 'BEGIN{print ('$e1'<0.765)?1:0}')
       test $check_lo -eq 1
       test $check_hi -eq 1
-      # empirically observed error 0.2274
-      check_lo=$(awk 'BEGIN{print ('$e2'>0.22)?1:0}')
-      check_hi=$(awk 'BEGIN{print ('$e2'<0.23)?1:0}')
+      # empirically observed error 0.9183
+      check_lo=$(awk 'BEGIN{print ('$e2'>0.91)?1:0}')
+      check_hi=$(awk 'BEGIN{print ('$e2'<0.92)?1:0}')
       test $check_lo -eq 1
       test $check_hi -eq 1
-      # empirically observed error 4.7081e-4
-      check_lo=$(awk 'BEGIN{print ('$e3'>4.70e-4)?1:0}')
-      check_hi=$(awk 'BEGIN{print ('$e3'<4.71e-4)?1:0}')
+      # empirically observed error 3.065e-3
+      check_lo=$(awk 'BEGIN{print ('$e3'>3.06e-3)?1:0}')
+      check_hi=$(awk 'BEGIN{print ('$e3'<3.07e-3)?1:0}')
       test $check_lo -eq 1
       test $check_hi -eq 1
-      # empirically observed error 4.7059e-4
-      check_lo=$(awk 'BEGIN{print ('$e4'>4.70e-4)?1:0}')
-      check_hi=$(awk 'BEGIN{print ('$e4'<4.71e-4)?1:0}')
+      # empirically observed error 3.0837e-3
+      check_lo=$(awk 'BEGIN{print ('$e4'>3.08e-3)?1:0}')
+      check_hi=$(awk 'BEGIN{print ('$e4'<3.09e-3)?1:0}')
       test $check_lo -eq 1
       test $check_hi -eq 1
-      # empirically observed error 7.8473e-4
-      check_lo=$(awk 'BEGIN{print ('$e5'>7.84e-4)?1:0}')
-      check_hi=$(awk 'BEGIN{print ('$e5'<7.85e-4)?1:0}')
+      # empirically observed error 5.0761e-3
+      check_lo=$(awk 'BEGIN{print ('$e5'>5.07e-3)?1:0}')
+      check_hi=$(awk 'BEGIN{print ('$e5'<5.08e-3)?1:0}')
       test $check_lo -eq 1
       test $check_hi -eq 1
     done < ternary_2d_2t_ambipolar_wall.rel_error.txt

--- a/test/test_argon_minimal.cpp
+++ b/test/test_argon_minimal.cpp
@@ -65,7 +65,7 @@ int main (int argc, char *argv[])
 
   double pressure = 101325.0;
 
-  PerfectMixture *mixture = new PerfectMixture( srcConfig, dim);
+  PerfectMixture *mixture = new PerfectMixture(srcConfig, dim, dim);
   ArgonMinimalTransport *transport = new ArgonMinimalTransport(mixture, srcConfig);
   int numSpecies = mixture->GetNumSpecies();
   int numActiveSpecies = mixture->GetNumActiveSpecies();

--- a/test/test_perfect_mixture.cpp
+++ b/test/test_perfect_mixture.cpp
@@ -89,6 +89,7 @@ int main (int argc, char *argv[])
   RunConfiguration& srcConfig = srcField->GetConfig();
   assert(srcConfig.GetWorkingFluid()==WorkingFluid::USER_DEFINED);
   assert(srcConfig.GetGasModel()==PERFECT_MIXTURE);
+  assert(!srcConfig.axisymmetric_);
 
   int dim = 3;
 
@@ -103,7 +104,7 @@ int main (int argc, char *argv[])
   {
     srcConfig.ambipolar = false;
     srcConfig.twoTemperature = false;
-    PerfectMixture *mixture = new PerfectMixture( srcConfig, dim);
+    PerfectMixture *mixture = new PerfectMixture(srcConfig, dim, dim);
 
     grvy_printf(GRVY_INFO, "\n Setting a random primitive variable. \n");
 
@@ -514,7 +515,7 @@ int main (int argc, char *argv[])
   {
     srcConfig.ambipolar = true;
     srcConfig.twoTemperature = false;
-    PerfectMixture *mixture = new PerfectMixture( srcConfig, dim);
+    PerfectMixture *mixture = new PerfectMixture(srcConfig, dim, dim);
 
     grvy_printf(GRVY_INFO, "\n Setting a random primitive variable. \n");
 
@@ -870,7 +871,7 @@ int main (int argc, char *argv[])
   {
     srcConfig.ambipolar = false;
     srcConfig.twoTemperature = true;
-    PerfectMixture *mixture = new PerfectMixture( srcConfig, dim );
+    PerfectMixture *mixture = new PerfectMixture(srcConfig, dim, dim);
 
     grvy_printf(GRVY_INFO, "\n Setting a random primitive variable. \n");
 
@@ -1228,7 +1229,7 @@ int main (int argc, char *argv[])
   {
     srcConfig.ambipolar = true;
     srcConfig.twoTemperature = true;
-    PerfectMixture *mixture = new PerfectMixture( srcConfig, dim );
+    PerfectMixture *mixture = new PerfectMixture(srcConfig, dim, dim);
 
     grvy_printf(GRVY_INFO, "\n Setting a random primitive variable. \n");
 

--- a/test/test_speed_of_sound.cpp
+++ b/test/test_speed_of_sound.cpp
@@ -23,6 +23,7 @@ int main (int argc, char *argv[])
   RunConfiguration& srcConfig = srcField->GetConfig();
   assert(srcConfig.GetWorkingFluid()==WorkingFluid::USER_DEFINED);
   assert(srcConfig.GetGasModel()==PERFECT_MIXTURE);
+  assert(!srcConfig.axisymmetric_);
 
   int dim = 3;
 
@@ -32,7 +33,7 @@ int main (int argc, char *argv[])
   {
     srcConfig.ambipolar = false;
     srcConfig.twoTemperature = false;
-    PerfectMixture *mixture = new PerfectMixture( srcConfig, dim);
+    PerfectMixture *mixture = new PerfectMixture(srcConfig, dim, dim);
 
     double airMW = 28.964e-3;
 


### PR DESCRIPTION
Minor changes to support axisymmetric case.

- `GasMixture` and `TransportProperty` have `dim` and `nvel_` separately and use them for appropriate indexing.
- `AxisymmetricSource` is now gas-agnostic.