### PR TITLE
Towards enabling the _GPU_ code path for the cpu

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,6 +165,22 @@ if test x$ENABLE_GPU != xyes; then
 fi
 AM_CONDITIONAL(HIP_ENABLED,test x$ENABLE_HIP = xyes)
 
+
+dnl ------------------------------
+dnl Check for GPU build without hip or cuda
+AC_ARG_ENABLE([gpu-cpu],
+         [AS_HELP_STRING([--enable-gpu-cpu],[Enable GPU code path on CPU (WARNING: Experimental option).])],
+	 [],[enable_gpu_cpu=no])
+
+if test x$enable_gpu_cpu = xyes; then
+   AC_MSG_NOTICE([Configuring for GPU code path build on CPU system])
+   AC_MSG_NOTICE([WARNING: This is an experimental feature.])
+   AC_DEFINE([_GPU_])
+   AM_CONDITIONAL(GPU_ENABLED,test x$enable_gpu_cpu = xyes)
+fi
+
+
+
 AX_PATH_MFEM([4.2],  [yes])
 
 dnl --

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -71,6 +71,8 @@ AS_ECHO("`$srcdir/m4/wrap_lines.py --maxWidth 110 --first 1 --remain 31 --prefix
 AS_ECHO("`$srcdir/m4/wrap_lines.py --maxWidth 110 --first 1 --remain 31 --prefix "   HIP_LDFLAGS.............. :" \
                                    --input="$HIP_LDFLAGS"`")
 fi
+
+echo GPU build enabled for cpu... : $enable_gpu_cpu
 echo '-----------------------------------------------------------------------------------'
 
 ])

