### PR TITLE
Allow _GPU_ code path on cpu

### DIFF
--- a/src/dgNonlinearForm.hpp
+++ b/src/dgNonlinearForm.hpp
@@ -94,23 +94,11 @@ class DGNonLinearForm : public ParNonlinearForm {
 
   void faceIntegration_gpu(Vector &y, int elType, int elemOffset, int elDof);
 
-  static void sharedFaceIntegration_gpu(const Vector &x, const Vector &faceU, const ParGridFunction *gradUp,
-                                        const Vector &faceGradUp, Vector &y, Vector &shared_uk_el1,
-                                        Vector &shared_uk_el2, Vector &shared_grad_upk_el1, Vector &shared_grad_upk_el2,
-                                        const int &Ndofs, const int &dim, const int &num_equation, GasMixture *mixture,
-                                        Fluxes *flux, const volumeFaceIntegrationArrays &gpuArrays,
-                                        const parallelFacesIntegrationArrays *parallelData, const int &maxIntPoints,
-                                        const int &maxDofs);
+  void sharedFaceIntegration_gpu(Vector &y);
 
   void interpFaceData_gpu(const Vector &x, int elType, int elemOffset, int elDof);
 
-  static void sharedFaceInterpolation_gpu(const Vector &x, const Vector &faceU, const ParGridFunction *gradUp,
-                                          const Vector &faceGradUp, Vector &shared_uk_el1, Vector &shared_uk_el2,
-                                          Vector &shared_grad_upk_el1, Vector &shared_grad_upk_el2, const int &Ndofs,
-                                          const int &dim, const int &num_equation, GasMixture *mixture,
-                                          const volumeFaceIntegrationArrays &gpuArrays,
-                                          const parallelFacesIntegrationArrays *parallelData, const int &maxIntPoints,
-                                          const int &maxDofs);
+  void sharedFaceInterpolation_gpu(const Vector &x);
   void evalFaceFlux_gpu();
 
 #ifdef _GPU_

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -268,7 +268,8 @@ void Gradients::computeGradients_bdr() {
     for (int i = 0; i < elType; i++) elemOffset += h_numElems[i];
     int dof_el = h_posDofIds[2 * elemOffset + 1];
     multInverse_gpu(h_numElems[elType], elemOffset, dof_el);
-    // multInverse_gpu(h_numElems[elType], elemOffset, dof_el, vfes->GetNDofs(), *gradUp, num_equation_, dim_, gpuArrays,
+    // multInverse_gpu(h_numElems[elType], elemOffset, dof_el, vfes->GetNDofs(), *gradUp, num_equation_, dim_,
+    // gpuArrays,
     //                 invMArray, posDofInvM);
   }
 }
@@ -555,15 +556,14 @@ void Gradients::interpGradSharedFace_gpu() {
   const int maxDofs = maxDofs_;
   const int Ndofs = vfes->GetNDofs();
 
-
   MFEM_FORALL_2D(el, maxNumElems, maxIntPoints, 1, 1, {
     double l1[216], l2[216], nor[3];
     double u1, u2;
     int index_i[216];
 
-    const int el1      = d_sharedElemsFaces[0 + el * 7];
+    const int el1 = d_sharedElemsFaces[0 + el * 7];
     const int numFaces = d_sharedElemsFaces[1 + el * 7];
-    const int dof1     = d_sharedElem1Dof12Q[1 + d_sharedElemsFaces[2 + el * 7] * 4];
+    const int dof1 = d_sharedElem1Dof12Q[1 + d_sharedElemsFaces[2 + el * 7] * 4];
 
     const int offsetEl1 = d_posDofIds[2 * el1];
 
@@ -577,7 +577,7 @@ void Gradients::interpGradSharedFace_gpu() {
       const int Q = d_sharedElem1Dof12Q[3 + f * 4];
 
       // begin loop through integration points
-      //for (int k = 0; k < Q; k++) {
+      // for (int k = 0; k < Q; k++) {
       MFEM_FOREACH_THREAD(k, x, Q) {
         // load interpolating functions
         for (int i = 0; i < dof1; i++) {
@@ -588,12 +588,12 @@ void Gradients::interpGradSharedFace_gpu() {
         }
 
         const double weight =
-          d_sharedShapeWnor1[maxDofs + k * (maxDofs + 1 + dim) + f * maxIntPoints * (maxDofs + 1 + dim)];
+            d_sharedShapeWnor1[maxDofs + k * (maxDofs + 1 + dim) + f * maxIntPoints * (maxDofs + 1 + dim)];
 
         for (int d = 0; d < dim; d++) {
-          nor[d] = d_sharedShapeWnor1[maxDofs + 1 + d + k * (maxDofs + 1 + dim) + f * maxIntPoints * (maxDofs + 1 + dim)];
+          nor[d] =
+              d_sharedShapeWnor1[maxDofs + 1 + d + k * (maxDofs + 1 + dim) + f * maxIntPoints * (maxDofs + 1 + dim)];
         }
-
 
         // set array for interpolated data to 0
         for (int eq = 0; eq < num_equation; eq++) {
@@ -610,13 +610,13 @@ void Gradients::interpGradSharedFace_gpu() {
             u2 += d_faceData[index] * l2[j];
           }
 
-          const int idx = dim * (eq + k * num_equation + elFace * maxIntPoints * num_equation + el * 5 * maxIntPoints * num_equation);
+          const int idx = dim * (eq + k * num_equation + elFace * maxIntPoints * num_equation +
+                                 el * 5 * maxIntPoints * num_equation);
           for (int d = 0; d < dim; d++) {
             d_dun[idx + d] = 0.5 * (u2 - u1) * nor[d] * weight;
           }
-
         }
-      }    // end loop through integration points
+      }  // end loop through integration points
     }
   });
 }
