### PR TITLE
One addition of collision integral

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,5 @@ test/ref_solns/collisions/Devoto.h5 filter=lfs diff=lfs merge=lfs -text
 test/ref_solns/transport/Chung.transport.h5 filter=lfs diff=lfs merge=lfs -text
 test/ref_solns/transport/Devoto1973.transport.h5 filter=lfs diff=lfs merge=lfs -text
 test/ref_solns/reaction.test.h5 filter=lfs diff=lfs merge=lfs -text
+test/ref_solns/collisions/Amdur_Mason.estimated.h5 filter=lfs diff=lfs merge=lfs -text
+test/ref_solns/collisions/Amdur_Mason.h5 filter=lfs diff=lfs merge=lfs -text

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -730,7 +730,9 @@ double ArgonMixtureTransport::collisionIntegral(const int _spI, const int _spJ, 
       }
     } break;
     case AR_AR: {
-      if ((l == 2) && (r == 2)) {
+      if ((l == 1) && (r == 1)) {
+        return collision::argon::ArAr11(temp);
+      } else if ((l == 2) && (r == 2)) {
         return collision::argon::ArAr22(temp);
       } else {
         grvy_printf(GRVY_ERROR,

--- a/src/collision_integrals.cpp
+++ b/src/collision_integrals.cpp
@@ -89,6 +89,12 @@ double rep24(const double Tp) { return 0.1323 * pow(log(1.0 + 2.7248 * pow(Tp, 1
 // Takes T in Kelvin, returns in unit of m^2.
 namespace argon {
 
+double ArAr11(const double T) {
+  // Reference : fitted from tabulated data of Amdur, I., & Mason, E. A. (1958). Properties of gases at very high
+  // temperatures. Physics of Fluids, 1(5), 370–383. https://doi.org/10.1063/1.1724353
+  return 2.2910e-18 * pow(T, -0.3032);
+}
+
 double ArAr22(const double T) {
   // Reference : Liu, W. S., Whitten, B. T., & Glass, I. I. (1978). Ionizing argon boundary layers. Part 1. Quasi-steady
   // flat-plate laminar boundary-layer flows. Journal of Fluid Mechanics, 87(4), 609–640.

--- a/src/collision_integrals.hpp
+++ b/src/collision_integrals.hpp
@@ -81,6 +81,8 @@ double rep24(const double Tp);
 // Takes T in Kelvin, returns in unit of m^2.
 namespace argon {
 
+double ArAr11(const double T);
+
 double ArAr22(const double T);
 
 // argon neutral (Ar) - argon positive ion (Ar1P)

--- a/test/ref_solns/collisions/Amdur_Mason.estimated.h5
+++ b/test/ref_solns/collisions/Amdur_Mason.estimated.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d96d0ac0e8c3847521d122c9e77d00fdda4c327739f17755588b7ebd65ae9f0c
+size 2816

--- a/test/ref_solns/collisions/Amdur_Mason.h5
+++ b/test/ref_solns/collisions/Amdur_Mason.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00df56980ef7aff2d65cfc915ecb7df125bf5e22aeb161488f0fc3469cdeba41
+size 3200

--- a/test/test_collision_integral.cpp
+++ b/test/test_collision_integral.cpp
@@ -306,5 +306,39 @@ int main (int argc, char *argv[])
     grvy_printf(GRVY_INFO, "\nPASS: Ar-Ar1+ (1,1) collision integral.\n");
   }
 
+  {
+    std::string fileName = "./ref_solns/collisions/Amdur_Mason.estimated.h5";
+    std::string datasetName = "Amdur_est";
+
+    DenseMatrix Amdur;
+    Array<int> dims = readTable(fileName, datasetName, Amdur);
+
+    Vector Tm(dims[0]);
+    Amdur.GetColumn(0, Tm);
+
+    double errorThreshold = 1.0e-2;
+
+    Vector O(dims[0]);
+    double relError = 0.0, relError1 = 0.0;
+    for (int m = 0; m < dims[0]; m++) {
+      O(m) = collision::argon::ArAr11(Tm(m));
+      int index = 3;
+
+      relError += abs((Amdur(m,index) - O(m)) / Amdur(m,index));
+      std::cout << O(m) << " =?= " << Amdur(m,index) << std::endl;
+      // std::cout << O(m) * Tm(m) * Tm(m) << " =?= " << Mason(m,1) << std::endl;
+    }
+    relError /= dims[0];
+    grvy_printf(GRVY_INFO, "\n Q11 with respect to Amdur & Mason (1958): %.8E\n", relError);
+    if (relError > errorThreshold) {
+      grvy_printf(GRVY_ERROR, "\n Collision integral error beyond threshold: %.8E\n", errorThreshold);
+      exit(ERROR);
+    }
+    // std::cout << relError << std::endl;
+    // std::cout << relError1 << std::endl;
+
+    grvy_printf(GRVY_INFO, "\nPASS: Ar-Ar (1,1) collision integral.\n");
+  }
+
   return 0;
 }


### PR DESCRIPTION
Rebase of #125. Merge after #126.

Collision integral required for general argon mixture: Ar-Ar (1,1) obtained from Amdur & Mason 1958.