### PR TITLE
Refactor gpu interior face integration

### DIFF
--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -221,109 +221,257 @@ void DGNonLinearForm::faceIntegration_gpu(Vector &y, Vector &uk_el1, Vector &uk_
   const double Sc = mixture->GetSchmidtNum();
   const Equations eqSystem = flux->GetEquationSystem();
 
-  MFEM_FORALL_2D(el, NumElemType, elDof, 1, 1, {
-    MFEM_FOREACH_THREAD(i, x, elDof) {
-      MFEM_SHARED double Fcontrib[216 * 20];
-      MFEM_SHARED double shape[216];
+// clang-format off
+  MFEM_FORALL(el, NumElemType, {
+    double U1[216 * 5], U2[216 * 5];
+    double GradUp1[216 * 3 * 5], GradUp2[216 * 3 * 5];
+    double shape1[216], shape2[216];
+    double u1[5], gradUp1[5 * 3];
+    double u2[5], gradUp2[5 * 3];
+    double vFlux1[5 * 3], vFlux2[5 * 3];
+    double Rflux[5], nor[3], Fcontrib[216 * 5];
+    int indexes_i[215], indexes_j[216];
 
-      MFEM_SHARED double Rflux[20], u1[20], u2[20], nor[3];
-      MFEM_SHARED double vFlux1[20 * 3], vFlux2[20 * 3];
-      MFEM_SHARED double gradUp1[20 * 3], gradUp2[20 * 3];
+    const int eli = elemOffset + el;
+    const int offsetEl1 = d_posDofIds[2 * eli];
+    // const int indexi = d_nodesIDs[offsetEl1];
+    const int elFaces = d_elemFaces[7 * eli];
 
-      const int eli = elemOffset + el;
-      const int offsetEl1 = d_posDofIds[2 * eli];
-      const int indexi = d_nodesIDs[offsetEl1 + i];
-      const int elFaces = d_elemFaces[7 * eli];
-
-      for (int eq = 0; eq < num_equation; eq++) Fcontrib[i + eq * elDof] = 0.;
-      MFEM_SYNC_THREAD;
-
-      // loop over faces
-      for (int face = 0; face < elFaces; face++) {
-    const int gFace = d_elemFaces[7 * eli + face + 1];
-    const int Q = d_elems12Q[3 * gFace + 2];
-    const int offsetShape1 = gFace * maxIntPoints * (maxDofs + 1 + dim);
-    const int offsetShape2 = gFace * maxIntPoints * maxDofs;
-    bool swapElems = false;
-
-    // get neighbor
-    int elj = d_elems12Q[3 * gFace];
-    if (elj == eli) {
-      elj = d_elems12Q[3 * gFace + 1];
-    } else {
-      swapElems = true;
+    // elem1 data
+    for (int i = 0; i < elDof; i++) {
+      int index = d_nodesIDs[offsetEl1 + i];
+      indexes_i[i] = index;
+      for (int eq = 0; eq < num_equation; eq++) {
+        Fcontrib[i + eq * elDof] = 0.;
+        // U1[i + eq * elDof] = d_x[index + eq * Ndofs];
+        // for (int d = 0; d < dim; d++)
+        //   GradUp1[i + eq * elDof + d * num_equation * elDof] = d_gradUp[index + eq * Ndofs + d * num_equation * Ndofs];
+      }
     }
 
-    int dofj = d_posDofIds[2 * elj + 1];
+    for (int face = 0; face < elFaces; face++) {
+      const int gFace = d_elemFaces[7 * eli + face + 1];
+      const int Q = d_elems12Q[3 * gFace + 2];
+      const int offsetShape1 = gFace * maxIntPoints * (maxDofs + 1 + dim);
+      const int offsetShape2 = gFace * maxIntPoints * maxDofs;
+      bool swapElems = false;
 
-    int dof1 = elDof;
-    int dof2 = dofj;
-    if (swapElems) {
-      dof1 = dofj;
-      dof2 = elDof;
-    }
-
-    // loop over integration points
-    for (int k = 0; k < Q; k++) {
-      const double weight = d_shapeWnor1[offsetShape1 + maxDofs + k * (maxDofs + 1 + dim)];
-      for (int eq = i; eq < dim; eq += elDof)
-        nor[eq] = d_shapeWnor1[offsetShape1 + maxDofs + 1 + eq + k * (maxDofs + 1 + dim)];
-
-      if (swapElems) {
-        for (int j = i; j < dof2; j += elDof) shape[j] = d_shape2[offsetShape2 + j + k * maxDofs];
+      // get neighbor
+      int elj = d_elems12Q[3 * gFace];
+      if (elj == eli) {
+        elj = d_elems12Q[3 * gFace + 1];
       } else {
-        for (int j = i; j < dof1; j += elDof) shape[j] = d_shapeWnor1[offsetShape1 + j + k * (maxDofs + 1 + dim)];
+        swapElems = true;
       }
 
-      for (int eq = i; eq < num_equation; eq += elDof) {
-        u1[eq] = d_uk_el1[eq + k * num_equation + gFace * maxIntPoints * num_equation];
-        u2[eq] = d_uk_el2[eq + k * num_equation + gFace * maxIntPoints * num_equation];
-        for (int d = 0; d < dim; d++) {
-          gradUp1[eq + d * num_equation] = d_grad_uk_el1[eq + k * num_equation + d * maxIntPoints * num_equation +
-                                                         gFace * dim * maxIntPoints * num_equation];
-          gradUp2[eq + d * num_equation] = d_grad_uk_el2[eq + k * num_equation + d * maxIntPoints * num_equation +
-                                                         gFace * dim * maxIntPoints * num_equation];
+      const int offsetElj = d_posDofIds[2 * elj];
+      int dofj = d_posDofIds[2 * elj + 1];
+
+      int dof1 = elDof;
+      int dof2 = dofj;
+      if (swapElems) {
+        dof1 = dofj;
+        dof2 = elDof;
+      }
+
+      // // elem2 data
+      // for (int j = 0; j < dofj; j++) {
+      //   indexes_j[j] = d_nodesIDs[offsetElj + j];
+      //   int index = indexes_j[j];
+      //   for (int eq = 0; eq < num_equation; eq++) {
+      //     U2[j + eq * dofj] = d_x[index + eq * Ndofs];
+      //     for (int d = 0; d < dim; d++)
+      //       GradUp2[j + eq * dofj + d * num_equation * dofj] = d_gradUp[index + eq * Ndofs + d * num_equation * Ndofs];
+      //   }
+      // }
+
+      for (int k = 0; k < Q; k++) {
+        // get shapes and normal
+        const double weight = d_shapeWnor1[offsetShape1 + maxDofs + k * (maxDofs + 1 + dim)];
+        for (int eq = 0; eq < dim; eq++)
+          nor[eq] = d_shapeWnor1[offsetShape1 + maxDofs + 1 + eq + k * (maxDofs + 1 + dim)];
+        for (int j = 0; j < dof1; j++) shape1[j] = d_shapeWnor1[offsetShape1 + j + k * (maxDofs + 1 + dim)];
+        for (int j = 0; j < dof2; j++) shape2[j] = d_shape2[offsetShape2 + j + k * maxDofs];
+        for (int eq = 0; eq < num_equation; eq++) {
+          u1[eq] = 0.;
+          u2[eq] = 0.;
+          for (int d = 0; d < dim; d++) {
+            gradUp1[eq + d * num_equation] = 0.;
+            gradUp2[eq + d * num_equation] = 0.;
+          }
+        }
+
+        // interpolate to integration point k
+        for (int eq = 0; eq < num_equation; eq++) {
+          u1[eq] = d_uk_el1[eq + k * num_equation + gFace * maxIntPoints * num_equation];
+          u2[eq] = d_uk_el2[eq + k * num_equation + gFace * maxIntPoints * num_equation];
+          // if (swapElems) {
+          //   for (int j = 0; j < dof1; j++) u1[eq] += U2[j + eq * dof1] * shape1[j];
+          //   for (int j = 0; j < dof2; j++) u2[eq] += U1[j + eq * dof2] * shape2[j];
+          // } else {
+          //   for (int j = 0; j < dof1; j++) u1[eq] += U1[j + eq * dof1] * shape1[j];
+          //   for (int j = 0; j < dof2; j++) u2[eq] += U2[j + eq * dof2] * shape2[j];
+          // }
+          for (int d = 0; d < dim; d++) {
+            gradUp1[eq + d * num_equation] = d_grad_uk_el1[eq + k * num_equation + d * maxIntPoints * num_equation +
+                                                           gFace * dim * maxIntPoints * num_equation];
+            gradUp2[eq + d * num_equation] = d_grad_uk_el2[eq + k * num_equation + d * maxIntPoints * num_equation +
+                                                           gFace * dim * maxIntPoints * num_equation];
+          }
+
+        }
+
+        // // interpolate gradients
+        // for (int d = 0; d < dim; d++) {
+        //   for (int eq = 0; eq < num_equation; eq++) {
+        //     if (swapElems) {
+        //       for (int j = 0; j < dof1; j++)
+        //         gradUp1[eq + d * num_equation] += GradUp2[j + eq * dof1 + d * num_equation * dof1] * shape1[j];
+        //       for (int j = 0; j < dof2; j++)
+        //         gradUp2[eq + d * num_equation] += GradUp1[j + eq * dof2 + d * num_equation * dof2] * shape2[j];
+        //     } else {
+        //       for (int j = 0; j < dof1; j++)
+        //         gradUp1[eq + d * num_equation] += GradUp1[j + eq * dof1 + d * num_equation * dof1] * shape1[j];
+        //       for (int j = 0; j < dof2; j++)
+        //         gradUp2[eq + d * num_equation] += GradUp2[j + eq * dof2 + d * num_equation * dof2] * shape2[j];
+        //     }
+        //   }
+        // }
+
+        RiemannSolver::riemannLF_serial_gpu(&u1[0], &u2[0], &Rflux[0], &nor[0], gamma, Rg, dim, num_equation);
+        Fluxes::viscousFlux_serial_gpu(&vFlux1[0], &u1[0], &gradUp1[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,
+                                       num_equation);
+        Fluxes::viscousFlux_serial_gpu(&vFlux2[0], &u2[0], &gradUp2[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,
+                                       num_equation);
+        for (int eq = 0; eq < num_equation; eq++) {
+          for (int d = 0; d < dim; d++)
+            vFlux1[eq + d * num_equation] = 0.5 * (vFlux1[eq + d * num_equation] + vFlux2[eq + d * num_equation]);
+        }
+
+        for (int eq = 0; eq < num_equation; eq++) {
+          for (int d = 0; d < dim; d++) Rflux[eq] -= vFlux1[eq + d * num_equation] * nor[d];
+        }
+
+        for (int i = 0; i < elDof; i++) {
+          for (int eq = 0; eq < num_equation; eq++) {
+            if (swapElems)
+              Fcontrib[i + eq * elDof] += weight * shape2[i] * Rflux[eq];
+            else
+              Fcontrib[i + eq * elDof] -= weight * shape1[i] * Rflux[eq];
+          }
         }
       }
-      MFEM_SYNC_THREAD;
-
-      // compute Riemann flux
-      RiemannSolver::riemannLF_gpu(&u1[0], &u2[0], &Rflux[0], &nor[0], gamma, Rg, dim, eqSystem, num_equation, i,
-                                   elDof);
-      Fluxes::viscousFlux_gpu(&vFlux1[0], &u1[0], &gradUp1[0], eqSystem, gamma, Rg, viscMult, bulkViscMult, Pr, Sc, i,
-                              elDof, dim, num_equation);
-      Fluxes::viscousFlux_gpu(&vFlux2[0], &u2[0], &gradUp2[0], eqSystem, gamma, Rg, viscMult, bulkViscMult, Pr, Sc, i,
-                              elDof, dim, num_equation);
-      MFEM_SYNC_THREAD;
-      // if(i<num_equation)
-      for (int eq = i; eq < num_equation; eq += elDof) {
-        for (int d = 0; d < dim; d++)
-          vFlux1[eq + d * num_equation] = 0.5 * (vFlux1[eq + d * num_equation] + vFlux2[eq + d * num_equation]);
-      }
-      MFEM_SYNC_THREAD;
-      for (int eq = i; eq < num_equation; eq += elDof) {
-        for (int d = 0; d < dim; d++) Rflux[eq] -= vFlux1[eq + d * num_equation] * nor[d];
-      }
-      MFEM_SYNC_THREAD;
-
-      // add integration point contribution
-      for (int eq = 0; eq < num_equation; eq++) {
-        //             if( swapElems ) Fcontrib[i+eq*elDof] += weight*l2[i]*Rflux[eq];
-        //             else Fcontrib[i+eq*elDof] -= weight*l1[i]*Rflux[eq];
-        if (swapElems)
-          Fcontrib[i + eq * elDof] += weight * shape[i] * Rflux[eq];
-        else
-          Fcontrib[i + eq * elDof] -= weight * shape[i] * Rflux[eq];
-      }
     }
-      }
 
-      // write to global memory
-      for (int eq = 0; eq < num_equation; eq++) {
-    d_y[indexi + eq * Ndofs] += Fcontrib[i + eq * elDof];
-      }
-}
-});
+    for (int i = 0; i < elDof; i++) {
+      int index = indexes_i[i];
+      for (int eq = 0; eq < num_equation; eq++) d_y[index + eq * Ndofs] += Fcontrib[i + eq * elDof];
+    }
+  });
+
+//   MFEM_FORALL_2D(el, NumElemType, elDof, 1, 1, {
+//     MFEM_FOREACH_THREAD(i, x, elDof) {
+//       MFEM_SHARED double Fcontrib[216 * 20];
+//       MFEM_SHARED double shape[216];
+
+//       MFEM_SHARED double Rflux[20], u1[20], u2[20], nor[3];
+//       MFEM_SHARED double vFlux1[20 * 3], vFlux2[20 * 3];
+//       MFEM_SHARED double gradUp1[20 * 3], gradUp2[20 * 3];
+
+//       const int eli = elemOffset + el;
+//       const int offsetEl1 = d_posDofIds[2 * eli];
+//       const int indexi = d_nodesIDs[offsetEl1 + i];
+//       const int elFaces = d_elemFaces[7 * eli];
+
+//       for (int eq = 0; eq < num_equation; eq++) Fcontrib[i + eq * elDof] = 0.;
+//       MFEM_SYNC_THREAD;
+
+//       // loop over faces
+//       for (int face = 0; face < elFaces; face++) {
+//     const int gFace = d_elemFaces[7 * eli + face + 1];
+//     const int Q = d_elems12Q[3 * gFace + 2];
+//     const int offsetShape1 = gFace * maxIntPoints * (maxDofs + 1 + dim);
+//     const int offsetShape2 = gFace * maxIntPoints * maxDofs;
+//     bool swapElems = false;
+
+//     // get neighbor
+//     int elj = d_elems12Q[3 * gFace];
+//     if (elj == eli) {
+//       elj = d_elems12Q[3 * gFace + 1];
+//     } else {
+//       swapElems = true;
+//     }
+
+//     int dofj = d_posDofIds[2 * elj + 1];
+
+//     int dof1 = elDof;
+//     int dof2 = dofj;
+//     if (swapElems) {
+//       dof1 = dofj;
+//       dof2 = elDof;
+//     }
+
+//     // loop over integration points
+//     for (int k = 0; k < Q; k++) {
+//       const double weight = d_shapeWnor1[offsetShape1 + maxDofs + k * (maxDofs + 1 + dim)];
+//       for (int eq = i; eq < dim; eq += elDof)
+//         nor[eq] = d_shapeWnor1[offsetShape1 + maxDofs + 1 + eq + k * (maxDofs + 1 + dim)];
+
+//       if (swapElems) {
+//         for (int j = i; j < dof2; j += elDof) shape[j] = d_shape2[offsetShape2 + j + k * maxDofs];
+//       } else {
+//         for (int j = i; j < dof1; j += elDof) shape[j] = d_shapeWnor1[offsetShape1 + j + k * (maxDofs + 1 + dim)];
+//       }
+
+//       for (int eq = i; eq < num_equation; eq += elDof) {
+//         u1[eq] = d_uk_el1[eq + k * num_equation + gFace * maxIntPoints * num_equation];
+//         u2[eq] = d_uk_el2[eq + k * num_equation + gFace * maxIntPoints * num_equation];
+//         for (int d = 0; d < dim; d++) {
+//           gradUp1[eq + d * num_equation] = d_grad_uk_el1[eq + k * num_equation + d * maxIntPoints * num_equation +
+//                                                          gFace * dim * maxIntPoints * num_equation];
+//           gradUp2[eq + d * num_equation] = d_grad_uk_el2[eq + k * num_equation + d * maxIntPoints * num_equation +
+//                                                          gFace * dim * maxIntPoints * num_equation];
+//         }
+//       }
+//       MFEM_SYNC_THREAD;
+
+//       // compute Riemann flux
+//       RiemannSolver::riemannLF_gpu(&u1[0], &u2[0], &Rflux[0], &nor[0], gamma, Rg, dim, eqSystem, num_equation, i,
+//                                    elDof);
+//       Fluxes::viscousFlux_gpu(&vFlux1[0], &u1[0], &gradUp1[0], eqSystem, gamma, Rg, viscMult, bulkViscMult, Pr, Sc, i,
+//                               elDof, dim, num_equation);
+//       Fluxes::viscousFlux_gpu(&vFlux2[0], &u2[0], &gradUp2[0], eqSystem, gamma, Rg, viscMult, bulkViscMult, Pr, Sc, i,
+//                               elDof, dim, num_equation);
+//       MFEM_SYNC_THREAD;
+//       // if(i<num_equation)
+//       for (int eq = i; eq < num_equation; eq += elDof) {
+//         for (int d = 0; d < dim; d++)
+//           vFlux1[eq + d * num_equation] = 0.5 * (vFlux1[eq + d * num_equation] + vFlux2[eq + d * num_equation]);
+//       }
+//       MFEM_SYNC_THREAD;
+//       for (int eq = i; eq < num_equation; eq += elDof) {
+//         for (int d = 0; d < dim; d++) Rflux[eq] -= vFlux1[eq + d * num_equation] * nor[d];
+//       }
+//       MFEM_SYNC_THREAD;
+
+//       // add integration point contribution
+//       for (int eq = 0; eq < num_equation; eq++) {
+//         //             if( swapElems ) Fcontrib[i+eq*elDof] += weight*l2[i]*Rflux[eq];
+//         //             else Fcontrib[i+eq*elDof] -= weight*l1[i]*Rflux[eq];
+//         if (swapElems)
+//           Fcontrib[i + eq * elDof] += weight * shape[i] * Rflux[eq];
+//         else
+//           Fcontrib[i + eq * elDof] -= weight * shape[i] * Rflux[eq];
+//       }
+//     }
+//       }
+
+//       // write to global memory
+//       for (int eq = 0; eq < num_equation; eq++) {
+//     d_y[indexi + eq * Ndofs] += Fcontrib[i + eq * elDof];
+//       }
+// }
+// });
 }
 
 // clang-format off

--- a/src/dgNonlinearForm.hpp
+++ b/src/dgNonlinearForm.hpp
@@ -52,7 +52,7 @@ class DGNonLinearForm : public ParNonlinearForm {
   ParFiniteElementSpace *vfes;
   ParFiniteElementSpace *gradFes;
 
-  ParGridFunction *gradUp;
+  ParGridFunction *gradUp_;
 
   BCintegrator *bcIntegrator;
 
@@ -108,13 +108,8 @@ class DGNonLinearForm : public ParNonlinearForm {
                                         const parallelFacesIntegrationArrays *parallelData, const int &maxIntPoints,
                                         const int &maxDofs);
 
-  static void interpFaceData_gpu(const Vector &x, Vector &uk_el1, Vector &uk_el2, Vector &grad_uk_el1,
-                                 Vector &grad_uk_el2, const ParGridFunction *gradUp, const int &Ndofs, const int &Nf,
-                                 const int &NumElemsType, const int &elemOffset, const int &elDof, const int &dim,
-                                 const int &num_equation, const double &gamma, const double &Rg, const double &viscMult,
-                                 const double &bulkViscMult, const double &Pr,
-                                 const volumeFaceIntegrationArrays &gpuArrays, const int &maxIntPoints,
-                                 const int &maxDofs);
+  void interpFaceData_gpu(const Vector &x, int elType, int elemOffset, int elDof);
+
   static void sharedFaceInterpolation_gpu(const Vector &x, const Vector &faceU, const ParGridFunction *gradUp,
                                           const Vector &faceGradUp, Vector &shared_uk_el1, Vector &shared_uk_el2,
                                           Vector &shared_grad_upk_el1, Vector &shared_grad_upk_el2, const int &Ndofs,

--- a/src/dgNonlinearForm.hpp
+++ b/src/dgNonlinearForm.hpp
@@ -76,6 +76,7 @@ class DGNonLinearForm : public ParNonlinearForm {
 
   Vector uk_el1, grad_upk_el1;
   Vector uk_el2, grad_upk_el2;
+  Vector face_flux_;
 
   Vector shared_uk_el1, shared_grad_upk_el1;
   Vector shared_uk_el2, shared_grad_upk_el2;
@@ -91,7 +92,8 @@ class DGNonLinearForm : public ParNonlinearForm {
   void setParallelData(parallelFacesIntegrationArrays *_parallelData, dataTransferArrays *_transferU,
                        dataTransferArrays *_transferGradUp);
 
-  static void faceIntegration_gpu(Vector &y, Vector &uk_el1, Vector &uk_el2, Vector &grad_uk_el1, Vector &grad_uk_el2,
+  static void faceIntegration_gpu(Vector &y, Vector &face_flux,
+                                  Vector &uk_el1, Vector &uk_el2, Vector &grad_uk_el1, Vector &grad_uk_el2,
                                   const ParGridFunction *gradUp, Fluxes *flux, const int &Ndofs, const int &Nf,
                                   const int &NumElemsType, const int &elemOffset, const int &elDof, const int &dim,
                                   const int &num_equation, GasMixture *mixture,
@@ -120,6 +122,14 @@ class DGNonLinearForm : public ParNonlinearForm {
                                           const volumeFaceIntegrationArrays &gpuArrays,
                                           const parallelFacesIntegrationArrays *parallelData, const int &maxIntPoints,
                                           const int &maxDofs);
+  void evalFaceFlux_gpu(Vector &uk_el1, Vector &uk_el2, Vector &grad_uk_el1, Vector &grad_uk_el2,
+                        Fluxes *flux,
+                        const int &Ndofs, const int &Nf, const int &NumElemType,
+                        const int &elemOffset, const int &elDof, const int &dim,
+                        const int &num_equation, GasMixture *mixture,
+                        const volumeFaceIntegrationArrays &gpuArrays, const int &maxIntPoints,
+                        const int &maxDofs);
+
 
 #ifdef _GPU_
   void Mult_domain(const Vector &x, Vector &y);

--- a/src/dgNonlinearForm.hpp
+++ b/src/dgNonlinearForm.hpp
@@ -92,13 +92,7 @@ class DGNonLinearForm : public ParNonlinearForm {
   void setParallelData(parallelFacesIntegrationArrays *_parallelData, dataTransferArrays *_transferU,
                        dataTransferArrays *_transferGradUp);
 
-  static void faceIntegration_gpu(Vector &y, Vector &face_flux,
-                                  Vector &uk_el1, Vector &uk_el2, Vector &grad_uk_el1, Vector &grad_uk_el2,
-                                  const ParGridFunction *gradUp, Fluxes *flux, const int &Ndofs, const int &Nf,
-                                  const int &NumElemsType, const int &elemOffset, const int &elDof, const int &dim,
-                                  const int &num_equation, GasMixture *mixture,
-                                  const volumeFaceIntegrationArrays &gpuArrays, const int &maxIntPoints,
-                                  const int &maxDofs);
+  void faceIntegration_gpu(Vector &y, int elType, int elemOffset, int elDof);
 
   static void sharedFaceIntegration_gpu(const Vector &x, const Vector &faceU, const ParGridFunction *gradUp,
                                         const Vector &faceGradUp, Vector &y, Vector &shared_uk_el1,
@@ -118,7 +112,6 @@ class DGNonLinearForm : public ParNonlinearForm {
                                           const parallelFacesIntegrationArrays *parallelData, const int &maxIntPoints,
                                           const int &maxDofs);
   void evalFaceFlux_gpu();
-
 
 #ifdef _GPU_
   void Mult_domain(const Vector &x, Vector &y);

--- a/src/dgNonlinearForm.hpp
+++ b/src/dgNonlinearForm.hpp
@@ -57,8 +57,8 @@ class DGNonLinearForm : public ParNonlinearForm {
   BCintegrator *bcIntegrator;
 
   IntegrationRules *intRules;
-  const int dim;
-  const int num_equation;
+  const int dim_;
+  const int num_equation_;
   GasMixture *mixture;
 
   const volumeFaceIntegrationArrays &gpuArrays;
@@ -71,8 +71,8 @@ class DGNonLinearForm : public ParNonlinearForm {
   mutable dataTransferArrays *transferU;
   mutable dataTransferArrays *transferGradUp;
 
-  const int &maxIntPoints;
-  const int &maxDofs;
+  const int &maxIntPoints_;
+  const int &maxDofs_;
 
   Vector uk_el1, grad_upk_el1;
   Vector uk_el2, grad_upk_el2;
@@ -122,13 +122,7 @@ class DGNonLinearForm : public ParNonlinearForm {
                                           const volumeFaceIntegrationArrays &gpuArrays,
                                           const parallelFacesIntegrationArrays *parallelData, const int &maxIntPoints,
                                           const int &maxDofs);
-  void evalFaceFlux_gpu(Vector &uk_el1, Vector &uk_el2, Vector &grad_uk_el1, Vector &grad_uk_el2,
-                        Fluxes *flux,
-                        const int &Ndofs, const int &Nf, const int &NumElemType,
-                        const int &elemOffset, const int &elDof, const int &dim,
-                        const int &num_equation, GasMixture *mixture,
-                        const volumeFaceIntegrationArrays &gpuArrays, const int &maxIntPoints,
-                        const int &maxDofs);
+  void evalFaceFlux_gpu();
 
 
 #ifdef _GPU_

--- a/src/fluxes.hpp
+++ b/src/fluxes.hpp
@@ -184,7 +184,7 @@ class Fluxes {
         stress[i][j] = gradUpn[1 + j + i * num_equation] + gradUpn[1 + i + j * num_equation];
       }
       // temperature gradient
-      //gradT[i] = temp * (gradUpn[1 + dim + i * num_equation] / p - gradUpn[0 + i * num_equation] / Un[0]);
+      // gradT[i] = temp * (gradUpn[1 + dim + i * num_equation] / p - gradUpn[0 + i * num_equation] / Un[0]);
       gradT[i] = gradUpn[1 + dim + i * num_equation];
 
       vel[i] = Un[1 + i] / Un[0];

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -298,22 +298,22 @@ void OutletBC::initBCs() {
 }
 
 void OutletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector &bdrFlux) {
-// {
-//   std::cout << "stateIn." << std::endl;
-//   for (int eq = 0; eq < num_equation; eq++) {
-//     std::cout << stateIn(eq) << ",\t";
-//   }
-//   std::cout << std::endl;
-//
-//   std::cout << "gradState." << std::endl;
-//   for (int eq = 0; eq < num_equation; eq++) {
-//     for (int d = 0; d < dim; d++) {
-//       std::cout << gradState(eq, d) << ",\t";
-//     }
-//     std::cout << std::endl;
-//   }
-//   exit(-1);
-// }
+  // {
+  //   std::cout << "stateIn." << std::endl;
+  //   for (int eq = 0; eq < num_equation; eq++) {
+  //     std::cout << stateIn(eq) << ",\t";
+  //   }
+  //   std::cout << std::endl;
+  //
+  //   std::cout << "gradState." << std::endl;
+  //   for (int eq = 0; eq < num_equation; eq++) {
+  //     for (int d = 0; d < dim; d++) {
+  //       std::cout << gradState(eq, d) << ",\t";
+  //     }
+  //     std::cout << std::endl;
+  //   }
+  //   exit(-1);
+  // }
   switch (outletType) {
     case SUB_P:
       subsonicReflectingPressure(normal, stateIn, bdrFlux);

--- a/src/riemann_solver.hpp
+++ b/src/riemann_solver.hpp
@@ -208,7 +208,6 @@ class RiemannSolver {
     }
   }
 
-
 #endif
 };
 

--- a/src/riemann_solver.hpp
+++ b/src/riemann_solver.hpp
@@ -100,6 +100,20 @@ class RiemannSolver {
     }
   }
 
+  static MFEM_HOST_DEVICE void convFluxDotNorm_serial_gpu(const double *state, const double pres, const double *nor,
+                                                          const int &dim, double *fluxN) {
+    double den_velN;
+
+    den_velN = 0.;
+    for (int d = 0; d < dim; d++) den_velN += state[d + 1] * nor[d];
+
+    fluxN[0] = den_velN;
+    for (int d = 0; d < dim; d++) fluxN[1 + d] = den_velN * state[d + 1] / state[0] + pres * nor[d];
+
+    const double H = (state[dim + 1] + pres) / state[0];
+    fluxN[1 + dim] = den_velN * H;
+  }
+
   static MFEM_HOST_DEVICE void riemannLF_gpu(const double *U1, const double *U2, double *flux, const double *nor,
                                              const double &gamma, const double &Rg, const int &dim,
                                              const Equations &eqSystem, const int &num_equation, const int &thrd,
@@ -152,6 +166,48 @@ class RiemannSolver {
       flux[i] = 0.5 * (flux1[i] + flux2[i]) - 0.5 * maxE * (U2[i] - U1[i]) * normag;
     }
   }
+
+  static MFEM_HOST_DEVICE void riemannLF_serial_gpu(const double *U1, const double *U2, double *flux, const double *nor,
+                                                    const double &gamma, const double &Rg, const int &dim,
+                                                    const int &num_equation) {
+    double KE1[3], KE2[3];
+    double vel1, vel2, p1, p2;
+    double maxE1, maxE2, maxE;
+    double flux1[5], flux2[5];
+    double normag;
+
+    for (int d = 0; d < dim; d++) {
+      KE1[d] = 0.5 * U1[1 + d] * U1[1 + d] / U1[0];
+      KE2[d] = 0.5 * U2[1 + d] * U2[1 + d] / U2[0];
+    }
+
+    p1 = DryAir::pressure(U1, &KE1[0], gamma, dim, num_equation);
+    p2 = DryAir::pressure(U2, &KE2[0], gamma, dim, num_equation);
+
+    vel1 = 0.;
+    for (int d = 0; d < dim; d++) vel1 += 2. * KE1[d] / U1[0];
+    vel1 = sqrt(vel1);
+
+    vel2 = 0.;
+    for (int d = 0; d < dim; d++) vel2 += 2 * KE2[d] / U2[0];
+    vel2 = sqrt(vel2);
+
+    maxE1 = vel1 + sqrt(gamma * p1 / U1[0]);
+    maxE2 = vel2 + sqrt(gamma * p2 / U2[0]);
+    maxE = max(maxE1, maxE2);
+
+    RiemannSolver::convFluxDotNorm_serial_gpu(U1, p1, nor, dim, flux1);
+    RiemannSolver::convFluxDotNorm_serial_gpu(U2, p2, nor, dim, flux2);
+
+    normag = 0.;
+    for (int i = 0; i < dim; i++) normag += nor[i] * nor[i];
+    normag = sqrt(normag);
+
+    for (int i = 0; i < num_equation; i++) {
+      flux[i] = 0.5 * (flux1[i] + flux2[i]) - 0.5 * maxE * (U2[i] - U1[i]) * normag;
+    }
+  }
+
 
 #endif
 };

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -141,7 +141,7 @@ void Tps::parseCommandLineArgs(int argc, char *argv[]) {
 /// Setup desired execution devices for MFEM
 void Tps::chooseDevices() {
 #ifdef _GPU_
-  device_.Configure(deviceConfig_, nprocs_ % numGpusPerRank_);
+  device_.Configure(deviceConfig_, rank_ % numGpusPerRank_);
 #endif
 
   if (isRank0_) {


### PR DESCRIPTION
This PR refactors the interior face integration routines for the gpu.  

#### Summary of code changes
The changes include

1. Use Marc's approach from #78, which refactors and simplifies some of the mfem device macro usage
2. Reduce duplicate calculations by 
    * Making each element responsible for interpolating its own state to the faces (rather than its own and its neighbors')
    * Evaluating the flux at the face quadrature points once and storing the result rather than recomputing it for both elements on a face
 3. Clean up, mainly by using class data where possible rather than function arguments

These changes have *only* been applied to the interior face routines.  Analogous changes could be applied to the shared face calculations as well (one assumes), but to keep this PR small, that has not been attempted yet.


#### Performance changes
The modifications have improved performance somewhat.  Specifically, on 1 mpi rank on Lassen, a modified version of the [cylinder test case](https://github.com/pecos/tps/blob/3a38a813467e24be478a8af4d650d44bbb0a0b0e/test/inputs/input.dtconst.cyl.ini#L1) goes from 17.7 seconds on `main` (in the solve) to 10.9, an improvement of about 38%.  The modifications to the test are 1) the order is increased to p=3, 2) the number of steps is increased to 100, and 3) the output frequency is reduced.  The input file diff relative to the regression test is below:

```
[oliver33@lassen708:test]$ diff inputs/input.dtconst.cyl.ini inputs/input.dtconst.cyl100.ini
6c6
< order = 1
---
> order = 3 # 1
9,10c9,10
< maxIters = 4
< outputFreq = 5
---
> maxIters = 100
> outputFreq = 20
21c21
< cfl = 0.80
---
> cfl = 0.12 # 0.80

```

The output from the grvy timers for this case is below:

* On `main` before the PR:
```
-----------------------------------------------------------------------------------------------
TPS - Performance Timings:                              |      Mean      Variance       Count
--> solve               : 1.76863e+01 secs ( 79.2083 %) | [1.76863e-01  2.60817e-02        100]
--> restart_files_hdf5  : 6.86684e-02 secs (  0.3075 %) | [1.37337e-02  5.72839e-07          5]
--> GRVY_Unassigned     : 4.57388e+00 secs ( 20.4841 %)

    Total Measured Time = 2.23289e+01 secs (100.0000 %)
-----------------------------------------------------------------------------------------------

```

* On this branch:
```
-----------------------------------------------------------------------------------------------
TPS - Performance Timings:                              |      Mean      Variance       Count
--> solve               : 1.09058e+01 secs ( 70.1072 %) | [1.09058e-01  2.59142e-02        100]
--> restart_files_hdf5  : 6.57170e-02 secs (  0.4225 %) | [1.31434e-02  6.02010e-07          5]
--> GRVY_Unassigned     : 4.58439e+00 secs ( 29.4703 %)

    Total Measured Time = 1.55560e+01 secs (100.0000 %)
-----------------------------------------------------------------------------------------------
```

Finally, snippets of `nvprof` output for this case are included here to show the reduction in time spent in kernels associated with interior face integration on the gpu:

* On `main` before this PR:
```
==21552== Profiling application: ../src/tps -run inputs/input.dtconst.cyl100.ini
==21552== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   45.91%  6.72093s       400  16.802ms  16.745ms  23.898ms  _ZN4mfem10CuKernel2DIZN15DGNonLinearForm19faceIntegration_gpuERNS_6VectorES3_S3_S3_S3_PKNS_15ParGridFunctionEP6FluxesRKiSA_SA_SA_SA_SA_SA_P10GasMixtureRK27volumeFaceIntegrationArraysSA_SA_EUliE_EEviT_i
                   22.53%  3.29769s       400  8.2442ms  8.1945ms  9.2603ms  _ZN4mfem10CuKernel2DIZN15DGNonLinearForm18interpFaceData_gpuERKNS_6VectorERS2_S5_S5_S5_PKNS_15ParGridFunctionERKiSA_SA_SA_SA_SA_SA_RKdSC_SC_SC_SC_RK27volumeFaceIntegrationArraysSA_SA_EUliE_EEviT_i
                   11.30%  1.65469s       400  4.1367ms  4.1190ms  4.7785ms  _ZN4mfem10CuKernel2DIZN9Gradients15faceContrib_gpuEiiiiRKNS_6VectorERS2_iiRK27volumeFaceIntegrationArraysRKiSA_EUliE_EEviT_i
                    7.87%  1.15157s       400  2.8789ms  2.8687ms  3.2078ms  _ZN4mfem10CuKernel2DIZN9Gradients20computeGradients_gpuEiiiiRKNS_6VectorERS2_iiRK27volumeFaceIntegrationArraysRKiSA_EUliE_EEviT_i
                    4.54%  518.67ms       400  1.2967ms  1.2894ms  1.6569ms  _ZN4mfem10CuKernel2DIZN6WallBC18integrateWalls_gpuE8WallTypeRKdRNS_6VectorERKS5_S6_S6_RKNS_5ArrayIiEESC_PNS_15ParGridFunctionESE_S6_S6_RSA_SF_SF_RK9EquationsRKiSK_SK_SK_P10GasMixtureEUliE_EEviT_i
                    1.86%  271.92ms        54  5.0356ms  1.3760us  120.89ms  [CUDA memcpy HtoD]
                    1.66%  243.64ms      2000  121.82us  118.62us  144.03us  _ZN8cusparse21load_balancing_kernelILj512ELj4ELm16384EiiNS_7CsrmvOpILi512EdLb0EEEJKiKdS4_didEEEvPKT3_T2_S5_S5_iPKS8_T4_DpPT5_
                    0.97%  141.28ms       400  353.19us  350.14us  434.75us  _ZN4mfem10CuKernel2DIZN6Fluxes17viscousFluxes_gpuERKNS_6VectorEPNS_15ParGridFunctionERNS_11DenseTensorERK9EquationsP10GasMixturePKS5_RK19linearlyVaryingViscRKiSK_SK_EUliE_EEviT_i
                    0.82%  119.78ms       400  299.46us  297.05us  354.91us  _ZN4mfem10CuKernel2DIZN6WallBC15interpWalls_gpuE8WallTypeRKdRNS_6VectorES6_RKS5_RKNS_5ArrayIiEESC_PNS_15ParGridFunctionESE_S6_S6_RSA_SF_SF_RKiSH_SH_SH_EUliE_EEviT_i
                    0.80%  117.37ms       400  293.43us  290.62us  328.16us  _ZN4mfem10CuKernel2DIZN9Gradients15multInverse_gpuEiiiiRNS_6VectorEiiRK27volumeFaceIntegrationArraysRKS2_RKNS_5ArrayIiEEEUliE_EEviT_i
                    0.62%  90.356ms       400  225.89us  223.45us  268.48us  _ZN4mfem10CuKernel2DIZN11RHSoperator18multiPlyInvers_gpuERNS_6VectorES3_RK27volumeFaceIntegrationArraysRKS2_RKNS_5ArrayIiEEiiiiiEUliE_EEviT_i
                    0.50%  72.477ms       400  181.19us  180.25us  255.39us  _ZN4mfem10CuKernel2DIZN6Fluxes20convectiveFluxes_gpuERKNS_6VectorERNS_11DenseTensorERK9EquationsP10GasMixtureRKiSD_SD_EUliE_EEviT_i

```
* On this branch:
```
==63462== Profiling application: ../src/tps -run inputs/input.dtconst.cyl100.ini
==63462== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   21.26%  1.65840s       400  4.1460ms  4.1182ms  4.7775ms  _ZN4mfem10CuKernel2DIZN9Gradients15faceContrib_gpuEiiiiRKNS_6VectorERS2_iiRK27volumeFaceIntegrationArraysRKiSA_EUliE_EEviT_i
                   18.27%  1.42513s       400  3.5628ms  3.5074ms  4.0475ms  _ZN4mfem10CuKernel2DIZN15DGNonLinearForm18interpFaceData_gpuERKNS_6VectorEiiiEUliE_EEviT_i
                   15.81%  1.23360s       400  3.0840ms  3.0610ms  3.2895ms  _ZN4mfem10CuKernel1DIZN15DGNonLinearForm19faceIntegration_gpuERNS_6VectorEiiiEUliE_EEviT_
                   14.78%  1.15312s       400  2.8828ms  2.8688ms  3.2065ms  _ZN4mfem10CuKernel2DIZN9Gradients20computeGradients_gpuEiiiiRKNS_6VectorERS2_iiRK27volumeFaceIntegrationArraysRKiSA_EUliE_EEviT_i
                    6.67%  520.04ms       400  1.3001ms  1.2891ms  1.6550ms  _ZN4mfem10CuKernel2DIZN6WallBC18integrateWalls_gpuE8WallTypeRKdRNS_6VectorERKS5_S6_S6_RKNS_5ArrayIiEESC_PNS_15ParGridFunctionESE_S6_S6_RSA_SF_SF_RK9EquationsRKiSK_SK_SK_P10GasMixtureEUliE_EEviT_i
                    6.62%  516.48ms       400  1.2912ms  1.2678ms  1.3494ms  _ZN4mfem10CuKernel1DIZN15DGNonLinearForm16evalFaceFlux_gpuEvEUliE_EEviT_
                    3.49%  271.97ms        54  5.0366ms  1.3760us  120.03ms  [CUDA memcpy HtoD]
                    3.07%  239.86ms      2000  119.93us  116.80us  141.76us  _ZN8cusparse21load_balancing_kernelILj512ELj4ELm16384EiiNS_7CsrmvOpILi512EdLb0EEEJKiKdS4_didEEEvPKT3_T2_S5_S5_iPKS8_T4_DpPT5_
                    1.84%  143.91ms       400  359.78us  355.42us  444.67us  _ZN4mfem10CuKernel2DIZN6Fluxes17viscousFluxes_gpuERKNS_6VectorEPNS_15ParGridFunctionERNS_11DenseTensorERK9EquationsP10GasMixturePKS5_RK19linearlyVaryingViscRKiSK_SK_EUliE_EEviT_i
                    1.54%  120.52ms       400  301.29us  298.20us  355.71us  _ZN4mfem10CuKernel2DIZN6WallBC15interpWalls_gpuE8WallTypeRKdRNS_6VectorES6_RKS5_RKNS_5ArrayIiEESC_PNS_15ParGridFunctionESE_S6_S6_RSA_SF_SF_RKiSH_SH_SH_EUliE_EEviT_i
                    1.51%  117.64ms       400  294.11us  290.36us  329.08us  _ZN4mfem10CuKernel2DIZN9Gradients15multInverse_gpuEiiiiRNS_6VectorEiiRK27volumeFaceIntegrationArraysRKS2_RKNS_5ArrayIiEEEUliE_EEviT_i
                    1.16%  90.609ms       400  226.52us  224.25us  269.05us  _ZN4mfem10CuKernel2DIZN11RHSoperator18multiPlyInvers_gpuERNS_6VectorES3_RK27volumeFaceIntegrationArraysRKS2_RKNS_5ArrayIiEEiiiiiEUliE_EEviT_i
                    0.93%  72.541ms       400  181.35us  180.03us  256.48us  _ZN4mfem10CuKernel2DIZN6Fluxes20convectiveFluxes_gpuERKNS_6VectorERNS_11DenseTensorERK9EquationsP10GasMixtureRKiSD_SD_EUliE_EEviT_i
                    0.92%  71.653ms       400  179.13us  177.60us  209.47us  _ZN4mfem10CuKernel2DIZN11RHSoperator20updatePrimitives_gpuEPNS_6VectorEPKS2_ddiiiRK9EquationsEUliE_EEviT_i
                    0.39%  30.584ms       400  76.459us  75.612us  98.492us  _ZN4mfem10CuKernel2DIZN7InletBC19integrateInlets_gpuE9InletTypeRKNS_6VectorERKdRS3_S5_S8_RKNS_5ArrayIiEESC_PNS_15ParGridFunctionESE_S8_S8_RSA_SF_SF_RKiSH_SH_SH_P10GasMixtureR9EquationsEUliE_EEviT_i

```