@@ -639,12 +639,12 @@ void Gradients::integrationGradSharedFace_gpu() {
   const int maxDofs = maxDofs_;
   const int Ndofs = vfes->GetNDofs();
 
-  MFEM_FORALL_2D(el, parallelData->sharedElemsFaces.Size() / 7, maxDofs, 1, 1, { // NOLINT
-    //double l1[216];
+  MFEM_FORALL_2D(el, parallelData->sharedElemsFaces.Size() / 7, maxDofs, 1, 1, {  // NOLINT
+    // double l1[216];
 
-    const int el1      = d_sharedElemsFaces[0 + el * 7];
+    const int el1 = d_sharedElemsFaces[0 + el * 7];
     const int numFaces = d_sharedElemsFaces[1 + el * 7];
-    const int dof1     = d_sharedElem1Dof12Q[1 + d_sharedElemsFaces[2 + el * 7] * 4];
+    const int dof1 = d_sharedElem1Dof12Q[1 + d_sharedElemsFaces[2 + el * 7] * 4];
     const int offsetEl1 = d_posDofIds[2 * el1];
 
     MFEM_FOREACH_THREAD(i, x, dof1) {
@@ -659,7 +659,8 @@ void Gradients::integrationGradSharedFace_gpu() {
 
           // add contribution
           for (int eq = 0; eq < num_equation; eq++) {
-            const int idxR = dim * (eq + k * num_equation + elFace * maxIntPoints * num_equation + el * 5 * maxIntPoints * num_equation);
+            const int idxR = dim * (eq + k * num_equation + elFace * maxIntPoints * num_equation +
+                                    el * 5 * maxIntPoints * num_equation);
             for (int d = 0; d < dim; d++) {
               const int idxL = eq * Ndofs + d * num_equation * Ndofs;
               d_gradUp[indexi + idxL] += d_dun[idxR + d] * l1;
@@ -669,7 +670,6 @@ void Gradients::integrationGradSharedFace_gpu() {
       }
     }
   });
-
 }
 
 void Gradients::multInverse_gpu(const int numElems, const int offsetElems, const int elDof) {

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -91,8 +91,7 @@ class Gradients : public ParNonlinearForm {
   parallelFacesIntegrationArrays *parallelData;
   dataTransferArrays *transferUp;
 
-  Vector shared_uk_el1;
-  Vector shared_uk_el2;
+  Vector dun_shared_face;
 
  public:
   Gradients(ParFiniteElementSpace *_vfes, ParFiniteElementSpace *_gradUpfes, int _dim, int _num_equation,
@@ -107,12 +106,10 @@ class Gradients : public ParNonlinearForm {
     parallelData = _parData;
     transferUp = _transferUp;
 
-    shared_uk_el1.UseDevice(true);
-    shared_uk_el2.UseDevice(true);
+    dun_shared_face.UseDevice(true);
 
     int maxNumElems = parallelData->sharedElemsFaces.Size() / 7;  // elements with shared faces
-    shared_uk_el1.SetSize(maxNumElems * 5 * maxIntPoints_ * num_equation_);
-    shared_uk_el2.SetSize(maxNumElems * 5 * maxIntPoints_ * num_equation_);
+    dun_shared_face.SetSize(dim_ * maxNumElems * 5 * maxIntPoints_ * num_equation_);
   }
 
   void computeGradients();

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -125,25 +125,11 @@ class Gradients : public ParNonlinearForm {
 
   void faceContrib_gpu(const int elType, const int offsetElems, const int elDof);
 
-  void interpGradSharedFace_gpu(const Vector &faceU, Vector &shared_uk_el1, Vector &shared_uk_el2,
-                                const int &Ndofs, const int &dim,
-                                const int &num_equation, GasMixture *mixture,
-                                const volumeFaceIntegrationArrays &gpuArrays,
-                                const parallelFacesIntegrationArrays *parallelData,
-                                const int &maxIntPoints, const int &maxDofs);
+  void interpGradSharedFace_gpu();
 
-  void integrationGradSharedFace_gpu(const Vector *Up, const Vector &faceUp, ParGridFunction *gradUp,
-                                     const int &Ndofs, const int &dim, const int &num_equation,
-                                     const double &gamma, const double &Rg, const double &viscMult,
-                                     const double &bulkViscMult, const double &Pr,
-                                     const volumeFaceIntegrationArrays &gpuArrays,
-                                     const parallelFacesIntegrationArrays *parallelData, const int &maxIntPoints,
-                                     const int &maxDofs);
+  void integrationGradSharedFace_gpu();
 
-  static void multInverse_gpu(const int numElems, const int offsetElems, const int elDof, const int totalDofs,
-                              Vector &gradUp, const int num_equation, const int dim,
-                              const volumeFaceIntegrationArrays &gpuArrays, const Vector &invMArray,
-                              const Array<int> &posDofInvM);
+  void multInverse_gpu(const int numElems, const int offsetElems, const int elDof);
 
   void interpFaceData_gpu(const Vector &x, int elType, int elemOffset, int elDof);
   void evalFaceIntegrand_gpu();


### PR DESCRIPTION
#### Purpose
In #128, we refactored much of the `_GPU_` code path to be valid when run on a cpu, but functions associated with faces shared across mpi ranks were not touched.  Because of this, the `_GPU_` code path was not correct on the cpu with mpi parallelism.  This PR is intended to fix this issue.

#### Approach
The approach is the same as in #128, just applied to the shared face functions, e.g., `DGNonLinearForm::sharedFaceIntegration_gpu`.