--- a/src/averaging_and_rms.cpp
+++ b/src/averaging_and_rms.cpp
@@ -327,10 +327,7 @@ void Averaging::addSample_gpu(ParGridFunction *meanUp, ParGridFunction *rms, int
   WorkingFluid fluid = mixture->GetWorkingFluid();
   const double Rg = mixture->GetGasConstant();
 
-  // MFEM_FORALL_2D(n, Ndof, 6, 1, 1, {
-  //   MFEM_FOREACH_THREAD(i, x, 6) {
-  MFEM_FORALL(n, Ndof,
-  {
+  MFEM_FORALL(n, Ndof, {
     double meanVel[3], vel[3];
     double nUp[20];  // NOTE: lets make sure we don't have more than 20 eq.
 

--- a/src/averaging_and_rms.cpp
+++ b/src/averaging_and_rms.cpp
@@ -327,85 +327,72 @@ void Averaging::addSample_gpu(ParGridFunction *meanUp, ParGridFunction *rms, int
   WorkingFluid fluid = mixture->GetWorkingFluid();
   const double Rg = mixture->GetGasConstant();
 
-  MFEM_FORALL_2D(n, Ndof, 6, 1, 1, {
-    MFEM_FOREACH_THREAD(i, x, 6) {
-      MFEM_SHARED double meanVel[3], vel[3];
-      MFEM_SHARED double nUp[20];  // NOTE: lets make sure we don't have more than 20 eq.
+  // MFEM_FORALL_2D(n, Ndof, 6, 1, 1, {
+  //   MFEM_FOREACH_THREAD(i, x, 6) {
+  MFEM_FORALL(n, Ndof,
+  {
+    double meanVel[3], vel[3];
+    double nUp[20];  // NOTE: lets make sure we don't have more than 20 eq.
 
-      for (int eq = i; eq < num_equation; eq += 6) {
-    nUp[eq] = d_Up[n + eq * Ndof];
-      }
-      MFEM_SYNC_THREAD;
-
-      // mean
-      for (int eq = i; eq < num_equation; eq += 6) {
-    double mUpi = d_meanUp[n + eq * Ndof];
-
-    double mVal = dSamplesMean * mUpi;
-
-    double newMeanUp;
-    if (eq != 1 + dim) {
-      newMeanUp = (mVal + nUp[eq]) / (dSamplesMean + 1);
-    } else {  // eq == 1+dim
-      double p;
-      if (fluid == DRY_AIR) {
-        p = DryAir::ComputePressureFromPrimitives_gpu(&nUp[0], Rg, dim);
-      }
-      newMeanUp = (mVal + p) / (dSamplesMean + 1);
+    for (int eq = 0; eq < num_equation; eq++) {
+      nUp[eq] = d_Up[n + eq * Ndof];
     }
 
-    d_meanUp[n + eq * Ndof] = newMeanUp;
+    // mean
+    for (int eq = 0; eq < num_equation; eq++) {
+      double mUpi = d_meanUp[n + eq * Ndof];
+      double mVal = dSamplesMean * mUpi;
+
+      double newMeanUp;
+      if (eq != 1 + dim) {
+        newMeanUp = (mVal + nUp[eq]) / (dSamplesMean + 1);
+      } else {  // eq == 1+dim
+        double p;
+        if (fluid == DRY_AIR) {
+          p = DryAir::ComputePressureFromPrimitives_gpu(&nUp[0], Rg, dim);
+        }
+        newMeanUp = (mVal + p) / (dSamplesMean + 1);
+      }
+
+      d_meanUp[n + eq * Ndof] = newMeanUp;
+    }
 
     // fill out mean velocity array
-    if (i > 0 && i <= 3) {
-      meanVel[i - 1] = newMeanUp;
-      vel[i - 1] = nUp[i];
+    for (int d = 0; d < dim; d++) {
+      meanVel[d] = d_meanUp[n + (d + 1) * Ndof];
+      vel[d] = nUp[d + 1];
     }
-    if (i == 3 && dim != 3) {
+    if (dim != 3) {
       meanVel[2] = 0.;
       vel[2] = 0.;
     }
-      }
-      MFEM_SYNC_THREAD;
 
-      // ----- RMS -----
-      // xx
-      if (i == 0) {
-    double val = d_rms[n];
+    // ----- RMS -----
+    double val = 0.;
+    // xx
+    val = d_rms[n];
     d_rms[n] = (val * dSamplesMean + (vel[0] - meanVel[0]) * (vel[0] - meanVel[0])) / (dSamplesMean + 1);
-      }
 
-      // yy
-      if (i == 1) {
-    double val = d_rms[n + Ndof];
+    // yy
+    val = d_rms[n + Ndof];
     d_rms[n + Ndof] = (val * dSamplesMean + (vel[1] - meanVel[1]) * (vel[1] - meanVel[1])) / (dSamplesMean + 1);
-      }
 
-      // zz
-      if (i == 2) {
-    double val = d_rms[n + 2 * Ndof];
+    // zz
+    val = d_rms[n + 2 * Ndof];
     d_rms[n + 2 * Ndof] = (val * dSamplesMean + (vel[2] - meanVel[2]) * (vel[2] - meanVel[2])) / (dSamplesMean + 1);
-      }
 
-      // xy
-      if (i == 3) {
-    double val = d_rms[n + 3 * Ndof];
+    // xy
+    val = d_rms[n + 3 * Ndof];
     d_rms[n + 3 * Ndof] = (val * dSamplesMean + (vel[0] - meanVel[0]) * (vel[1] - meanVel[1])) / (dSamplesMean + 1);
-      }
 
-      // xz
-      if (i == 4) {
-    double val = d_rms[n + 4 * Ndof];
+    // xz
+    val = d_rms[n + 4 * Ndof];
     d_rms[n + 4 * Ndof] = (val * dSamplesMean + (vel[0] - meanVel[0]) * (vel[2] - meanVel[2])) / (dSamplesMean + 1);
-      }
 
-      // yz
-      if (i == 5) {
-    double val = d_rms[n + 5 * Ndof];
+    // yz
+    val = d_rms[n + 5 * Ndof];
     d_rms[n + 5 * Ndof] = (val * dSamplesMean + (vel[1] - meanVel[1]) * (vel[2] - meanVel[2])) / (dSamplesMean + 1);
-      }
-}
-});
+  });
 }
 
 void Averaging::sumValues_gpu(const Vector &meanUp, const Vector &rms, Vector &local_sums, Vector &tmp_vector,

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -353,6 +353,19 @@ class DryAir : public GasMixture {
 
     if (thrd == 0) stateOut[1 + dim] = p / (gamma - 1.) + ke;
   }
+
+  static MFEM_HOST_DEVICE void modifyEnergyForPressure_gpu_serial(const double *stateIn, double *stateOut, const double &p,
+                                                                  const double &gamma, const double &Rg,
+                                                                  const int &num_equation, const int &dim) {
+    double ke;
+    ke = 0.;
+    for (int d = 0; d < dim; d++) ke += stateIn[1 + d] * stateIn[1 + d];
+    ke *= 0.5 / stateIn[0];
+
+    for (int eq = 0; eq < num_equation; eq++) stateOut[eq] = stateIn[eq];
+
+    stateOut[1 + dim] = p / (gamma - 1.) + ke;
+  }
 #endif
 };
 

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -330,6 +330,14 @@ class DryAir : public GasMixture {
     if (thrd == 1 + dim) stagState[thrd] = Rg / (gamma - 1.) * stateIn[0] * Temp;
   }
 
+  static MFEM_HOST_DEVICE void computeStagnantStateWithTemp_gpu_serial(const double *stateIn, double *stagState,
+                                                                       const double &Temp, const double &gamma,
+                                                                       const double &Rg, const int &num_equation,
+                                                                       const int &dim) {
+    for (int d = 0; d < dim; d++) stagState[1+d] = 0.;
+    stagState[1 + dim] = Rg / (gamma - 1.) * stateIn[0] * Temp;
+  }
+
   static MFEM_HOST_DEVICE void modifyEnergyForPressure_gpu(const double *stateIn, double *stateOut, const double &p,
                                                            const double &gamma, const double &Rg,
                                                            const int &num_equation, const int &dim, const int &thrd,

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -334,7 +334,7 @@ class DryAir : public GasMixture {
                                                                        const double &Temp, const double &gamma,
                                                                        const double &Rg, const int &num_equation,
                                                                        const int &dim) {
-    for (int d = 0; d < dim; d++) stagState[1+d] = 0.;
+    for (int d = 0; d < dim; d++) stagState[1 + d] = 0.;
     stagState[1 + dim] = Rg / (gamma - 1.) * stateIn[0] * Temp;
   }
 
@@ -354,9 +354,10 @@ class DryAir : public GasMixture {
     if (thrd == 0) stateOut[1 + dim] = p / (gamma - 1.) + ke;
   }
 
-  static MFEM_HOST_DEVICE void modifyEnergyForPressure_gpu_serial(const double *stateIn, double *stateOut, const double &p,
-                                                                  const double &gamma, const double &Rg,
-                                                                  const int &num_equation, const int &dim) {
+  static MFEM_HOST_DEVICE void modifyEnergyForPressure_gpu_serial(const double *stateIn, double *stateOut,
+                                                                  const double &p, const double &gamma,
+                                                                  const double &Rg, const int &num_equation,
+                                                                  const int &dim) {
     double ke;
     ke = 0.;
     for (int d = 0; d < dim; d++) ke += stateIn[1 + d] * stateIn[1 + d];

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -250,8 +250,7 @@ void Fluxes::convectiveFluxes_gpu(const Vector &x, DenseTensor &flux, const Equa
   double gamma = mixture->GetSpecificHeatRatio();
   double Sc = mixture->GetSchmidtNum();
 
-  MFEM_FORALL(n, dof,
-  {
+  MFEM_FORALL(n, dof, {
     double Un[20];
     double KE[3];
     double p;
@@ -280,8 +279,8 @@ void Fluxes::convectiveFluxes_gpu(const Vector &x, DenseTensor &flux, const Equa
         if (eq == num_equation - 1 && eqSystem == NS_PASSIVE)
           d_flux[n + d * dof + eq * dof * dim] = Un[num_equation - 1] * Un[1 + d] / Un[0];
       }
-    }  // end MFEM_FOREACH_THREAD
-  });  // end MFEM_FORALL_WD
+    }
+  });
 
 #endif
 }
@@ -326,7 +325,6 @@ void Fluxes::viscousFluxes_gpu(const Vector &x, ParGridFunction *gradUp, DenseTe
       }
     }
 
-    // TODO: Update viscous flux routine!
     // Fluxes::viscousFlux_gpu(&vFlux[0], &Un[0], &gradUpn[0], eqSystem, gamma, Rg, viscMult, bulkViscMult,
     //                         Pr, Sc, eq, num_equation, dim, num_equation);
     Fluxes::viscousFlux_serial_gpu(&vFlux[0], &Un[0], &gradUpn[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -250,22 +250,21 @@ void Fluxes::convectiveFluxes_gpu(const Vector &x, DenseTensor &flux, const Equa
   double gamma = mixture->GetSpecificHeatRatio();
   double Sc = mixture->GetSchmidtNum();
 
-  MFEM_FORALL_2D(n, dof, num_equation, 1, 1, {
-    MFEM_SHARED double Un[20];
-    MFEM_SHARED double KE[3];
-    MFEM_SHARED double p;
+  MFEM_FORALL(n, dof,
+  {
+    double Un[20];
+    double KE[3];
+    double p;
 
-    MFEM_FOREACH_THREAD(eq, x, num_equation) {
+    for (int eq = 0; eq < num_equation; eq++) {
       Un[eq] = dataIn[n + eq * dof];
-      MFEM_SYNC_THREAD;
+    }
+    for (int d = 0; d < dim; d++) KE[d] = 0.5 * Un[1 + d] * Un[1 + d] / Un[0];
+    if (dim != 3) KE[2] = 0.;
 
-      if (eq < dim) KE[eq] = 0.5 * Un[1 + eq] * Un[1 + eq] / Un[0];
-      if (dim != 3 && eq == 1) KE[2] = 0.;
-      MFEM_SYNC_THREAD;
+    p = DryAir::pressure(&Un[0], &KE[0], gamma, dim, num_equation);
 
-      if (eq == 0) p = DryAir::pressure(&Un[0], &KE[0], gamma, dim, num_equation);
-      MFEM_SYNC_THREAD;
-
+    for (int eq = 0; eq < num_equation; eq++) {
       double temp;
       for (int d = 0; d < dim; d++) {
         if (eq == 0) d_flux[n + d * dof + eq * dof * dim] = Un[1 + d];
@@ -283,6 +282,7 @@ void Fluxes::convectiveFluxes_gpu(const Vector &x, DenseTensor &flux, const Equa
       }
     }  // end MFEM_FOREACH_THREAD
   });  // end MFEM_FORALL_WD
+
 #endif
 }
 
@@ -310,43 +310,48 @@ void Fluxes::viscousFluxes_gpu(const Vector &x, ParGridFunction *gradUp, DenseTe
   const double Sc = mixture->GetSchmidtNum();
 
   // clang-format off
-  MFEM_FORALL_2D(n, dof, num_equation, 1, 1, {
-    MFEM_FOREACH_THREAD(eq, x, num_equation) {
-      MFEM_SHARED double Un[5];
-      MFEM_SHARED double gradUpn[5 * 3];
-      MFEM_SHARED double vFlux[5 * 3];
-      MFEM_SHARED double linVisc;
+  MFEM_FORALL(n, dof,
+  {
+    double Un[5];
+    double gradUpn[5 * 3];
+    double vFlux[5 * 3];
+    double linVisc;
 
-      // init. State
+    // init. State
+    for (int eq = 0; eq < num_equation; eq++) {
       Un[eq] = dataIn[n + eq * dof];
 
       for (int d = 0; d < dim; d++) {
         gradUpn[eq + d * num_equation] = d_gradUp[n + eq * dof + d * dof * num_equation];
       }
-      MFEM_SYNC_THREAD;
+    }
 
-      Fluxes::viscousFlux_gpu(&vFlux[0], &Un[0], &gradUpn[0], eqSystem, gamma, Rg, viscMult, bulkViscMult,
-                              Pr, Sc, eq, num_equation, dim, num_equation);
+    // TODO: Update viscous flux routine!
+    // Fluxes::viscousFlux_gpu(&vFlux[0], &Un[0], &gradUpn[0], eqSystem, gamma, Rg, viscMult, bulkViscMult,
+    //                         Pr, Sc, eq, num_equation, dim, num_equation);
+    Fluxes::viscousFlux_serial_gpu(&vFlux[0], &Un[0], &gradUpn[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,
+                                   num_equation);
 
-      MFEM_SYNC_THREAD;
 
-      if (d_spaceVaryViscMult != NULL) {
-        if (eq == 0) {
-          linVisc = d_spaceVaryViscMult[n];
-        }
-        MFEM_SYNC_THREAD;
+    MFEM_SYNC_THREAD;
 
-        for (int d = 0; d < dim; d++) {
+    if (d_spaceVaryViscMult != NULL) {
+      linVisc = d_spaceVaryViscMult[n];
+
+      for (int d = 0; d < dim; d++) {
+        for (int eq = 0; eq < num_equation; eq++) {
           vFlux[eq + d * num_equation] *= linVisc;
         }
       }
+    }
 
-      // write to global memory
+    // write to global memory
+    for (int eq = 0; eq < num_equation; eq++) {
       for (int d = 0; d < dim; d++) {
         d_flux[n + d * dof + eq * dof * dim] -= vFlux[eq + d * num_equation];
       }
-    }  // end MFEM_FOREACH_THREAD
-  });  // end MFEM_FORALL_2D
+    }
+  });  // end MFEM_FORALL
 #endif
 }
 // clang-format on

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -41,8 +41,8 @@ Gradients::Gradients(ParFiniteElementSpace *_vfes, ParFiniteElementSpace *_gradU
     : ParNonlinearForm(_vfes),
       vfes(_vfes),
       gradUpfes(_gradUpfes),
-      dim(_dim),
-      num_equation(_num_equation),
+      dim_(_dim),
+      num_equation_(_num_equation),
       Up(_Up),
       gradUp(_gradUp),
       mixture(_mixture),
@@ -53,10 +53,23 @@ Gradients::Gradients(ParFiniteElementSpace *_vfes, ParFiniteElementSpace *_gradU
       Me_inv(_Me_inv),
       invMArray(_invMArray),
       posDofInvM(_posDofInvM),
-      maxIntPoints(_maxIntPoints),
-      maxDofs(_maxDofs) {
+      maxIntPoints_(_maxIntPoints),
+      maxDofs_(_maxDofs) {
   h_numElems = gpuArrays.numElems.HostRead();
   h_posDofIds = gpuArrays.posDofIds.HostRead();
+
+  uk_el1.UseDevice(true);
+  uk_el2.UseDevice(true);
+  dun_face.UseDevice(true);
+
+  int nfaces = vfes->GetMesh()->GetNumFaces();
+  uk_el1.SetSize(nfaces * maxIntPoints_ * num_equation_);
+  uk_el2.SetSize(nfaces * maxIntPoints_ * num_equation_);
+  dun_face.SetSize(nfaces * maxIntPoints_ * num_equation_ * dim_);
+
+  uk_el1 = 0.;
+  uk_el2 = 0.;
+  dun_face = 0.;
 
 #ifndef _GPU_
   // element derivative stiffness matrix
@@ -66,7 +79,7 @@ Gradients::Gradients(ParFiniteElementSpace *_vfes, ParFiniteElementSpace *_gradU
     ElementTransformation *Tr = vfes->GetElementTransformation(el);
     const int eldDof = elem->GetDof();
 
-    Ke[el] = new DenseMatrix(eldDof, dim * eldDof);
+    Ke[el] = new DenseMatrix(eldDof, dim_ * eldDof);
 
     // element volume integral
     int intorder = 2 * elem->GetOrder();
@@ -74,8 +87,8 @@ Gradients::Gradients(ParFiniteElementSpace *_vfes, ParFiniteElementSpace *_gradU
     const IntegrationRule *ir = &intRules->Get(elem->GetGeomType(), intorder);
 
     Vector shape(eldDof);
-    DenseMatrix dshape(eldDof, dim);
-    DenseMatrix iGradUp(num_equation, dim);
+    DenseMatrix dshape(eldDof, dim_);
+    DenseMatrix iGradUp(num_equation_, dim_);
 
     for (int i = 0; i < ir->GetNPoints(); i++) {
       IntegrationPoint ip = ir->IntPoint(i);
@@ -87,7 +100,7 @@ Gradients::Gradients(ParFiniteElementSpace *_vfes, ParFiniteElementSpace *_gradU
 
       double detJac = Tr->Jacobian().Det() * ip.weight;
 
-      for (int d = 0; d < dim; d++) {
+      for (int d = 0; d < dim_; d++) {
         for (int k = 0; k < eldDof; k++) {
           for (int j = 0; j < eldDof; j++) {
             (*Ke[el])(j, k + d * eldDof) += shape(j) * dshape(k, d) * detJac;
@@ -111,7 +124,7 @@ void Gradients::computeGradients() {
   double *dataGradUp = gradUp->GetData();
 
   // Vars for face contributions
-  Vector faceContrib(dim * num_equation * totalDofs);
+  Vector faceContrib(dim_ * num_equation_ * totalDofs);
   faceContrib = 0.;
 
   // compute volume integral and fill out above vectors
@@ -123,23 +136,23 @@ void Gradients::computeGradients() {
     Array<int> vdofs;
     vfes->GetElementVDofs(el, vdofs);
     const int eldDof = elem->GetDof();
-    DenseMatrix elUp(eldDof, num_equation);
+    DenseMatrix elUp(eldDof, num_equation_);
     for (int d = 0; d < eldDof; d++) {
       int index = vdofs[d];
-      for (int eq = 0; eq < num_equation; eq++) {
+      for (int eq = 0; eq < num_equation_; eq++) {
         elUp(d, eq) = dataUp[index + eq * totalDofs];
       }
     }
 
-    elGradUp.SetSize(eldDof, num_equation * dim);
+    elGradUp.SetSize(eldDof, num_equation_ * dim_);
     elGradUp = 0.;
 
     // Add volume contrubutions to gradient
-    for (int eq = 0; eq < num_equation; eq++) {
-      for (int d = 0; d < dim; d++) {
+    for (int eq = 0; eq < num_equation_; eq++) {
+      for (int d = 0; d < dim_; d++) {
         for (int j = 0; j < eldDof; j++) {
           for (int k = 0; k < eldDof; k++) {
-            elGradUp(j, eq + d * num_equation) += (*Ke[el])(j, k + d * eldDof) * elUp(k, eq);
+            elGradUp(j, eq + d * num_equation_) += (*Ke[el])(j, k + d * eldDof) * elUp(k, eq);
           }
         }
       }
@@ -148,9 +161,9 @@ void Gradients::computeGradients() {
     // transfer result into gradUp
     for (int k = 0; k < eldDof; k++) {
       int index = vdofs[k];
-      for (int eq = 0; eq < num_equation; eq++) {
-        for (int d = 0; d < dim; d++) {
-          dataGradUp[index + eq * totalDofs + d * num_equation * totalDofs] = -elGradUp(k, eq + d * num_equation);
+      for (int eq = 0; eq < num_equation_; eq++) {
+        for (int d = 0; d < dim_; d++) {
+          dataGradUp[index + eq * totalDofs + d * num_equation_ * totalDofs] = -elGradUp(k, eq + d * num_equation_);
         }
       }
     }
@@ -170,14 +183,14 @@ void Gradients::computeGradients() {
     Vector aux(eldDof);
     Vector rhs(eldDof);
 
-    for (int d = 0; d < dim; d++) {
-      for (int eq = 0; eq < num_equation; eq++) {
+    for (int d = 0; d < dim_; d++) {
+      for (int eq = 0; eq < num_equation_; eq++) {
         for (int k = 0; k < eldDof; k++) {
           int index = vdofs[k];
-          //           rhs[k] = gradUp[index+eq*totalDofs+d*num_equation*totalDofs]+
-          //                   faceContrib[index+eq*totalDofs+d*num_equation*totalDofs];
-          rhs[k] = -dataGradUp[index + eq * totalDofs + d * num_equation * totalDofs] +
-                   faceContrib[index + eq * totalDofs + d * num_equation * totalDofs];
+          //           rhs[k] = gradUp[index+eq*totalDofs+d*num_equation_*totalDofs]+
+          //                   faceContrib[index+eq*totalDofs+d*num_equation_*totalDofs];
+          rhs[k] = -dataGradUp[index + eq * totalDofs + d * num_equation_ * totalDofs] +
+                   faceContrib[index + eq * totalDofs + d * num_equation_ * totalDofs];
         }
 
         // mult by inv mass matrix
@@ -186,7 +199,7 @@ void Gradients::computeGradients() {
         // save this in gradUp
         for (int k = 0; k < eldDof; k++) {
           int index = vdofs[k];
-          dataGradUp[index + eq * totalDofs + d * num_equation * totalDofs] = aux[k];
+          dataGradUp[index + eq * totalDofs + d * num_equation_ * totalDofs] = aux[k];
         }
       }
     }
@@ -199,6 +212,16 @@ void Gradients::computeGradients() {
 void Gradients::computeGradients_domain() {
   DGNonLinearForm::setToZero_gpu(*gradUp, gradUp->Size());
 
+  // Interpolate state info the faces (loops over elements)
+  for (int elType = 0; elType < gpuArrays.numElems.Size(); elType++) {
+    int elemOffset = 0;
+    for (int i = 0; i < elType; i++) elemOffset += h_numElems[i];
+    int dof_el = h_posDofIds[2 * elemOffset + 1];
+    interpFaceData_gpu(*Up, elType, elemOffset, dof_el);
+  }
+
+  evalFaceIntegrand_gpu();
+
   for (int elType = 0; elType < gpuArrays.numElems.Size(); elType++) {
     int elemOffset = 0;
     if (elType != 0) {
@@ -206,23 +229,32 @@ void Gradients::computeGradients_domain() {
     }
     int dof_el = h_posDofIds[2 * elemOffset + 1];
 
-    faceContrib_gpu(h_numElems[elType], elemOffset, dof_el, vfes->GetNDofs(), *Up, *gradUp, num_equation, dim,
-                    gpuArrays, maxDofs, maxIntPoints);
+    faceContrib_gpu(h_numElems[elType], elemOffset, dof_el, vfes->GetNDofs(), *Up, *gradUp, num_equation_, dim_,
+                    gpuArrays, maxDofs_, maxIntPoints_);
+  }
+
+  for (int elType = 0; elType < gpuArrays.numElems.Size(); elType++) {
+    int elemOffset = 0;
+    if (elType != 0) {
+      for (int i = 0; i < elType; i++) elemOffset += h_numElems[i];
+    }
+    int dof_el = h_posDofIds[2 * elemOffset + 1];
 
     computeGradients_gpu(h_numElems[elType], elemOffset, dof_el, vfes->GetNDofs(),
                          *Up,  // px,
-                         *gradUp, num_equation, dim, gpuArrays, maxDofs, maxIntPoints);
+                         *gradUp, num_equation_, dim_, gpuArrays, maxDofs_, maxIntPoints_);
   }
+
 }
 
 void Gradients::computeGradients_bdr() {
   ParMesh *pmesh = vfes->GetParMesh();
   const int Nshared = pmesh->GetNSharedFaces();
   if (Nshared > 0) {
-    integrationGradSharedFace_gpu(Up, transferUp->face_nbr_data, gradUp, vfes->GetNDofs(), dim, num_equation,
+    integrationGradSharedFace_gpu(Up, transferUp->face_nbr_data, gradUp, vfes->GetNDofs(), dim_, num_equation_,
                                   mixture->GetSpecificHeatRatio(), mixture->GetGasConstant(),
                                   mixture->GetViscMultiplyer(), mixture->GetBulkViscMultiplyer(),
-                                  mixture->GetPrandtlNum(), gpuArrays, parallelData, maxIntPoints, maxDofs);
+                                  mixture->GetPrandtlNum(), gpuArrays, parallelData, maxIntPoints_, maxDofs_);
   }
 
   // Multiply by inverse mass matrix
@@ -232,10 +264,104 @@ void Gradients::computeGradients_bdr() {
       for (int i = 0; i < elType; i++) elemOffset += h_numElems[i];
     }
     int dof_el = h_posDofIds[2 * elemOffset + 1];
-    multInverse_gpu(h_numElems[elType], elemOffset, dof_el, vfes->GetNDofs(), *gradUp, num_equation, dim, gpuArrays,
+    multInverse_gpu(h_numElems[elType], elemOffset, dof_el, vfes->GetNDofs(), *gradUp, num_equation_, dim_, gpuArrays,
                     invMArray, posDofInvM);
   }
 }
+
+void Gradients::interpFaceData_gpu(const Vector &Up, int elType, int elemOffset, int elDof) {
+  const double *d_x = Up.Read(); // Primitives!
+  double *d_uk_el1 = uk_el1.Write();
+  double *d_uk_el2 = uk_el2.Write();
+
+  auto d_elemFaces = gpuArrays.elemFaces.Read();
+  auto d_nodesIDs = gpuArrays.nodesIDs.Read();
+  auto d_posDofIds = gpuArrays.posDofIds.Read();
+  auto d_shapeWnor1 = gpuArrays.shapeWnor1.Read();
+  const double *d_shape2 = gpuArrays.shape2.Read();
+  auto d_elems12Q = gpuArrays.elems12Q.Read();
+
+  const int Ndofs = vfes->GetNDofs();
+  const int NumElemsType = h_numElems[elType];
+  const int dim = dim_;
+  const int num_equation = num_equation_;
+  const int maxIntPoints = maxIntPoints_;
+  const int maxDofs = maxDofs_;
+
+  // clang-format off
+  MFEM_FORALL_2D(el, NumElemsType, maxIntPoints, 1, 1,
+  {
+    // assuming max. num of equations = 20
+    // and max elem dof is 216 (a p=5 hex)
+    double uk1[20];
+    double shape[216];
+    int indexes_i[216];
+
+    const int eli = elemOffset + el;
+    const int offsetEl1 = d_posDofIds[2 * eli];
+    const int elFaces = d_elemFaces[7 * eli];
+    const int dof1 = elDof;
+
+    for (int i = 0; i < elDof; i++) {
+      int index = d_nodesIDs[offsetEl1 + i];
+      indexes_i[i] = index;
+    }
+
+    // loop over faces
+    for (int face = 0; face < elFaces; face++) {
+      const int gFace = d_elemFaces[7 * eli + face + 1];
+      const int Q = d_elems12Q[3 * gFace + 2];
+      int offsetShape1 = gFace * maxIntPoints * (maxDofs + 1 + dim);
+      int offsetShape2 = gFace * maxIntPoints * maxDofs;
+
+      // swapElems = false indicates that el is "element 1" for this face
+      // swapElems = true  indicates that el is "element 2" for this face
+      bool swapElems = false;
+      if (eli != d_elems12Q[3 * gFace]) {
+        swapElems = true;
+      }
+
+      // loop over quadrature points on this face
+      MFEM_FOREACH_THREAD(k, x, Q) {
+        // set interpolation data to 0
+        for (int n = 0; n < num_equation; n++) {
+          uk1[n] = 0.;
+        }
+
+        // load shape functions
+        if (swapElems) {
+          for (int j = 0; j < dof1; j++) shape[j] = d_shape2[offsetShape2 + j + k * maxDofs];
+        } else {
+          for (int j = 0; j < dof1; j++) shape[j] = d_shapeWnor1[offsetShape1 + j + k * (maxDofs + 1 + dim)];
+        }
+
+        for (int eq = 0; eq < num_equation; eq++) {
+          int index;
+
+          // interpolate state
+          for (int j = 0; j < dof1; j++) {
+            index = indexes_i[j];
+            uk1[eq] += d_x[index + eq * Ndofs] * shape[j];
+          }
+
+        }
+
+        // save quad pt data to global memory
+        if (swapElems) {
+          for (int eq = 0; eq < num_equation; eq++) {
+            d_uk_el2[eq + k * num_equation + gFace * maxIntPoints * num_equation] = uk1[eq];
+          }
+        } else {
+          for (int eq = 0; eq < num_equation; eq++) {
+            d_uk_el1[eq + k * num_equation + gFace * maxIntPoints * num_equation] = uk1[eq];
+          }
+        }
+      }   // end loop over integration points (MFEM_FOREACH_THREAD)
+    }  // end loop over faces
+  });
+  // clang-format on
+}
+
 
 void Gradients::computeGradients_gpu(const int numElems, const int offsetElems, const int elDof, const int totalDofs,
                                      const Vector &Up, Vector &gradUp, const int num_equation, const int dim,
@@ -248,51 +374,111 @@ void Gradients::computeGradients_gpu(const int numElems, const int offsetElems, 
   const double *d_elemShapeDshapeWJ = gpuArrays.elemShapeDshapeWJ.Read();
   auto d_elemPosQ_shapeDshapeWJ = gpuArrays.elemPosQ_shapeDshapeWJ.Read();
 
-  MFEM_FORALL_2D(el, numElems, elDof, 1, 1, {
-    MFEM_FOREACH_THREAD(i, x, elDof) {
-      MFEM_SHARED double Ui[216], gradUpi[216 * 3];
-      MFEM_SHARED double l1[216], dl1[216];
+  // MFEM_FORALL_2D(el, numElems, elDof, 1, 1,
+  // {
+  //   MFEM_FOREACH_THREAD(i, x, elDof) {
+  MFEM_FORALL(el, numElems,
+  {
+    const int eli = el + offsetElems;
+    const int offsetIDs    = d_posDofIds[2 * eli];
+    const int offsetDShape = d_elemPosQ_shapeDshapeWJ[2 * eli   ];
+    const int Q            = d_elemPosQ_shapeDshapeWJ[2 * eli + 1];
+    int index_i[216];
+    double Ui[216], gradUpi[216 * 3];
+    double l1[216], dl1[216];
+    double gradUpk;
 
-      const int eli = el + offsetElems;
-      const int offsetIDs    = d_posDofIds[2 * eli];
-      const int offsetDShape = d_elemPosQ_shapeDshapeWJ[2 * eli   ];
-      const int Q            = d_elemPosQ_shapeDshapeWJ[2 * eli + 1];
-      const int indexi = d_nodesIDs[offsetIDs + i];
 
-      double gradUpk;
-      for ( int eq = 0; eq < num_equation; eq++ ) {
-    Ui[i] = d_Up[indexi + eq * totalDofs];
-    for (int d = 0; d < dim; d++) {
-      // this loads face contribution
-      gradUpi[i + d * elDof] = d_gradUp[indexi + eq * totalDofs + d * num_equation * totalDofs];
+    for (int i = 0; i < elDof; i++) {
+      index_i[i] = d_nodesIDs[offsetIDs + i];
     }
-    MFEM_SYNC_THREAD;
+
+    for ( int eq = 0; eq < num_equation; eq++ ) {
+      for (int i = 0; i < elDof; i++) {
+        Ui[i] = d_Up[index_i[i] + eq * totalDofs];
+        for (int d = 0; d < dim; d++) {
+          // this loads face contribution
+          gradUpi[i + d * elDof] = d_gradUp[index_i[i] + eq * totalDofs + d * num_equation * totalDofs];
+        }
+      }
+
+      for (int k = 0; k < Q; k++) {
+        for (int i = 0; i < elDof; i++) {
+          l1[i] = d_elemShapeDshapeWJ[offsetDShape + i + k * ((dim + 1) * elDof + 1)];
+        }
+
+        for (int d = 0; d < dim; d++) {
+          // interpolate gradient in dth direction to kth quad point
+          gradUpk = 0.;
+          for (int j = 0; j < elDof; j++) {
+            dl1[j] = d_elemShapeDshapeWJ[offsetDShape + elDof + j + d * elDof + k * ((dim + 1) * elDof + 1)];
+            gradUpk += dl1[j] * Ui[j];
+          }
+
+
+          for (int i = 0; i < elDof; i++) {
+            const double weightDetJac = d_elemShapeDshapeWJ[offsetDShape + elDof + dim * elDof + k * ((dim + 1) * elDof + 1)];
+            gradUpi[i + d * elDof] += gradUpk * l1[i] * weightDetJac;
+          }
+        }
+      }
+
+        // write to global memory
+      for (int i = 0; i < elDof; i++) {
+        for (int d = 0; d < dim; d++) {
+          d_gradUp[index_i[i] + eq * totalDofs + d * num_equation * totalDofs] = gradUpi[i + d * elDof];
+        }
+      }
+    }  // end equation loop
+  });
+}
+
+// clang-format on
+void Gradients::evalFaceIntegrand_gpu() {
+  auto d_dun = dun_face.Write();
+  const double *d_uk_el1 = uk_el1.Read();
+  const double *d_uk_el2 = uk_el2.Read();
+
+  auto d_shapeWnor1 = gpuArrays.shapeWnor1.Read();
+  auto d_elems12Q = gpuArrays.elems12Q.Read();
+
+  Mesh *mesh = fes->GetMesh();
+  const int Nf = mesh->GetNumFaces();
+
+  const int dim = dim_;
+  const int num_equation = num_equation_;
+  const int maxIntPoints = maxIntPoints_;
+  const int maxDofs = maxDofs_;
+
+  MFEM_FORALL(iface, Nf,
+  {
+    double u1[20], u2[20], nor[3];
+
+    const int Q = d_elems12Q[3 * iface + 2];
+    const int offsetShape1 = iface * maxIntPoints * (maxDofs + 1 + dim);
+    const int offsetShape2 = iface * maxIntPoints * maxDofs;
 
     for (int k = 0; k < Q; k++) {
-      const double weightDetJac = d_elemShapeDshapeWJ[offsetDShape + elDof + dim * elDof + k * ((dim + 1) * elDof + 1)];
-      l1[i] = d_elemShapeDshapeWJ[offsetDShape + i + k * ((dim + 1) * elDof + 1)];
+      const double weight = d_shapeWnor1[offsetShape1 + maxDofs + k * (maxDofs + 1 + dim)];
+
+      double du[20];
+      for (int eq = 0; eq < num_equation; eq++) {
+        u1[eq] = d_uk_el1[eq + k * num_equation + iface * maxIntPoints * num_equation];
+        u2[eq] = d_uk_el2[eq + k * num_equation + iface * maxIntPoints * num_equation];
+        du[eq] = u2[eq] - u1[eq];
+      }
 
       for (int d = 0; d < dim; d++) {
-        gradUpk = 0.;
-
-        dl1[i] = d_elemShapeDshapeWJ[offsetDShape + elDof + i + d * elDof + k * ((dim + 1) * elDof + 1)];
-        MFEM_SYNC_THREAD;
-
-        for (int j = 0; j < elDof; j++) gradUpk += dl1[j] * Ui[j];
-        MFEM_SYNC_THREAD;
-
-        gradUpi[i + d * elDof] += gradUpk * l1[i] * weightDetJac;
-      }  // end loop dimensions
-    }    // end loop integration points
-
-    // write to global memory
-    for (int d = 0; d < dim; d++)
-      d_gradUp[indexi + eq * totalDofs + d * num_equation * totalDofs] = gradUpi[i + d * elDof];
-    MFEM_SYNC_THREAD;
-      }  // end equation loop
+        nor[d] = weight * 0.5 * d_shapeWnor1[offsetShape1 + maxDofs + 1 + d + k * (maxDofs + 1 + dim)];
+        for (int eq = 0; eq < num_equation; eq++) {
+          const int idx = eq + k * num_equation + d * maxIntPoints * num_equation + iface * dim * maxIntPoints * num_equation;
+          d_dun[idx] = du[eq] * nor[d];
+        }
+      }
+    }  // end loop over integration points
+  });  // end loop over faces
 }
-});
-}
+
 
 // clang-format on
 void Gradients::faceContrib_gpu(const int numElems, const int offsetElems, const int elDof, const int totalDofs,
@@ -300,7 +486,11 @@ void Gradients::faceContrib_gpu(const int numElems, const int offsetElems, const
                                 const volumeFaceIntegrationArrays &gpuArrays, const int &maxDofs,
                                 const int &maxIntPoints) {
   const double *d_Up = Up.Read();
-  double *d_gradUp = gradUp.Write();
+  const double *d_uk_el1 = uk_el1.Read();
+  const double *d_uk_el2 = uk_el2.Read();
+  const double *d_dun = dun_face.Read();
+
+  double *d_gradUp = gradUp.Write(); // NB: I assume this comes in set to zero!
   auto d_posDofIds = gpuArrays.posDofIds.Read();
   auto d_nodesIDs = gpuArrays.nodesIDs.Read();
 
@@ -310,132 +500,65 @@ void Gradients::faceContrib_gpu(const int numElems, const int offsetElems, const
   const double *d_shape2 = gpuArrays.shape2.Read();
   auto d_elems12Q = gpuArrays.elems12Q.Read();
 
-  MFEM_FORALL_2D(el, numElems, elDof, 1, 1, {
+  //MFEM_FORALL(el, numElems,
+  MFEM_FORALL_2D(el, numElems, elDof, 1, 1,
+  {
+    const int eli = el + offsetElems;
+    const int offsetIDs    = d_posDofIds[2 * eli];
+
     MFEM_FOREACH_THREAD(i, x, elDof) {
-      MFEM_SHARED double U1[216], U2[216], gradUpi[216 * 3];
-      MFEM_SHARED double l1[216], l2[216];
-      MFEM_SHARED double u1[20], u2[20], nor[3];
-      MFEM_SHARED int index_j[216];
-
-      const int eli = el + offsetElems;
-      const int offsetIDs    = d_posDofIds[2 * eli];
-      const int indexi = d_nodesIDs[offsetIDs + i];
-
-      // set to 0 the contribution to the gradients
-      for ( int eq = 0; eq < num_equation; eq++ ) {
-    for (int d = 0; d < dim; d++) {
-      gradUpi[i + eq * elDof + d * num_equation * elDof] = 0.;
-    }
-      }
-      MFEM_SYNC_THREAD;
+      const int idx = d_nodesIDs[offsetIDs + i];
+      double const* shape;
 
       // ================  FACE CONTRIBUTION  ================
       const int elFaces = d_elemFaces[7 * eli];
       for (int face = 0; face < elFaces; face++) {
-    const int gFace = d_elemFaces[7 * eli + face + 1];
-    const int Q = d_elems12Q[3 * gFace + 2];
-    const int offsetShape1 = gFace * maxIntPoints * (maxDofs + 1 + dim);
-    const int offsetShape2 = gFace * maxIntPoints * maxDofs;
-    bool swapElems = false;
+        const int gFace = d_elemFaces[7 * eli + face + 1];
+        const int Q = d_elems12Q[3 * gFace + 2];
+        const int offsetShape1 = gFace * maxIntPoints * (maxDofs + 1 + dim);
+        const int offsetShape2 = gFace * maxIntPoints * maxDofs;
+        bool swapElems = false;
 
-    // get neighbor
-    int elj = d_elems12Q[3 * gFace];
-    if (elj == eli) {
-      elj = d_elems12Q[3 * gFace + 1];
-    } else {
-      swapElems = true;
-    }
+        // get neighbor
+        int elj = d_elems12Q[3 * gFace];
+        if (elj != eli) {
+          swapElems = true;
+        }
 
-    const int offsetElj = d_posDofIds[2 * elj];
-    int dofj = d_posDofIds[2 * elj + 1];
-    int dof1 = elDof;
-    int dof2 = dofj;
-    if (swapElems) {
-      dof1 = dofj;
-      dof2 = elDof;
-    }
-
-    for (int j = i; j < dofj; j += elDof) index_j[j] = d_nodesIDs[offsetElj + j];
-    MFEM_SYNC_THREAD;
-
-    for (int k = 0; k < Q; k++) {
-      const double weight = d_shapeWnor1[offsetShape1 + maxDofs + k * (maxDofs + 1 + dim)];
-      for (int d = i; d < dim; d += elDof)
-        nor[d] = d_shapeWnor1[offsetShape1 + maxDofs + 1 + d + k * (maxDofs + 1 + dim)];
-      // load interpolators
-      for (int j = i; j < dof1; j += elDof) l1[j] = d_shapeWnor1[offsetShape1 + j + k * (maxDofs + 1 + dim)];
-      for (int j = i; j < dof2; j += elDof) l2[j] = d_shape2[offsetShape2 + j + k * maxDofs];
-      MFEM_SYNC_THREAD;
-
-      // set to 0
-      for (int eq = i; eq < num_equation; eq += elDof) {
-        u1[eq] = 0.;
-        u2[eq] = 0.;
-      }
-      MFEM_SYNC_THREAD;
-
-      for (int eq = 0; eq < num_equation; eq++) {
-        if (swapElems) {
-          // load el1
-          for (int j = i; j < dof1; j += elDof) {
-            int index = index_j[j];
-            U1[j] = d_Up[index + eq * totalDofs];
+        for (int k = 0; k < Q; k++) {
+          // load interpolators
+          if (swapElems) {
+            shape = d_shape2 + offsetShape2 + k * maxDofs;
+          } else {
+            shape = d_shapeWnor1 + offsetShape1 + k * (maxDofs + 1 + dim);
           }
-          MFEM_SYNC_THREAD;
 
-          // load el2
-          for (int j = i; j < dof2; j += elDof) U2[j] = d_Up[indexi + eq * totalDofs];
-          MFEM_SYNC_THREAD;
-
-        } else {
-          // load data el1
-          for (int j = i; j < dof1; j += elDof) U1[j] = d_Up[indexi + eq * totalDofs];
-          MFEM_SYNC_THREAD;
-
-          // elem 2
-          for (int j = i; j < dof2; j += elDof) {
-            int index = index_j[j];
-            U2[j] = d_Up[index + eq * totalDofs];
+          for (int d = 0; d < dim; d++) {
+            for (int eq = 0; eq < num_equation; eq++) {
+              const int idxc = eq + k * num_equation + d * maxIntPoints * num_equation + gFace * dim * maxIntPoints * num_equation;
+              double contrib = d_dun[idxc];
+              const int ioff1 = eq * totalDofs + d * num_equation * totalDofs;
+              //const int ioff = eq * elDof + d * num_equation * elDof;
+              // gradUpi[i + ioff] += contrib * shape[i];
+              d_gradUp[idx + ioff1] += contrib * shape[i];
+            }
           }
-          MFEM_SYNC_THREAD;
         }
-
-        // interpolate el1
-        // NOTE: make parallel
-        if (i == 0) {
-          for (int j = 0; j < dof1; j++) u1[eq] += l1[j] * U1[j];
-        }
-        MFEM_SYNC_THREAD;
-
-        // interpolate el2
-        // NOTE: make parallel
-        if (i == 0) {
-          for (int j = 0; j < dof2; j++) u2[eq] += l2[j] * U2[j];
-        }
-        MFEM_SYNC_THREAD;
-
-        for (int d = 0; d < dim; d++) {
-          double contrib = weight * 0.5 * (u2[eq] - u1[eq]) * nor[d];
-          if (swapElems)
-            contrib *= l2[i];
-          else
-            contrib *= l1[i];
-
-          gradUpi[i + eq * elDof + d * num_equation * elDof] += contrib;
-        }
-      }  // end equation loop
-    }    // end loop over integration points
-
-    // global memory
-    for (int eq = 0; eq < num_equation; eq++) {
-      for (int d = 0; d < dim; d++) {
-        d_gradUp[indexi + eq * totalDofs + d * num_equation * totalDofs] =
-            gradUpi[i + eq * elDof + d * num_equation * elDof];
       }
     }
-      }
-}
-});
+
+    // // global memory
+    // for (int d = 0; d < dim; d++) {
+    //   for (int eq = 0; eq < num_equation; eq++) {
+    //     const int ioff1 = eq * totalDofs + d * num_equation * totalDofs;
+    //     const int ioff2 = eq * elDof + d * num_equation * elDof;
+    //     for (int i = 0; i < elDof; i++) {
+    //       int idx = d_nodesIDs[offsetIDs + i];
+    //       d_gradUp[idx + ioff1] = gradUpi[i + ioff2];
+    //     }
+    //   }
+    // }
+  });
 }
 
 void Gradients::integrationGradSharedFace_gpu(const Vector *Up, const Vector &faceUp, ParGridFunction *gradUp,

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -49,8 +49,8 @@ class Gradients : public ParNonlinearForm {
  private:
   ParFiniteElementSpace *vfes;
   ParFiniteElementSpace *gradUpfes;
-  const int dim;
-  const int num_equation;
+  const int dim_;
+  const int num_equation_;
 
   ParGridFunction *Up;
   ParGridFunction *gradUp;
@@ -64,6 +64,9 @@ class Gradients : public ParNonlinearForm {
   const int intRuleType;
 
   const volumeFaceIntegrationArrays &gpuArrays;
+  Vector uk_el1;
+  Vector uk_el2;
+  Vector dun_face;
 
   const int *h_numElems;
   const int *h_posDofIds;
@@ -74,8 +77,8 @@ class Gradients : public ParNonlinearForm {
   Vector &invMArray;
   Array<int> &posDofInvM;
 
-  const int &maxIntPoints;
-  const int &maxDofs;
+  const int &maxIntPoints_;
+  const int &maxDofs_;
 
   // gradients of shape functions for all nodes and weight multiplied by det(Jac)
   // at each integration point
@@ -112,10 +115,10 @@ class Gradients : public ParNonlinearForm {
                                    //                                    const Array<int> &elemPosQ_shapeDshapeWJ,
                                    const int &maxDofs, const int &maxIntPoints);
 
-  static void faceContrib_gpu(const int numElems, const int offsetElems, const int elDof, const int totalDofs,
-                              const Vector &Up, Vector &gradUp, const int num_equation, const int dim,
-                              const volumeFaceIntegrationArrays &gpuArrays, const int &maxDofs,
-                              const int &maxIntPoints);
+  void faceContrib_gpu(const int numElems, const int offsetElems, const int elDof, const int totalDofs,
+                       const Vector &Up, Vector &gradUp, const int num_equation, const int dim,
+                       const volumeFaceIntegrationArrays &gpuArrays, const int &maxDofs,
+                       const int &maxIntPoints);
 
   static void integrationGradSharedFace_gpu(const Vector *Up, const Vector &faceUp, ParGridFunction *gradUp,
                                             const int &Ndofs, const int &dim, const int &num_equation,
@@ -129,6 +132,9 @@ class Gradients : public ParNonlinearForm {
                               Vector &gradUp, const int num_equation, const int dim,
                               const volumeFaceIntegrationArrays &gpuArrays, const Vector &invMArray,
                               const Array<int> &posDofInvM);
+
+  void interpFaceData_gpu(const Vector &x, int elType, int elemOffset, int elDof);
+  void evalFaceIntegrand_gpu();
 #endif
 };
 

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -74,6 +74,9 @@ class Gradients : public ParNonlinearForm {
   // DenseMatrix *Me_inv;
   Array<DenseMatrix *> &Me_inv;
   Array<DenseMatrix *> Ke;
+  Vector Ke_array_;
+  Array<int> Ke_positions_;
+
   Vector &invMArray;
   Array<int> &posDofInvM;
 
@@ -108,12 +111,12 @@ class Gradients : public ParNonlinearForm {
   void computeGradients_domain();
   void computeGradients_bdr();
 
-  static void computeGradients_gpu(const int numElems, const int offsetElems, const int elDof, const int totalDofs,
-                                   const Vector &Up, Vector &gradUp, const int num_equation, const int dim,
-                                   const volumeFaceIntegrationArrays &gpuArrays,
-                                   //                                    const Vector &elemShapeDshapeWJ,
-                                   //                                    const Array<int> &elemPosQ_shapeDshapeWJ,
-                                   const int &maxDofs, const int &maxIntPoints);
+  void computeGradients_gpu(const int numElems, const int offsetElems, const int elDof, const int totalDofs,
+                            const Vector &Up, Vector &gradUp, const int num_equation, const int dim,
+                            const volumeFaceIntegrationArrays &gpuArrays,
+                            //                                    const Vector &elemShapeDshapeWJ,
+                            //                                    const Array<int> &elemPosQ_shapeDshapeWJ,
+                            const int &maxDofs, const int &maxIntPoints);
 
   void faceContrib_gpu(const int numElems, const int offsetElems, const int elDof, const int totalDofs,
                        const Vector &Up, Vector &gradUp, const int num_equation, const int dim,

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -111,17 +111,9 @@ class Gradients : public ParNonlinearForm {
   void computeGradients_domain();
   void computeGradients_bdr();
 
-  void computeGradients_gpu(const int numElems, const int offsetElems, const int elDof, const int totalDofs,
-                            const Vector &Up, Vector &gradUp, const int num_equation, const int dim,
-                            const volumeFaceIntegrationArrays &gpuArrays,
-                            //                                    const Vector &elemShapeDshapeWJ,
-                            //                                    const Array<int> &elemPosQ_shapeDshapeWJ,
-                            const int &maxDofs, const int &maxIntPoints);
+  void computeGradients_gpu(const int elType, const int offsetElems, const int elDof);
 
-  void faceContrib_gpu(const int numElems, const int offsetElems, const int elDof, const int totalDofs,
-                       const Vector &Up, Vector &gradUp, const int num_equation, const int dim,
-                       const volumeFaceIntegrationArrays &gpuArrays, const int &maxDofs,
-                       const int &maxIntPoints);
+  void faceContrib_gpu(const int elType, const int offsetElems, const int elDof);
 
   static void integrationGradSharedFace_gpu(const Vector *Up, const Vector &faceUp, ParGridFunction *gradUp,
                                             const int &Ndofs, const int &dim, const int &num_equation,

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -764,9 +764,9 @@ void InletBC::integrateInlets_gpu(const InletType type, const Vector &inputState
 
   MFEM_FORALL(n, numBdrElem,
   {
-    double Fcontrib[216 * 20];
+    double Fcontrib[216 * 5];
     double shape[216];
-    double Rflux[20], u1[20], u2[20], nor[3];
+    double Rflux[5], u1[5], u2[5], nor[3];
     double weight;
 
     const int el = d_listElems[n];
@@ -795,8 +795,6 @@ void InletBC::integrateInlets_gpu(const InletType type, const Vector &inputState
       switch (type) {
       case InletType::SUB_DENS_VEL:
         computeSubDenseVel_gpu_serial(&u1[0], &u2[0], &nor[0], d_inputState, gamma, Rg, dim, num_equation, fluid);
-        // computeSubDenseVel(&u1[0], &u2[0], &nor[0], d_inputState, gamma, Rg, dim, num_equation, fluid, eqSystem, i,
-        //                    maxDofs);
         break;
       case InletType::SUB_DENS_VEL_NR:
         printf("INLET BC NOT IMPLEMENTED");

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -762,8 +762,7 @@ void InletBC::integrateInlets_gpu(const InletType type, const Vector &inputState
 
   const WorkingFluid fluid = mixture->GetWorkingFluid();
 
-  MFEM_FORALL(n, numBdrElem,
-  {
+  MFEM_FORALL(n, numBdrElem, {
     double Fcontrib[216 * 5];
     double shape[216];
     double Rflux[5], u1[5], u2[5], nor[3];
@@ -771,17 +770,16 @@ void InletBC::integrateInlets_gpu(const InletType type, const Vector &inputState
 
     const int el = d_listElems[n];
     const int offsetBdrU = d_offsetBoundaryU[n];
-    const int Q    = d_intPointsElIDBC[2 * el  ];
+    const int Q = d_intPointsElIDBC[2 * el];
     const int elID = d_intPointsElIDBC[2 * el + 1];
-    const int elOffset = d_posDofIds[2 * elID  ];
-    const int elDof    = d_posDofIds[2 * elID + 1];
+    const int elOffset = d_posDofIds[2 * elID];
+    const int elDof = d_posDofIds[2 * elID + 1];
 
     for (int i = 0; i < elDof; i++) {
       for (int eq = 0; eq < num_equation; eq++) Fcontrib[i + eq * elDof] = 0.;
     }
 
     for (int q = 0; q < Q; q++) {  // loop over int. points
-
       for (int i = 0; i < elDof; i++) shape[i] = d_shapesBC[i + q * maxDofs + el * maxIntPoints * maxDofs];
       for (int d = 0; d < dim; d++) nor[d] = d_normW[d + q * (dim + 1) + el * maxIntPoints * (dim + 1)];
       weight = d_normW[dim + q * (dim + 1) + el * maxIntPoints * (dim + 1)];
@@ -793,15 +791,15 @@ void InletBC::integrateInlets_gpu(const InletType type, const Vector &inputState
 
       // compute mirror state
       switch (type) {
-      case InletType::SUB_DENS_VEL:
-        computeSubDenseVel_gpu_serial(&u1[0], &u2[0], &nor[0], d_inputState, gamma, Rg, dim, num_equation, fluid);
-        break;
-      case InletType::SUB_DENS_VEL_NR:
-        printf("INLET BC NOT IMPLEMENTED");
-        break;
-      case InletType::SUB_VEL_CONST_ENT:
-        printf("INLET BC NOT IMPLEMENTED");
-        break;
+        case InletType::SUB_DENS_VEL:
+          computeSubDenseVel_gpu_serial(&u1[0], &u2[0], &nor[0], d_inputState, gamma, Rg, dim, num_equation, fluid);
+          break;
+        case InletType::SUB_DENS_VEL_NR:
+          printf("INLET BC NOT IMPLEMENTED");
+          break;
+        case InletType::SUB_VEL_CONST_ENT:
+          printf("INLET BC NOT IMPLEMENTED");
+          break;
       }
 
       // compute flux
@@ -843,19 +841,18 @@ void InletBC::interpInlet_gpu(const InletType type, const mfem::Vector &inputSta
   const int totDofs = x.Size() / num_equation;
   const int numBdrElem = listElems.Size();
 
-  MFEM_FORALL(n, numBdrElem,
-  {
+  MFEM_FORALL(n, numBdrElem, {
     double Ui[216];
     double shape[216];
     double u1;
 
     const int el = d_listElems[n];
-    const int Q    = d_intPointsElIDBC[2 * el  ];
+    const int Q = d_intPointsElIDBC[2 * el];
     const int elID = d_intPointsElIDBC[2 * el + 1];
-    const int elOffset = d_posDofIds[2 * elID  ];
-    const int elDof    = d_posDofIds[2 * elID + 1];
+    const int elOffset = d_posDofIds[2 * elID];
+    const int elDof = d_posDofIds[2 * elID + 1];
 
-    for ( int eq = 0; eq < num_equation; eq++ ) {
+    for (int eq = 0; eq < num_equation; eq++) {
       // get data
       for (int i = 0; i < elDof; i++) {
         const int indexi = d_nodesIDs[elOffset + i];
@@ -872,8 +869,8 @@ void InletBC::interpInlet_gpu(const InletType type, const mfem::Vector &inputSta
 
         // save to global memory
         d_interpUbdr[eq + q * num_equation + n * maxIntPoints * num_equation] = u1;
-      }    // end loop over intergration points
-    }  // end loop over equations
+      }  // end loop over intergration points
+    }    // end loop over equations
   });
 #endif
 }

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -762,44 +762,41 @@ void InletBC::integrateInlets_gpu(const InletType type, const Vector &inputState
 
   const WorkingFluid fluid = mixture->GetWorkingFluid();
 
-  MFEM_FORALL_2D(n, numBdrElem, maxDofs, 1, 1, {     // NOLINT
-    MFEM_FOREACH_THREAD(i, x, maxDofs) {             // NOLINT
-      //
-      MFEM_SHARED double Fcontrib[216 * 20];
-      MFEM_SHARED double shape[216];
-      MFEM_SHARED double Rflux[20], u1[20], u2[20], nor[3];
-      MFEM_SHARED double weight;
+  MFEM_FORALL(n, numBdrElem,
+  {
+    double Fcontrib[216 * 20];
+    double shape[216];
+    double Rflux[20], u1[20], u2[20], nor[3];
+    double weight;
 
-      const int el = d_listElems[n];
-      const int offsetBdrU = d_offsetBoundaryU[n];
-      const int Q    = d_intPointsElIDBC[2 * el  ];
-      const int elID = d_intPointsElIDBC[2 * el + 1];
-      const int elOffset = d_posDofIds[2 * elID  ];
-      const int elDof    = d_posDofIds[2 * elID + 1];
-      int indexi;
-      if (i < elDof) {
-    indexi = d_nodesIDs[elOffset + i];
-    for (int eq = 0; eq < num_equation; eq++) Fcontrib[i + eq * elDof] = 0.;
+    const int el = d_listElems[n];
+    const int offsetBdrU = d_offsetBoundaryU[n];
+    const int Q    = d_intPointsElIDBC[2 * el  ];
+    const int elID = d_intPointsElIDBC[2 * el + 1];
+    const int elOffset = d_posDofIds[2 * elID  ];
+    const int elDof    = d_posDofIds[2 * elID + 1];
+
+    for (int i = 0; i < elDof; i++) {
+      for (int eq = 0; eq < num_equation; eq++) Fcontrib[i + eq * elDof] = 0.;
+    }
+
+    for (int q = 0; q < Q; q++) {  // loop over int. points
+
+      for (int i = 0; i < elDof; i++) shape[i] = d_shapesBC[i + q * maxDofs + el * maxIntPoints * maxDofs];
+      for (int d = 0; d < dim; d++) nor[d] = d_normW[d + q * (dim + 1) + el * maxIntPoints * (dim + 1)];
+      weight = d_normW[dim + q * (dim + 1) + el * maxIntPoints * (dim + 1)];
+
+      // get interpolated data
+      for (int eq = 0; eq < num_equation; eq++) {
+        u1[eq] = d_interpUbdr[eq + q * num_equation + n * maxIntPoints * num_equation];
       }
 
-      for (int q = 0; q < Q; q++) {  // loop over int. points
-    if (i < elDof) shape[i] = d_shapesBC[i + q * maxDofs + el * maxIntPoints * maxDofs];
-    if (i < dim) nor[i] = d_normW[i + q * (dim + 1) + el * maxIntPoints * (dim + 1)];
-    if (dim == 2 && i == maxDofs - 2) nor[2] = 0.;
-    if (i == maxDofs - 1) weight = d_normW[dim + q * (dim + 1) + el * maxIntPoints * (dim + 1)];
-    MFEM_SYNC_THREAD;
-
-    // get interpolated data
-    if (i < num_equation) {
-      u1[i] = d_interpUbdr[i + q * num_equation + n * maxIntPoints * num_equation];
-    }
-    MFEM_SYNC_THREAD;
-
-    // compute mirror state
-    switch (type) {
+      // compute mirror state
+      switch (type) {
       case InletType::SUB_DENS_VEL:
-        computeSubDenseVel(&u1[0], &u2[0], &nor[0], d_inputState, gamma, Rg, dim, num_equation, fluid, eqSystem, i,
-                           maxDofs);
+        computeSubDenseVel_gpu_serial(&u1[0], &u2[0], &nor[0], d_inputState, gamma, Rg, dim, num_equation, fluid);
+        // computeSubDenseVel(&u1[0], &u2[0], &nor[0], d_inputState, gamma, Rg, dim, num_equation, fluid, eqSystem, i,
+        //                    maxDofs);
         break;
       case InletType::SUB_DENS_VEL_NR:
         printf("INLET BC NOT IMPLEMENTED");
@@ -807,25 +804,23 @@ void InletBC::integrateInlets_gpu(const InletType type, const Vector &inputState
       case InletType::SUB_VEL_CONST_ENT:
         printf("INLET BC NOT IMPLEMENTED");
         break;
-    }
-    MFEM_SYNC_THREAD;
+      }
 
-    // compute flux
-    RiemannSolver::riemannLF_gpu(&u1[0], &u2[0], &Rflux[0], &nor[0], gamma, Rg, dim, eqSystem, num_equation, i,
-                                 maxDofs);
-    MFEM_SYNC_THREAD;
-    // sum contributions to integral
-    if (i < elDof) {
-      for (int eq = 0; eq < num_equation; eq++) Fcontrib[i + eq * elDof] -= Rflux[eq] * shape[i] * weight;
+      // compute flux
+      RiemannSolver::riemannLF_serial_gpu(&u1[0], &u2[0], &Rflux[0], &nor[0], gamma, Rg, dim, num_equation);
+
+      // sum contributions to integral
+      for (int i = 0; i < elDof; i++) {
+        for (int eq = 0; eq < num_equation; eq++) Fcontrib[i + eq * elDof] -= Rflux[eq] * shape[i] * weight;
+      }
     }
-    MFEM_SYNC_THREAD;
-      }
-      // add to global data
-      if (i < elDof) {
-    for (int eq = 0; eq < num_equation; eq++) d_y[indexi + eq * totDofs] += Fcontrib[i + eq * elDof];
-      }
-}
-});
+
+    // add to global data
+    for (int i = 0; i < elDof; i++) {
+      const int indexi = d_nodesIDs[elOffset + i];
+      for (int eq = 0; eq < num_equation; eq++) d_y[indexi + eq * totDofs] += Fcontrib[i + eq * elDof];
+    }
+  });
 #endif
 }
 
@@ -850,45 +845,37 @@ void InletBC::interpInlet_gpu(const InletType type, const mfem::Vector &inputSta
   const int totDofs = x.Size() / num_equation;
   const int numBdrElem = listElems.Size();
 
-  MFEM_FORALL_2D(n, numBdrElem, maxDofs, 1, 1, {     // NOLINT
-    MFEM_FOREACH_THREAD(i, x, maxDofs) {             // NOLINT
-      //
-      MFEM_SHARED double Ui[216];
-      MFEM_SHARED double shape[216];
-      MFEM_SHARED double u1;
+  MFEM_FORALL(n, numBdrElem,
+  {
+    double Ui[216];
+    double shape[216];
+    double u1;
 
-      const int el = d_listElems[n];
-      const int Q    = d_intPointsElIDBC[2 * el  ];
-      const int elID = d_intPointsElIDBC[2 * el + 1];
-      const int elOffset = d_posDofIds[2 * elID  ];
-      const int elDof    = d_posDofIds[2 * elID + 1];
-      int indexi;
-      if (i < elDof)
-        indexi = d_nodesIDs[elOffset + i];
+    const int el = d_listElems[n];
+    const int Q    = d_intPointsElIDBC[2 * el  ];
+    const int elID = d_intPointsElIDBC[2 * el + 1];
+    const int elOffset = d_posDofIds[2 * elID  ];
+    const int elDof    = d_posDofIds[2 * elID + 1];
 
-      for ( int eq = 0; eq < num_equation; eq++ ) {
-    // get data
-    if (i < elDof) Ui[i] = d_U[indexi + eq * totDofs];
-    MFEM_SYNC_THREAD;
-
-    for (int q = 0; q < Q; q++) {
-      if (i < elDof) shape[i] = d_shapesBC[i + q * maxDofs + el * maxIntPoints * maxDofs];
-      MFEM_SYNC_THREAD;
-
-      u1 = 0.;
-      // interpolation
-      // NOTE: make parallel!
-      if (i == 0) {
-        for (int j = 0; j < elDof; j++) u1 += shape[j] * Ui[j];
+    for ( int eq = 0; eq < num_equation; eq++ ) {
+      // get data
+      for (int i = 0; i < elDof; i++) {
+        const int indexi = d_nodesIDs[elOffset + i];
+        Ui[i] = d_U[indexi + eq * totDofs];
       }
-      MFEM_SYNC_THREAD;
 
-      // save to global memory
-      if (i == 0) d_interpUbdr[eq + q * num_equation + n * maxIntPoints * num_equation] = u1;
-      MFEM_SYNC_THREAD;
-    }    // end loop over intergration points
-      }  // end loop over equations
-}
-});
+      for (int q = 0; q < Q; q++) {
+        for (int i = 0; i < elDof; i++) {
+          shape[i] = d_shapesBC[i + q * maxDofs + el * maxIntPoints * maxDofs];
+        }
+
+        u1 = 0.;
+        for (int j = 0; j < elDof; j++) u1 += shape[j] * Ui[j];
+
+        // save to global memory
+        d_interpUbdr[eq + q * num_equation + n * maxIntPoints * num_equation] = u1;
+      }    // end loop over intergration points
+    }  // end loop over equations
+  });
 #endif
 }

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -156,8 +156,9 @@ class InletBC : public BoundaryCondition {
   }
 
   static MFEM_HOST_DEVICE void computeSubDenseVel_gpu_serial(const double *u1, double *u2, const double *nor,
-                                                             const double *inputState, const double &gamma, const double &Rg,
-                                                             const int &dim, const int &num_equation, const WorkingFluid &fluid) {
+                                                             const double *inputState, const double &gamma,
+                                                             const double &Rg, const int &dim, const int &num_equation,
+                                                             const WorkingFluid &fluid) {
     // assumes there at least as many threads as number of equations
     double KE[3];
     double p;

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -398,8 +398,7 @@ void OutletBC::updateMean_gpu(ParGridFunction *Up, Vector &localMeanUp, const in
     // }
   });
 
-  MFEM_FORALL(eq, num_equation,
-  {
+  MFEM_FORALL(eq, num_equation, {
     // serial sum (for each eq)
     for (int el = 1; el < numBdrElems; el++) {
       d_bdrUp[eq] += d_bdrUp[eq + el * num_equation * maxIntPoints];
@@ -1145,7 +1144,7 @@ void OutletBC::integrateOutlets_gpu(const OutletType type, Equations &eqSystem, 
     }
   });  // end MFEM_FORALL_2D
 #endif
-// clang-format on
+  // clang-format on
 }
 
 void OutletBC::interpOutlet_gpu(const OutletType type, const mfem::Array<double> &inputState,
@@ -1172,21 +1171,19 @@ void OutletBC::interpOutlet_gpu(const OutletType type, const mfem::Array<double>
   const int totDofs = x.Size() / num_equation;
   const int numBdrElem = listElems.Size();
 
-  MFEM_FORALL(n, numBdrElem,
-  {
+  MFEM_FORALL(n, numBdrElem, {
     //
-    double Ui[216], gradUpi[216*3];
+    double Ui[216], gradUpi[216 * 3];
     double shape[216];
     double u1, gUp[3];
 
     const int el = d_listElems[n];
-    const int Q    = d_intPointsElIDBC[2 * el  ];
+    const int Q = d_intPointsElIDBC[2 * el];
     const int elID = d_intPointsElIDBC[2 * el + 1];
-    const int elOffset = d_posDofIds[2 * elID  ];
-    const int elDof    = d_posDofIds[2 * elID + 1];
+    const int elOffset = d_posDofIds[2 * elID];
+    const int elDof = d_posDofIds[2 * elID + 1];
 
-    for ( int eq = 0; eq < num_equation; eq++ ) {
-
+    for (int eq = 0; eq < num_equation; eq++) {
       // get data
       for (int i = 0; i < elDof; i++) {
         const int indexi = d_nodesIDs[elOffset + i];
@@ -1211,10 +1208,11 @@ void OutletBC::interpOutlet_gpu(const OutletType type, const mfem::Array<double>
         d_interpUbdr[eq + q * num_equation + n * maxIntPoints * num_equation] = u1;
 
         for (int d = 0; d < dim; d++) {
-          d_interpGrads[eq + d * num_equation + q * dim * num_equation + n * maxIntPoints * dim * num_equation] = gUp[d];
+          d_interpGrads[eq + d * num_equation + q * dim * num_equation + n * maxIntPoints * dim * num_equation] =
+              gUp[d];
         }
-      }    // end loop over intergration points
-    }  // end loop over equations
+      }  // end loop over intergration points
+    }    // end loop over equations
   });
 #endif
 }

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -156,9 +156,10 @@ class OutletBC : public BoundaryCondition {
     //     }
   }
 
-  static MFEM_HOST_DEVICE void computeSubPressure_gpu_serial(const double *u1, double *u2, const double *nor, const double &press,
-                                                             const double &gamma, const double &Rg, const int &dim,
-                                                             const int &num_equation, const WorkingFluid &fluid) {
+  static MFEM_HOST_DEVICE void computeSubPressure_gpu_serial(const double *u1, double *u2, const double *nor,
+                                                             const double &press, const double &gamma, const double &Rg,
+                                                             const int &dim, const int &num_equation,
+                                                             const WorkingFluid &fluid) {
     if (fluid == WorkingFluid::DRY_AIR) {
       DryAir::modifyEnergyForPressure_gpu_serial(u1, u2, press, gamma, Rg, num_equation, dim);
     }
@@ -319,12 +320,11 @@ class OutletBC : public BoundaryCondition {
     if (thrd < num_equation) boundaryU[thrd + n * num_equation] = newU[thrd];
   }
 
-  static MFEM_HOST_DEVICE void computeNRSubPress_serial(const int &n, const double *u1, const double *gradUp,
-                                                        const double *meanUp, const double &dt, double *u2, double *boundaryU,
-                                                        const double *inputState, const double *nor, const double *d_tang1,
-                                                        const double *d_tang2, const double *d_inv, const double &refLength,
-                                                        const double &gamma, const double &Rg, const int &elDof,
-                                                        const int &dim, const int &num_equation, const Equations &eqSystem) {
+  static MFEM_HOST_DEVICE void computeNRSubPress_serial(
+      const int &n, const double *u1, const double *gradUp, const double *meanUp, const double &dt, double *u2,
+      double *boundaryU, const double *inputState, const double *nor, const double *d_tang1, const double *d_tang2,
+      const double *d_inv, const double &refLength, const double &gamma, const double &Rg, const int &elDof,
+      const int &dim, const int &num_equation, const Equations &eqSystem) {
     double unitNorm[3], meanVel[3], normGrad[20];
     double mod;
     double speedSound, meanK, dpdn;
@@ -345,8 +345,7 @@ class OutletBC : public BoundaryCondition {
     for (int d = 0; d < dim; d++) {
       meanVel[0] += unitNorm[d] * meanUp[d + 1];
       meanVel[1] += d_tang1[d] * meanUp[d + 1];
-      if (dim == 3)
-        meanVel[2] += d_tang2[d] * meanUp[d + 1];
+      if (dim == 3) meanVel[2] += d_tang2[d] * meanUp[d + 1];
     }
 
     for (int eq = 0; eq < num_equation; eq++) {
@@ -590,11 +589,10 @@ class OutletBC : public BoundaryCondition {
   }
 
   static MFEM_HOST_DEVICE void computeNRSubMassFlow_serial(
-     const int &n, const double *u1, const double *gradUp, const double *meanUp, const double &dt,
-      double *u2, double *boundaryU, const double *inputState, const double *nor, const double *d_tang1,
-      const double *d_tang2, const double *d_inv, const double &refLength, const double &area, const double &gamma,
-      const double &Rg, const int &elDof, const int &dim, const int &num_equation, const Equations &eqSystem) {
-
+      const int &n, const double *u1, const double *gradUp, const double *meanUp, const double &dt, double *u2,
+      double *boundaryU, const double *inputState, const double *nor, const double *d_tang1, const double *d_tang2,
+      const double *d_inv, const double &refLength, const double &area, const double &gamma, const double &Rg,
+      const int &elDof, const int &dim, const int &num_equation, const Equations &eqSystem) {
     double unitNorm[3], meanVel[3], normGrad[20];
     double mod;
     double speedSound, meanK, dpdn;
@@ -647,7 +645,6 @@ class OutletBC : public BoundaryCondition {
       L4 *= meanVel[0];
     }
 
-
     L5 = 0.;
     for (int d = 0; d < dim; d++) L5 += unitNorm[d] * normGrad[1 + d];
     L5 = dpdn + meanUp[0] * speedSound * L5;
@@ -661,7 +658,6 @@ class OutletBC : public BoundaryCondition {
     const double sigma = speedSound / refLength;
     L1 = -sigma * (meanVel[0] - inputState[0] / meanUp[0] / area);
     L1 *= meanUp[0] * speedSound;
-
 
     d1 = (L2 + 0.5 * (L5 + L1)) / speedSound / speedSound;
     d2 = 0.5 * (L5 - L1) / meanUp[0] / speedSound;
@@ -708,7 +704,6 @@ class OutletBC : public BoundaryCondition {
         sum[i] += d_inv[i + j * dim] * newU[1 + j];
       }
     }
-
 
     for (int d = 0; d < dim; d++) {
       newU[d + 1] = sum[d];

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -552,8 +552,7 @@ void RHSoperator::updatePrimitives_gpu(Vector *Up, const Vector *x_in, const dou
   auto dataUp = Up->Write();   // make sure data is available in GPU
   auto dataIn = x_in->Read();  // make sure data is available in GPU
 
-  MFEM_FORALL(n, ndofs,
-  {
+  MFEM_FORALL(n, ndofs, {
     double state[20];  // assuming 20 equations
     // MFEM_SHARED double p;
     double KE[3];
@@ -572,8 +571,7 @@ void RHSoperator::updatePrimitives_gpu(Vector *Up, const Vector *x_in, const dou
     dataUp[n + 2 * ndofs] = state[2] / state[0];
     if (dim == 3) dataUp[n + 3 * ndofs] = state[3] / state[0];
     dataUp[n + (1 + dim) * ndofs] = DryAir::temperature(&state[0], &KE[0], gamma, Rgas, dim, num_equation);
-    if (eqSystem == NS_PASSIVE)
-      dataUp[n + (num_equation - 1) * ndofs] = state[num_equation - 1] / state[0];
+    if (eqSystem == NS_PASSIVE) dataUp[n + (num_equation - 1) * ndofs] = state[num_equation - 1] / state[0];
   });
 
   // MFEM_FORALL_2D(n, ndofs, num_equation, 1, 1, {
@@ -616,8 +614,7 @@ void RHSoperator::multiPlyInvers_gpu(Vector &y, Vector &z, const volumeFaceInteg
   auto d_posDofInvM = posDofInvM.Read();
   const double *d_invM = invMArray.Read();
 
-  MFEM_FORALL_2D(el, NE, dof, 1, 1,
-  {
+  MFEM_FORALL_2D(el, NE, dof, 1, 1, {
     MFEM_SHARED double data[216 * 20];
 
     int eli = el + elemOffset;

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -552,31 +552,56 @@ void RHSoperator::updatePrimitives_gpu(Vector *Up, const Vector *x_in, const dou
   auto dataUp = Up->Write();   // make sure data is available in GPU
   auto dataIn = x_in->Read();  // make sure data is available in GPU
 
-  MFEM_FORALL_2D(n, ndofs, num_equation, 1, 1, {
-    MFEM_SHARED double state[20];  // assuming 20 equations
+  MFEM_FORALL(n, ndofs,
+  {
+    double state[20];  // assuming 20 equations
     // MFEM_SHARED double p;
-    MFEM_SHARED double KE[3];
+    double KE[3];
 
-    MFEM_FOREACH_THREAD(eq, x, num_equation) {
+    for (int eq = 0; eq < num_equation; eq++) {
       state[eq] = dataIn[n + eq * ndofs];  // loads data into shared memory
-      MFEM_SYNC_THREAD;
-
-      // compute temperature
-      if (eq < dim) KE[eq] = 0.5 * state[1 + eq] * state[1 + eq] / state[0];
-      if (eq == num_equation - 1 && dim == 2) KE[2] = 0;
-      MFEM_SYNC_THREAD;
-
-      // each thread writes to global memory
-      if (eq == 0) dataUp[n] = state[0];
-      if (eq == 1) dataUp[n + ndofs] = state[1] / state[0];
-      if (eq == 2) dataUp[n + 2 * ndofs] = state[2] / state[0];
-      if (eq == 3 && dim == 3) dataUp[n + 3 * ndofs] = state[3] / state[0];
-      if (eq == 1 + dim)
-        dataUp[n + (1 + dim) * ndofs] = DryAir::temperature(&state[0], &KE[0], gamma, Rgas, dim, num_equation);
-      if (eq == num_equation - 1 && eqSystem == NS_PASSIVE)
-        dataUp[n + (num_equation - 1) * ndofs] = state[num_equation - 1] / state[0];
     }
+
+    for (int d = 0; d < dim; d++) {
+      KE[d] = 0.5 * state[1 + d] * state[1 + d] / state[0];
+    }
+    if (dim == 2) KE[2] = 0;
+
+    dataUp[n] = state[0];
+    dataUp[n + ndofs] = state[1] / state[0];
+    dataUp[n + 2 * ndofs] = state[2] / state[0];
+    if (dim == 3) dataUp[n + 3 * ndofs] = state[3] / state[0];
+    dataUp[n + (1 + dim) * ndofs] = DryAir::temperature(&state[0], &KE[0], gamma, Rgas, dim, num_equation);
+    if (eqSystem == NS_PASSIVE)
+      dataUp[n + (num_equation - 1) * ndofs] = state[num_equation - 1] / state[0];
   });
+
+  // MFEM_FORALL_2D(n, ndofs, num_equation, 1, 1, {
+  //   MFEM_SHARED double state[20];  // assuming 20 equations
+  //   // MFEM_SHARED double p;
+  //   MFEM_SHARED double KE[3];
+
+  //   MFEM_FOREACH_THREAD(eq, x, num_equation) {
+  //     state[eq] = dataIn[n + eq * ndofs];  // loads data into shared memory
+  //     MFEM_SYNC_THREAD;
+
+  //     // compute temperature
+  //     if (eq < dim) KE[eq] = 0.5 * state[1 + eq] * state[1 + eq] / state[0];
+  //     if (eq == num_equation - 1 && dim == 2) KE[2] = 0;
+  //     MFEM_SYNC_THREAD;
+
+  //     // each thread writes to global memory
+  //     if (eq == 0) dataUp[n] = state[0];
+  //     if (eq == 1) dataUp[n + ndofs] = state[1] / state[0];
+  //     if (eq == 2) dataUp[n + 2 * ndofs] = state[2] / state[0];
+  //     if (eq == 3 && dim == 3) dataUp[n + 3 * ndofs] = state[3] / state[0];
+  //     if (eq == 1 + dim)
+  //       dataUp[n + (1 + dim) * ndofs] = DryAir::temperature(&state[0], &KE[0], gamma, Rgas, dim, num_equation);
+  //     if (eq == num_equation - 1 && eqSystem == NS_PASSIVE)
+  //       dataUp[n + (num_equation - 1) * ndofs] = state[num_equation - 1] / state[0];
+  //   }
+  // });
+
 #endif
 }
 
@@ -591,28 +616,55 @@ void RHSoperator::multiPlyInvers_gpu(Vector &y, Vector &z, const volumeFaceInteg
   auto d_posDofInvM = posDofInvM.Read();
   const double *d_invM = invMArray.Read();
 
-  MFEM_FORALL_2D(el, NE, dof, 1, 1, {
-    MFEM_FOREACH_THREAD(i, x, dof) {
-      MFEM_SHARED double data[216 * 20];
+  //MFEM_FORALL_2D(el, NE, dof, 1, 1,
+  MFEM_FORALL(el, NE,
+  {
+    double data[216 * 20];
 
-      int eli = el + elemOffset;
-      int offsetInv = d_posDofInvM[2 * eli];
-      int offsetIds = d_posDofIds[2 * eli];
+    int eli = el + elemOffset;
+    int offsetInv = d_posDofInvM[2 * eli];
+    int offsetIds = d_posDofIds[2 * eli];
 
+    for (int i = 0; i < dof; i++) {
       int index = d_nodesIDs[offsetIds + i];
-
       for (int eq = 0; eq < num_equation; eq++) {
-    data[i + eq * dof] = d_z[index + eq * totNumDof];
+        data[i + eq * dof] = d_z[index + eq * totNumDof];
       }
-      MFEM_SYNC_THREAD;
+    }
 
+    for (int i = 0; i < dof; i++) {
+      int index = d_nodesIDs[offsetIds + i];
       for (int eq = 0; eq < num_equation; eq++) {
-    double tmp = 0.;
-    for (int k = 0; k < dof; k++) tmp += d_invM[offsetInv + i * dof + k] * data[k + eq * dof];
-    d_y[index + eq * totNumDof] = tmp;
+        double tmp = 0.;
+        for (int k = 0; k < dof; k++) tmp += d_invM[offsetInv + i * dof + k] * data[k + eq * dof];
+        d_y[index + eq * totNumDof] = tmp;
       }
-}
-});
+    }
+  });
+
+  //   MFEM_FORALL_2D(el, NE, dof, 1, 1,
+  // {
+  //   MFEM_FOREACH_THREAD(i, x, dof) {
+  //     MFEM_SHARED double data[216 * 20];
+
+  //     int eli = el + elemOffset;
+  //     int offsetInv = d_posDofInvM[2 * eli];
+  //     int offsetIds = d_posDofIds[2 * eli];
+
+  //     int index = d_nodesIDs[offsetIds + i];
+
+  //     for (int eq = 0; eq < num_equation; eq++) {
+  //       data[i + eq * dof] = d_z[index + eq * totNumDof];
+  //     }
+  //     MFEM_SYNC_THREAD;
+
+  //     for (int eq = 0; eq < num_equation; eq++) {
+  //       double tmp = 0.;
+  //       for (int k = 0; k < dof; k++) tmp += d_invM[offsetInv + i * dof + k] * data[k + eq * dof];
+  //       d_y[index + eq * totNumDof] = tmp;
+  //     }
+  //   }
+  // });
 
 //   MFEM_FORALL_2D(el,NE,dof,1,1,
 //   {

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -352,10 +352,14 @@ void WallBC::integrateWalls_gpu(const WallType type, const double &wallTemp, Vec
   // clang-format on
   MFEM_FORALL(el_wall, wallElems.Size() / 7,
   {
-    double Fcontrib[216 * 20];
+    // double Fcontrib[216 * 20];
+    // double shape[216];
+    // double Rflux[20], u1[20], u2[20], nor[3], gradUpi[20 * 3];
+    // double vF1[20 * 3], vF2[20 * 3];
+    double Fcontrib[216 * 5];
     double shape[216];
-    double Rflux[20], u1[20], u2[20], nor[3], gradUpi[20 * 3];
-    double vF1[20 * 3], vF2[20 * 3];
+    double Rflux[5], u1[5], u2[5], nor[3], gradUpi[5 * 3];
+    double vF1[5 * 3], vF2[5 * 3];
     double weight;
 
     const int numFaces = d_wallElems[0 + el_wall * 7];

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -350,104 +350,89 @@ void WallBC::integrateWalls_gpu(const WallType type, const double &wallTemp, Vec
   const WorkingFluid fluid = mixture->GetWorkingFluid();
 
   // clang-format on
-  MFEM_FORALL_2D(el, wallElems.Size() / 7, maxDofs, 1, 1, {
-    MFEM_FOREACH_THREAD(i, x, maxDofs) {
-      MFEM_SHARED double Fcontrib[216 * 20];
-      MFEM_SHARED double shape[216];
-      MFEM_SHARED double Rflux[20], u1[20], u2[20], nor[3], gradUpi[20 * 3];
-      MFEM_SHARED double vF1[20 * 3], vF2[20 * 3];
-      MFEM_SHARED double weight;
+  MFEM_FORALL(el_wall, wallElems.Size() / 7,
+  {
+    double Fcontrib[216 * 20];
+    double shape[216];
+    double Rflux[20], u1[20], u2[20], nor[3], gradUpi[20 * 3];
+    double vF1[20 * 3], vF2[20 * 3];
+    double weight;
 
-      const int numFaces = d_wallElems[0 + el * 7];
-      bool elemDataRecovered = false;
-      int elOffset;
-      int elDof;
-      int elID;
-      int indexi;
+    const int numFaces = d_wallElems[0 + el_wall * 7];
+    bool elemDataRecovered = false;
+    int elOffset = 0;
+    int elDof = 0;
+    int el = 0;
 
-      for (int f = 0; f < numFaces; f++) {
-    const int n = d_wallElems[1 + f + el * 7];
+    for (int f = 0; f < numFaces; f++) {
+      const int n = d_wallElems[1 + f + el_wall * 7];
 
-    const int el = d_listElems[n];
-    const int Q = d_intPointsElIDBC[2 * el];
+      const int el_bdry = d_listElems[n];
+      const int Q = d_intPointsElIDBC[2 * el_bdry];
 
-    if (!elemDataRecovered) {
-      elID = d_intPointsElIDBC[2 * el + 1];
+      if (!elemDataRecovered) {
+        el = d_intPointsElIDBC[2 * el_bdry + 1];
 
-      elOffset = d_posDofIds[2 * elID];
-      elDof = d_posDofIds[2 * elID + 1];
+        elOffset = d_posDofIds[2 * el];
+        elDof = d_posDofIds[2 * el + 1];
 
-      if (i < elDof) indexi = d_nodesIDs[elOffset + i];
-    }
-
-    // set contriution to 0
-    if (i < elDof && !elemDataRecovered) {
-      for (int eq = 0; eq < num_equation; eq++) {
-        Fcontrib[i + eq * elDof] = 0.;
+        for (int i = 0; i < elDof; i++) {
+          for (int eq = 0; eq < num_equation; eq++) {
+            Fcontrib[i + eq * elDof] = 0.;
+          }
+        }
+        elemDataRecovered = true;
       }
-      elemDataRecovered = true;
-    }
 
-    for (int q = 0; q < Q; q++) {  // loop over int. points
-      if (i < elDof) shape[i] = d_shapesBC[i + q * maxDofs + el * maxIntPoints * maxDofs];
-      if (i < dim) nor[i] = d_normW[i + q * (dim + 1) + el * maxIntPoints * (dim + 1)];
-      if (dim == 2 && i == maxDofs - 2) nor[2] = 0.;
-      if (i == maxDofs - 1) weight = d_normW[dim + q * (dim + 1) + el * maxIntPoints * (dim + 1)];
-      MFEM_SYNC_THREAD;
+      for (int q = 0; q < Q; q++) {  // loop over int. points
+        for (int i = 0; i < elDof; i++) shape[i] = d_shapesBC[i + q * maxDofs + el_bdry * maxIntPoints * maxDofs];
+        for (int d = 0; d < dim; d++) nor[d] = d_normW[d + q * (dim + 1) + el_bdry * maxIntPoints * (dim + 1)];
+        weight = d_normW[dim + q * (dim + 1) + el_bdry * maxIntPoints * (dim + 1)];
 
-      // recover interpolated data
-      if (i < num_equation) {
-        u1[i] = d_interpolU[i + q * num_equation + n * maxIntPoints * num_equation];
-        for (int d = 0; d < dim; d++)
-          gradUpi[i + d * num_equation] =
-              d_interpGrads[i + d * num_equation + q * dim * num_equation + n * maxIntPoints * dim * num_equation];
-      }
-      MFEM_SYNC_THREAD;
+        for (int eq = 0; eq < num_equation; eq++) {// recover interpolated data
+          u1[eq] = d_interpolU[eq + q * num_equation + n * maxIntPoints * num_equation];
+          for (int d = 0; d < dim; d++)
+            gradUpi[eq + d * num_equation] =
+              d_interpGrads[eq + d * num_equation + q * dim * num_equation + n * maxIntPoints * dim * num_equation];
+        }
 
-      // compute mirror state
-      switch (type) {
+        // compute mirror state
+        switch (type) {
         case WallType::INV:
-          computeInvWallState(&u1[0], &u2[0], &nor[0], dim, num_equation, i, maxDofs);
+          computeInvWallState_gpu_serial(&u1[0], &u2[0], &nor[0], dim, num_equation);
           break;
         case WallType::VISC_ISOTH:
-          computeIsothermalState(&u1[0], &u2[0], &nor[0], wallTemp, gamma, Rg, dim, num_equation, fluid, i, maxDofs);
+          computeIsothermalState_gpu_serial(&u1[0], &u2[0], &nor[0], wallTemp, gamma, Rg, dim, num_equation, fluid);
           break;
         case WallType::VISC_ADIAB:
           break;
+        }
+
+        // evaluate flux
+        RiemannSolver::riemannLF_serial_gpu(&u1[0], &u2[0], &Rflux[0], &nor[0], gamma, Rg, dim, num_equation);
+        Fluxes::viscousFlux_serial_gpu(&vF1[0], &u1[0], &gradUpi[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,
+                                       num_equation);
+        Fluxes::viscousFlux_serial_gpu(&vF2[0], &u2[0], &gradUpi[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,
+                                       num_equation);
+
+        // add visc flux contribution
+        for (int eq = 0; eq < num_equation; eq++ )
+          for (int d = 0; d < dim; d++)
+            Rflux[eq] -= 0.5 * (vF2[eq + d * num_equation] + vF1[eq + d * num_equation]) * nor[d];
+
+        // sum contributions to integral
+        for (int i = 0; i < elDof; i++) {
+          for (int eq = 0; eq < num_equation; eq++) Fcontrib[i + eq * elDof] -= Rflux[eq] * shape[i] * weight;
+        }
       }
-      MFEM_SYNC_THREAD;
-
-      // compute flux
-      RiemannSolver::riemannLF_gpu(&u1[0], &u2[0], &Rflux[0], &nor[0], gamma, Rg, dim, eqSystem, num_equation, i,
-                                   maxDofs);
-
-      // compute viscous flux
-      Fluxes::viscousFlux_gpu(&vF1[0], &u1[0], &gradUpi[0], eqSystem, gamma, Rg, viscMult, bulkViscMult, Pr, Sc, i,
-                              maxDofs, dim, num_equation);
-      Fluxes::viscousFlux_gpu(&vF2[0], &u2[0], &gradUpi[0], eqSystem, gamma, Rg, viscMult, bulkViscMult, Pr, Sc, i,
-                              maxDofs, dim, num_equation);
-      MFEM_SYNC_THREAD;
-
-      // add visc flux contribution
-      for (int eq = i; eq < num_equation; eq += maxDofs)
-        for (int d = 0; d < dim; d++)
-          Rflux[eq] -= 0.5 * (vF2[eq + d * num_equation] + vF1[eq + d * num_equation]) * nor[d];
-      MFEM_SYNC_THREAD;
-
-      // sum contributions to integral
-      if (i < elDof) {
-        for (int eq = 0; eq < num_equation; eq++) Fcontrib[i + eq * elDof] -= Rflux[eq] * shape[i] * weight;
-      }
-      MFEM_SYNC_THREAD;
     }
-      }
 
-      // add to global data
-      if (i < elDof) {
-    for (int eq = 0; eq < num_equation; eq++) d_y[indexi + eq * totDofs] += Fcontrib[i + eq * elDof];
-      }
-}
-});
+    // add to global data
+    for (int i = 0; i < elDof; i++) {
+      const int indexi = d_nodesIDs[elOffset + i];
+      for (int eq = 0; eq < num_equation; eq++) d_y[indexi + eq * totDofs] += Fcontrib[i + eq * elDof];
+    }
+  });
 #endif
 }
 
@@ -475,72 +460,56 @@ void WallBC::interpWalls_gpu(const WallType type, const double &wallTemp, mfem::
   const int numBdrElem = listElems.Size();
 
   // clang-format on
-  MFEM_FORALL_2D(el, wallElems.Size() / 7, maxDofs, 1, 1, {
-    MFEM_FOREACH_THREAD(i, x, maxDofs) {
-      MFEM_SHARED double Ui[216], gradUpi[216*3];;
-      MFEM_SHARED double shape[216];
-      MFEM_SHARED double u1, gUp[3];
-      MFEM_SHARED double weight;
+  MFEM_FORALL(el_wall, wallElems.Size() / 7, // el_wall is index within wall boundary elements?
+  {
+    double Ui[216], gradUpi[216*3];
+    double shape[216];
 
-      const int numFaces = d_wallElems[0 + el * 7];
-      bool changeElem = true;
-      int elOffset;
-      int elDof;
-      int elID = -666;
-      int indexi;
+    const int numFaces = d_wallElems[0 + el_wall * 7];
 
-      for (int f = 0; f < numFaces; f++) {
-    const int n = d_wallElems[1 + f + el * 7];
-    const int el = d_listElems[n];
-    const int Q = d_intPointsElIDBC[2 * el];
-    int newID = d_intPointsElIDBC[2 * el + 1];
-    if (newID != elID) {
-      changeElem = true;
-      elID = newID;
-    }
+    for (int f = 0; f < numFaces; f++) {
 
-    if (changeElem) {  // NOTE: in new implementation this doesn't save much
-      elOffset = d_posDofIds[2 * elID];
-      elDof = d_posDofIds[2 * elID + 1];
-      changeElem = false;
-    }
+      const int n = d_wallElems[1 + f + el_wall * 7];
+      const int el_bdry = d_listElems[n];  // element number within all boundary elements?
+      const int Q = d_intPointsElIDBC[2 * el_bdry];
+      const int el = d_intPointsElIDBC[2 * el_bdry + 1];  // global element number (on this mpi rank) ?
 
-    for (int eq = 0; eq < num_equation; eq++) {
-      // load data
-      if (i < elDof) {
-        indexi = d_nodesIDs[elOffset + i];
-        Ui[i] = d_U[indexi + eq * totDofs];
-        for (int d = 0; d < dim; d++)
-          gradUpi[i + d * elDof] = d_gradUp[indexi + eq * totDofs + d * num_equation * totDofs];
-      }
+      const int elOffset = d_posDofIds[2 * el];
+      const int elDof = d_posDofIds[2 * el + 1];
 
-      for (int q = 0; q < Q; q++) {
-        if (i < elDof) shape[i] = d_shapesBC[i + q * maxDofs + el * maxIntPoints * maxDofs];
-        MFEM_SYNC_THREAD;
+      for (int eq = 0; eq < num_equation; eq++) {
+        for (int i = 0; i < elDof; i++) {
+          // load data
+          const int indexi = d_nodesIDs[elOffset + i];
+          Ui[i] = d_U[indexi + eq * totDofs];
+          for (int d = 0; d < dim; d++)
+            gradUpi[i + d * elDof] = d_gradUp[indexi + eq * totDofs + d * num_equation * totDofs];
 
-        // interpolation
-        // NOTE: make parallel
-        if (i == 0) {
-          u1 = 0.;
+        }
+
+        for (int q = 0; q < Q; q++) {
+          for (int j = 0; j < elDof; j++) shape[j] = d_shapesBC[j + q * maxDofs + el_bdry * maxIntPoints * maxDofs];
+
+          double u1 = 0.;
           for (int j = 0; j < elDof; j++) u1 += shape[j] * Ui[j];
-        }
-        if (i < dim) {
-          gUp[i] = 0.;
-          for (int j = 0; j < elDof; j++) gUp[i] += gradUpi[j + i * elDof] * shape[j];
-        }
-        MFEM_SYNC_THREAD;
 
-        // save to global
-        if (i == 0) d_interpolU[eq + q * num_equation + n * maxIntPoints * num_equation] = u1;
-        if (i < dim)
-          d_interpGrads[eq + i * num_equation + q * dim * num_equation + n * maxIntPoints * dim * num_equation] =
-              gUp[i];
-        MFEM_SYNC_THREAD;
-      }  // end loop integration points
-    }    // end loop equations
-      }  // end loop faces
-}
-});
+          double gUp[3];
+          for (int d = 0; d < dim; d++) {
+            gUp[d] = 0.;
+            for (int j = 0; j < elDof; j++) gUp[d] += gradUpi[j + d * elDof] * shape[j];
+          }
+
+          // save to global
+          d_interpolU[eq + q * num_equation + n * maxIntPoints * num_equation] = u1;
+
+          for (int d = 0; d < dim; d++) {
+            d_interpGrads[eq + d * num_equation + q * dim * num_equation + n * maxIntPoints * dim * num_equation] =
+              gUp[d];
+          }
+        }  // end quadrature point loop
+      }  // end equation loop
+    }  // end face loop
+  });  // end element loop
 #endif
 }
 

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -129,8 +129,8 @@ class WallBC : public BoundaryCondition {
     }
   }
 
-  static MFEM_HOST_DEVICE void computeInvWallState_gpu_serial(const double *u1, double *u2, const double *nor, const int &dim,
-                                                              const int &num_equation) {
+  static MFEM_HOST_DEVICE void computeInvWallState_gpu_serial(const double *u1, double *u2, const double *nor,
+                                                              const int &dim, const int &num_equation) {
     double momNormal, norm;
     double unitNor[3];
 
@@ -164,9 +164,9 @@ class WallBC : public BoundaryCondition {
   }
 
   static MFEM_HOST_DEVICE void computeIsothermalState_gpu_serial(const double *u1, double *u2, const double *nor,
-                                                                 const double &wallTemp, const double &gamma, const double &Rg,
-                                                                 const int &dim, const int &num_equation,
-                                                                 const WorkingFluid &fluid) {
+                                                                 const double &wallTemp, const double &gamma,
+                                                                 const double &Rg, const int &dim,
+                                                                 const int &num_equation, const WorkingFluid &fluid) {
     for (int eq = 0; eq < num_equation; eq++) {
       u2[eq] = u1[eq];
     }

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -129,6 +129,27 @@ class WallBC : public BoundaryCondition {
     }
   }
 
+  static MFEM_HOST_DEVICE void computeInvWallState_gpu_serial(const double *u1, double *u2, const double *nor, const int &dim,
+                                                              const int &num_equation) {
+    double momNormal, norm;
+    double unitNor[3];
+
+    norm = 0.;
+    for (int d = 0; d < dim; d++) norm += nor[d] * nor[d];
+    norm = sqrt(norm);
+
+    for (int d = 0; d < dim; d++) unitNor[d] = nor[d] / norm;
+
+    momNormal = 0.;
+    for (int d = 0; d < dim; d++) momNormal += unitNor[d] * u1[d + 1];
+
+    for (int eq = 0; eq < num_equation; eq++) u2[eq] = u1[eq];
+
+    for (int d = 0; d < dim; d++) {
+      u2[d + 1] = u1[d + 1] - 2. * momNormal * unitNor[d];
+    }
+  }
+
   static MFEM_HOST_DEVICE void computeIsothermalState(const double *u1, double *u2, const double *nor,
                                                       const double &wallTemp, const double &gamma, const double &Rg,
                                                       const int &dim, const int &num_equation,
@@ -141,6 +162,20 @@ class WallBC : public BoundaryCondition {
       DryAir::computeStagnantStateWithTemp_gpu(u1, u2, wallTemp, gamma, Rg, num_equation, dim, thrd, maxThreads);
     }
   }
+
+  static MFEM_HOST_DEVICE void computeIsothermalState_gpu_serial(const double *u1, double *u2, const double *nor,
+                                                                 const double &wallTemp, const double &gamma, const double &Rg,
+                                                                 const int &dim, const int &num_equation,
+                                                                 const WorkingFluid &fluid) {
+    for (int eq = 0; eq < num_equation; eq++) {
+      u2[eq] = u1[eq];
+    }
+
+    if (fluid == WorkingFluid::DRY_AIR) {
+      DryAir::computeStagnantStateWithTemp_gpu_serial(u1, u2, wallTemp, gamma, Rg, num_equation, dim);
+    }
+  }
+
 #endif
 };
 


### PR DESCRIPTION
#### Overview
This PR allows use of the gpu code path, as defined by `#ifdef _GPU_`,  on a cpu system---i.e., without cuda or hip.  To use the option, provide `--enable-gpu-cpu` at configure time.  The default is to use the usual cpu code path.

#### Purpose
The goals are to 
1. Simplify code development supporting multiply architectures
2. Take advantage of some optimizations on the `_GPU_` path that do not require a gpu

At least for the near future, we will still have two paths through the code.  However, if the `_GPU_` path does not actually require a gpu, eventually we may be able to merge to one.  Even if we don't, having `_GPU_` support using the cpu should lower the barrier to porting new capabilities into the `_GPU_` path.  Further, because of some optimizations, the `_GPU_` path should be faster, even on a cpu.  Thus, for supported capabilities, it makes sense to run production with the `_GPU_` path even on cpu-only systems (e.g. quartz).

#### Approach
The MFEM macros we use in the `_GPU_` path (e.g., `MFEM_FORALL`) all compile to sensible code on the cpu.  However, they do not automatically protect the user from writing code that is valid when executed with sufficient parallelism but invalid in serial.  As an example, the macro `MFEM_SYNC_THREAD` becomes a no-op for the cpu, so the following code works on the gpu but not the cpu:

```
MFEM_FORALL(eq, 5,
{
  MFEM_SHARED double T;
  MFEM_SHARED double u[5];
  u[eq] = d_x[eq + offset];
  MFEM_SYNC_THREAD;
  if (eq == 0) T = computeTemperature(u);
}
``` 
On the gpu, each of 5 threads will fill one entry of `u` and then synchronize before the temperature is computed, just on thread 0.  However, on the cpu, this will become

```
for (int eq = 0; eq < 5; eq++)
{
  double T;
  double u[5];
  u[eq] = d_x[eq + offset];
  if (eq == 0) T = computeTemperature(u);
}
``` 
which is clearly nonsense because `computeTemperature` is called with the last 4 components of `u` uninitialized.

This is not a real example taken from the code, but we have similar issues throughout the `_GPU_` code path.  The changes in this PR refactor such code to make it valid when using the cpu version of the MFEM macros.

In principle, such changes may reduce our ability to exploit the parallelism of the gpu and get the best performance.  However, in practice, the changes have very little effect on performance, as shown below.

#### Performance Effects
Performance on gpu systems is essentially unchanged, while the `_GPU_` path provides some benefit on cpu systems.

##### Lassen
This refactor has led to very little performance impact on gpu systems.  Some functions are a bit more expensive and some are a bit cheaper, but overall, on 1 mpi rank on lassen, the `solve` step from the cylinder test case from PR #123 runs in nearly same time:

* main prior to this PR
```
----------------------------------------------------------------------------------------------- 
TPS - Performance Timings:                              |      Mean      Variance       Count   
--> solve               : 7.62181e+00 secs ( 54.4085 %) | [7.62181e-02  5.59340e-05        100] 
--> restart_files_hdf5  : 2.84240e-02 secs (  0.2029 %) | [2.84240e-02  0.00000e+00          1] 
--> GRVY_Unassigned     : 6.35824e+00 secs ( 45.3885 %)                                         
                                                                                                
    Total Measured Time = 1.40085e+01 secs (100.0000 %)                                         
-----------------------------------------------------------------------------------------------
```

* this branch
```
-----------------------------------------------------------------------------------------------  
TPS - Performance Timings:                              |      Mean      Variance       Count    
--> solve               : 7.65611e+00 secs ( 52.4960 %) | [7.65611e-02  4.83122e-04        100]  
--> restart_files_hdf5  : 1.97248e-02 secs (  0.1352 %) | [1.97248e-02  0.00000e+00          1]  
--> GRVY_Unassigned     : 6.90833e+00 secs ( 47.3687 %)                                          
                                                                                                 
    Total Measured Time = 1.45842e+01 secs (100.0000 %)                                          
-----------------------------------------------------------------------------------------------
```

##### Quartz
On 1 mpi rank on quartz, for the same cylinder case, we have

* this branch with usual cpu code path:
```
-----------------------------------------------------------------------------------------------
TPS - Performance Timings:                              |      Mean      Variance       Count
--> solve               : 3.83685e+02 secs ( 98.5235 %) | [3.83685e+00  4.54335e-02        100]
--> restart_files_hdf5  : 4.31303e-01 secs (  0.1108 %) | [4.31303e-01  0.00000e+00          1]
--> GRVY_Unassigned     : 5.31872e+00 secs (  1.3658 %)

    Total Measured Time = 3.89435e+02 secs (100.0000 %)
-----------------------------------------------------------------------------------------------
```

* this branch with `_GPU_` code path:
```
-----------------------------------------------------------------------------------------------
TPS - Performance Timings:                              |      Mean      Variance       Count
--> solve               : 2.66923e+02 secs ( 97.7990 %) | [2.66923e+00  2.11108e-02        100]
--> restart_files_hdf5  : 2.34165e-01 secs (  0.0858 %) | [2.34165e-01  0.00000e+00          1]
--> GRVY_Unassigned     : 5.77292e+00 secs (  2.1152 %)

    Total Measured Time = 2.72930e+02 secs (100.0000 %)
-----------------------------------------------------------------------------------------------
```
which is about a 30% improvement.

#### Known issues
This PR does not provide support for executing the `_GPU_` code path on a cpu system in parallel.  Refactoring of shared face functions such as `DGNonLinearForm::sharedFaceInterpolation_gpu` (see [here](https://github.com/pecos/tps/blob/fda7c02e9303917ab0d3267db057ffe0df7c764e/src/dgNonlinearForm.cpp#L501)) will be required.  To keep this PR small, I propose to leave those changes for a follow-on PR.


