### PR TITLE
Further _GPU_ refactoring

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,12 @@ AX_PROG_CXX_MPI
 #CXXFLAGS="-std=c++17 $CXXFLAGS"
 CXXFLAGS="-std=c++11 $CXXFLAGS"
 
+# check for mpi-ext.h
+AH_TEMPLATE([HAVE_MPI_EXT],[Enable MPI extensions declared in mpi-ext.h])
+AC_CHECK_HEADER([mpi-ext.h],[found_mpi_ext=yes],[found_mpi_ext=no],[#include <mpi.h>])
+if test "x${found_mpi_ext}" = "xyes" ; then
+   AC_DEFINE([HAVE_MPI_EXT])
+fi
 
 # 3rd party libraries
 
@@ -182,6 +188,7 @@ fi
 
 
 AX_PATH_MFEM([4.2],  [yes])
+
 
 dnl --
 

--- a/src/BoundaryCondition.cpp
+++ b/src/BoundaryCondition.cpp
@@ -41,9 +41,9 @@ BoundaryCondition::BoundaryCondition(RiemannSolver *_rsolver, GasMixture *_mixtu
       vfes(_vfes),
       intRules(_intRules),
       dt(_dt),
-      dim(_dim),
-      nvel(axisym ? 3 : _dim),
-      num_equation(_num_equation),
+      dim_(_dim),
+      nvel_(axisym ? 3 : _dim),
+      num_equation_(_num_equation),
       patchNumber(_patchNumber),
       refLength(_refLength),
       axisymmetric_(axisym) {

--- a/src/BoundaryCondition.hpp
+++ b/src/BoundaryCondition.hpp
@@ -51,9 +51,9 @@ class BoundaryCondition {
   ParFiniteElementSpace *vfes;
   IntegrationRules *intRules;
   double &dt;
-  const int dim;
-  const int nvel;
-  const int num_equation;
+  const int dim_;
+  const int nvel_;
+  const int num_equation_;
   const int patchNumber;
   const double refLength;
 
@@ -64,8 +64,7 @@ class BoundaryCondition {
 
   Array<int> offsetsBoundaryU;
 
-  Vector interpolated_Ubdr_;
-  Vector interpolatedGradUpbdr_;
+  Vector face_flux_;
 
  public:
   BoundaryCondition(RiemannSolver *_rsolver, GasMixture *_mixture, Equations _eqSystem, ParFiniteElementSpace *_vfes,

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -140,7 +140,7 @@ void DGNonLinearForm::Mult(const Vector &x, Vector &y) {
 
 #ifdef _GPU_
 void DGNonLinearForm::Mult_domain(const Vector &x, Vector &y) {
-  //setToZero_gpu(y, y.Size());  // assume y comes in set to zero (or that we are updating)
+  // setToZero_gpu(y, y.Size());  // assume y comes in set to zero (or that we are updating)
 
   // Internal face integration
   if (fnfi.Size()) {
@@ -184,7 +184,7 @@ void DGNonLinearForm::setToZero_gpu(Vector &x, const int size) {
 }
 
 void DGNonLinearForm::faceIntegration_gpu(Vector &y, int elType, int elemOffset, int elDof) {
-  //double *d_y = y.Write();
+  // double *d_y = y.Write();
   double *d_y = y.ReadWrite();
   const double *d_f = face_flux_.Read();
 
@@ -250,10 +250,10 @@ void DGNonLinearForm::faceIntegration_gpu(Vector &y, int elType, int elemOffset,
         const double weight = d_shapeWnor1[offsetShape1 + maxDofs + k * (maxDofs + 1 + dim)];
 
         if (swapElems) {
-          MFEM_FOREACH_THREAD(j, x, elDof){ shape[j] = d_shape2[offsetShape2 + j + k * maxDofs]; }
+          MFEM_FOREACH_THREAD(j, x, elDof) { shape[j] = d_shape2[offsetShape2 + j + k * maxDofs]; }
         } else {
           // NB: Negaive sign correct b/c we *add* to flux below regardless of swapElems
-          MFEM_FOREACH_THREAD(j, x, elDof){ shape[j] = -d_shapeWnor1[offsetShape1 + j + k * (maxDofs + 1 + dim)]; }
+          MFEM_FOREACH_THREAD(j, x, elDof) { shape[j] = -d_shapeWnor1[offsetShape1 + j + k * (maxDofs + 1 + dim)]; }
         }
         MFEM_SYNC_THREAD;
 
@@ -267,7 +267,6 @@ void DGNonLinearForm::faceIntegration_gpu(Vector &y, int elType, int elemOffset,
           }
         }
         MFEM_SYNC_THREAD;
-
       }  // end loop over quad pts
     }  // end loop over faces
 
@@ -581,7 +580,7 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
   const int maxDofs = maxDofs_;
 
   const double gamma = mixture->GetSpecificHeatRatio();
-  const double Rg    = mixture->GetGasConstant();
+  const double Rg = mixture->GetGasConstant();
   const double viscMult = mixture->GetViscMultiplyer();
   const double bulkViscMult = mixture->GetBulkViscMultiplyer();
   const double Pr = mixture->GetPrandtlNum();
@@ -621,8 +620,8 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
         }
 
         for (int d = 0; d < dim; d++) {
-          nor[d] = d_sharedShapeWnor1[maxDofs + 1 + d + k * (maxDofs + 1 + dim) +
-                                      f * maxIntPoints * (maxDofs + 1 + dim)];
+          nor[d] =
+              d_sharedShapeWnor1[maxDofs + 1 + d + k * (maxDofs + 1 + dim) + f * maxIntPoints * (maxDofs + 1 + dim)];
         }
 
         // set array for interpolated data to 0
@@ -668,7 +667,6 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
         Fluxes::viscousFlux_serial_gpu(&vFlux2[0], &u2[0], &gradUp2[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,
                                        num_equation);
 
-
         for (int eq = 0; eq < num_equation; eq++) {
           for (int d = 0; d < dim; d++)
             vFlux1[eq + d * num_equation] = 0.5 * (vFlux1[eq + d * num_equation] + vFlux2[eq + d * num_equation]);
@@ -679,7 +677,7 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
 
         for (int eq = 0; eq < num_equation; eq++) {
           const int idx =
-            eq + k * num_equation + elFace * maxIntPoints * num_equation + el * 5 * maxIntPoints * num_equation;
+              eq + k * num_equation + elFace * maxIntPoints * num_equation + el * 5 * maxIntPoints * num_equation;
           d_shared_flux[idx] = Rflux[eq];
         }
       }  // end loop through integration points

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -140,7 +140,7 @@ void DGNonLinearForm::Mult(const Vector &x, Vector &y) {
 
 #ifdef _GPU_
 void DGNonLinearForm::Mult_domain(const Vector &x, Vector &y) {
-  setToZero_gpu(y, y.Size());
+  //setToZero_gpu(y, y.Size());  // assume y comes in set to zero (or that we are updating)
 
   // Internal face integration
   if (fnfi.Size()) {
@@ -184,7 +184,8 @@ void DGNonLinearForm::setToZero_gpu(Vector &x, const int size) {
 }
 
 void DGNonLinearForm::faceIntegration_gpu(Vector &y, int elType, int elemOffset, int elDof) {
-  double *d_y = y.Write();
+  //double *d_y = y.Write();
+  double *d_y = y.ReadWrite();
   const double *d_f = face_flux_.Read();
 
   auto d_elemFaces = gpuArrays.elemFaces.Read();

--- a/src/dgNonlinearForm.hpp
+++ b/src/dgNonlinearForm.hpp
@@ -78,8 +78,7 @@ class DGNonLinearForm : public ParNonlinearForm {
   Vector uk_el2, grad_upk_el2;
   Vector face_flux_;
 
-  Vector shared_uk_el1, shared_grad_upk_el1;
-  Vector shared_uk_el2, shared_grad_upk_el2;
+  Vector shared_flux;
 
  public:
   DGNonLinearForm(Fluxes *_flux, ParFiniteElementSpace *f, ParFiniteElementSpace *gradFes, ParGridFunction *_gradUp,

--- a/src/dgNonlinearForm.hpp
+++ b/src/dgNonlinearForm.hpp
@@ -94,23 +94,11 @@ class DGNonLinearForm : public ParNonlinearForm {
 
   void faceIntegration_gpu(Vector &y, int elType, int elemOffset, int elDof);
 
-  static void sharedFaceIntegration_gpu(const Vector &x, const Vector &faceU, const ParGridFunction *gradUp,
-                                        const Vector &faceGradUp, Vector &y, Vector &shared_uk_el1,
-                                        Vector &shared_uk_el2, Vector &shared_grad_upk_el1, Vector &shared_grad_upk_el2,
-                                        const int &Ndofs, const int &dim, const int &num_equation, GasMixture *mixture,
-                                        Fluxes *flux, const volumeFaceIntegrationArrays &gpuArrays,
-                                        const parallelFacesIntegrationArrays *parallelData, const int &maxIntPoints,
-                                        const int &maxDofs);
+  void sharedFaceIntegration_gpu(Vector &y);
 
   void interpFaceData_gpu(const Vector &x, int elType, int elemOffset, int elDof);
 
-  static void sharedFaceInterpolation_gpu(const Vector &x, const Vector &faceU, const ParGridFunction *gradUp,
-                                          const Vector &faceGradUp, Vector &shared_uk_el1, Vector &shared_uk_el2,
-                                          Vector &shared_grad_upk_el1, Vector &shared_grad_upk_el2, const int &Ndofs,
-                                          const int &dim, const int &num_equation, GasMixture *mixture,
-                                          const volumeFaceIntegrationArrays &gpuArrays,
-                                          const parallelFacesIntegrationArrays *parallelData, const int &maxIntPoints,
-                                          const int &maxDofs);
+  void sharedFaceInterpolation_gpu(const Vector &x);
   void evalFaceFlux_gpu();
 
 #ifdef _GPU_

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -268,7 +268,8 @@ void Gradients::computeGradients_bdr() {
     for (int i = 0; i < elType; i++) elemOffset += h_numElems[i];
     int dof_el = h_posDofIds[2 * elemOffset + 1];
     multInverse_gpu(h_numElems[elType], elemOffset, dof_el);
-    // multInverse_gpu(h_numElems[elType], elemOffset, dof_el, vfes->GetNDofs(), *gradUp, num_equation_, dim_, gpuArrays,
+    // multInverse_gpu(h_numElems[elType], elemOffset, dof_el, vfes->GetNDofs(), *gradUp, num_equation_, dim_,
+    // gpuArrays,
     //                 invMArray, posDofInvM);
   }
 }
@@ -555,15 +556,14 @@ void Gradients::interpGradSharedFace_gpu() {
   const int maxDofs = maxDofs_;
   const int Ndofs = vfes->GetNDofs();
 
-
   MFEM_FORALL_2D(el, maxNumElems, maxIntPoints, 1, 1, {
     double l1[216], l2[216], nor[3];
     double u1, u2;
     int index_i[216];
 
-    const int el1      = d_sharedElemsFaces[0 + el * 7];
+    const int el1 = d_sharedElemsFaces[0 + el * 7];
     const int numFaces = d_sharedElemsFaces[1 + el * 7];
-    const int dof1     = d_sharedElem1Dof12Q[1 + d_sharedElemsFaces[2 + el * 7] * 4];
+    const int dof1 = d_sharedElem1Dof12Q[1 + d_sharedElemsFaces[2 + el * 7] * 4];
 
     const int offsetEl1 = d_posDofIds[2 * el1];
 
@@ -577,7 +577,7 @@ void Gradients::interpGradSharedFace_gpu() {
       const int Q = d_sharedElem1Dof12Q[3 + f * 4];
 
       // begin loop through integration points
-      //for (int k = 0; k < Q; k++) {
+      // for (int k = 0; k < Q; k++) {
       MFEM_FOREACH_THREAD(k, x, Q) {
         // load interpolating functions
         for (int i = 0; i < dof1; i++) {
@@ -588,12 +588,12 @@ void Gradients::interpGradSharedFace_gpu() {
         }
 
         const double weight =
-          d_sharedShapeWnor1[maxDofs + k * (maxDofs + 1 + dim) + f * maxIntPoints * (maxDofs + 1 + dim)];
+            d_sharedShapeWnor1[maxDofs + k * (maxDofs + 1 + dim) + f * maxIntPoints * (maxDofs + 1 + dim)];
 
         for (int d = 0; d < dim; d++) {
-          nor[d] = d_sharedShapeWnor1[maxDofs + 1 + d + k * (maxDofs + 1 + dim) + f * maxIntPoints * (maxDofs + 1 + dim)];
+          nor[d] =
+              d_sharedShapeWnor1[maxDofs + 1 + d + k * (maxDofs + 1 + dim) + f * maxIntPoints * (maxDofs + 1 + dim)];
         }
-
 
         // set array for interpolated data to 0
         for (int eq = 0; eq < num_equation; eq++) {
@@ -610,13 +610,13 @@ void Gradients::interpGradSharedFace_gpu() {
             u2 += d_faceData[index] * l2[j];
           }
 
-          const int idx = dim * (eq + k * num_equation + elFace * maxIntPoints * num_equation + el * 5 * maxIntPoints * num_equation);
+          const int idx = dim * (eq + k * num_equation + elFace * maxIntPoints * num_equation +
+                                 el * 5 * maxIntPoints * num_equation);
           for (int d = 0; d < dim; d++) {
             d_dun[idx + d] = 0.5 * (u2 - u1) * nor[d] * weight;
           }
-
         }
-      }    // end loop through integration points
+      }  // end loop through integration points
     }
   });
 }
@@ -639,12 +639,12 @@ void Gradients::integrationGradSharedFace_gpu() {
   const int maxDofs = maxDofs_;
   const int Ndofs = vfes->GetNDofs();
 
-  MFEM_FORALL_2D(el, parallelData->sharedElemsFaces.Size() / 7, maxDofs, 1, 1, { // NOLINT
-    //double l1[216];
+  MFEM_FORALL_2D(el, parallelData->sharedElemsFaces.Size() / 7, maxDofs, 1, 1, {  // NOLINT
+    // double l1[216];
 
-    const int el1      = d_sharedElemsFaces[0 + el * 7];
+    const int el1 = d_sharedElemsFaces[0 + el * 7];
     const int numFaces = d_sharedElemsFaces[1 + el * 7];
-    const int dof1     = d_sharedElem1Dof12Q[1 + d_sharedElemsFaces[2 + el * 7] * 4];
+    const int dof1 = d_sharedElem1Dof12Q[1 + d_sharedElemsFaces[2 + el * 7] * 4];
     const int offsetEl1 = d_posDofIds[2 * el1];
 
     MFEM_FOREACH_THREAD(i, x, dof1) {
@@ -659,7 +659,8 @@ void Gradients::integrationGradSharedFace_gpu() {
 
           // add contribution
           for (int eq = 0; eq < num_equation; eq++) {
-            const int idxR = dim * (eq + k * num_equation + elFace * maxIntPoints * num_equation + el * 5 * maxIntPoints * num_equation);
+            const int idxR = dim * (eq + k * num_equation + elFace * maxIntPoints * num_equation +
+                                    el * 5 * maxIntPoints * num_equation);
             for (int d = 0; d < dim; d++) {
               const int idxL = eq * Ndofs + d * num_equation * Ndofs;
               d_gradUp[indexi + idxL] += d_dun[idxR + d] * l1;
@@ -669,7 +670,6 @@ void Gradients::integrationGradSharedFace_gpu() {
       }
     }
   });
-
 }
 
 void Gradients::multInverse_gpu(const int numElems, const int offsetElems, const int elDof) {

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -381,7 +381,7 @@ void Gradients::computeGradients_gpu(const int elType, const int offsetElems, co
   const int num_equation = num_equation_;
   const int dim = dim_;
 
-  //MFEM_FORALL(el, numElems, {
+  // MFEM_FORALL(el, numElems, {
   MFEM_FORALL_2D(el, numElems, elDof, 1, 1, {
     const int eli = el + offsetElems;
     const int offsetIDs = d_posDofIds[2 * eli];

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -91,8 +91,7 @@ class Gradients : public ParNonlinearForm {
   parallelFacesIntegrationArrays *parallelData;
   dataTransferArrays *transferUp;
 
-  Vector shared_uk_el1;
-  Vector shared_uk_el2;
+  Vector dun_shared_face;
 
  public:
   Gradients(ParFiniteElementSpace *_vfes, ParFiniteElementSpace *_gradUpfes, int _dim, int _num_equation,
@@ -107,12 +106,10 @@ class Gradients : public ParNonlinearForm {
     parallelData = _parData;
     transferUp = _transferUp;
 
-    shared_uk_el1.UseDevice(true);
-    shared_uk_el2.UseDevice(true);
+    dun_shared_face.UseDevice(true);
 
     int maxNumElems = parallelData->sharedElemsFaces.Size() / 7;  // elements with shared faces
-    shared_uk_el1.SetSize(maxNumElems * 5 * maxIntPoints_ * num_equation_);
-    shared_uk_el2.SetSize(maxNumElems * 5 * maxIntPoints_ * num_equation_);
+    dun_shared_face.SetSize(dim_ * maxNumElems * 5 * maxIntPoints_ * num_equation_);
   }
 
   void computeGradients();

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -125,25 +125,11 @@ class Gradients : public ParNonlinearForm {
 
   void faceContrib_gpu(const int elType, const int offsetElems, const int elDof);
 
-  void interpGradSharedFace_gpu(const Vector &faceU, Vector &shared_uk_el1, Vector &shared_uk_el2,
-                                const int &Ndofs, const int &dim,
-                                const int &num_equation, GasMixture *mixture,
-                                const volumeFaceIntegrationArrays &gpuArrays,
-                                const parallelFacesIntegrationArrays *parallelData,
-                                const int &maxIntPoints, const int &maxDofs);
+  void interpGradSharedFace_gpu();
 
-  void integrationGradSharedFace_gpu(const Vector *Up, const Vector &faceUp, ParGridFunction *gradUp,
-                                     const int &Ndofs, const int &dim, const int &num_equation,
-                                     const double &gamma, const double &Rg, const double &viscMult,
-                                     const double &bulkViscMult, const double &Pr,
-                                     const volumeFaceIntegrationArrays &gpuArrays,
-                                     const parallelFacesIntegrationArrays *parallelData, const int &maxIntPoints,
-                                     const int &maxDofs);
+  void integrationGradSharedFace_gpu();
 
-  static void multInverse_gpu(const int numElems, const int offsetElems, const int elDof, const int totalDofs,
-                              Vector &gradUp, const int num_equation, const int dim,
-                              const volumeFaceIntegrationArrays &gpuArrays, const Vector &invMArray,
-                              const Array<int> &posDofInvM);
+  void multInverse_gpu(const int numElems, const int offsetElems, const int elDof);
 
   void interpFaceData_gpu(const Vector &x, int elType, int elemOffset, int elDof);
   void evalFaceIntegrand_gpu();

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -67,28 +67,28 @@ InletBC::InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rs
   groupsMPI->setPatch(_patchNumber);
 
   localMeanUp.UseDevice(true);
-  localMeanUp.SetSize(num_equation + 1);
+  localMeanUp.SetSize(num_equation_ + 1);
   localMeanUp = 0.;
 
   glob_sum.UseDevice(true);
-  glob_sum.SetSize(num_equation + 1);
+  glob_sum.SetSize(num_equation_ + 1);
   glob_sum = 0.;
 
   meanUp.UseDevice(true);
-  meanUp.SetSize(num_equation);
+  meanUp.SetSize(num_equation_);
   meanUp = 0.;
   auto hmeanUp = meanUp.HostWrite();
 
   hmeanUp[0] = 1.2;
   hmeanUp[1] = 60;
   hmeanUp[2] = 0;
-  if (nvel == 3) hmeanUp[3] = 0.;
-  hmeanUp[1 + nvel] = 101300;
+  if (nvel_ == 3) hmeanUp[3] = 0.;
+  hmeanUp[1 + nvel_] = 101300;
   if (eqSystem == NS_PASSIVE) {
-    hmeanUp[num_equation - 1] = 0.;
+    hmeanUp[num_equation_ - 1] = 0.;
   } else if (numActiveSpecies_ > 0) {
     for (int sp = 0; sp < numActiveSpecies_; sp++) {
-      hmeanUp[nvel + 2 + sp] = 0.0;
+      hmeanUp[nvel_ + 2 + sp] = 0.0;
     }
   }
 
@@ -97,7 +97,7 @@ InletBC::InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rs
   // assuming planar outlets (for GPU only)
   Vector normal;
   normal.UseDevice(false);
-  normal.SetSize(dim);
+  normal.SetSize(dim_);
   bool normalFull = false;
 
   // init boundary U
@@ -131,16 +131,16 @@ InletBC::InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rs
   }
 
   boundaryU.UseDevice(true);
-  boundaryU.SetSize(bdrN * num_equation);
+  boundaryU.SetSize(bdrN * num_equation_);
   boundaryU = 0.;
   Vector iState, iUp;
   iState.UseDevice(false);
   iUp.UseDevice(false);
-  iState.SetSize(num_equation);
-  iUp.SetSize(num_equation);
+  iState.SetSize(num_equation_);
+  iUp.SetSize(num_equation_);
   auto hboundaryU = boundaryU.HostWrite();
   for (int i = 0; i < bdrN; i++) {
-    for (int eq = 0; eq < num_equation; eq++) iUp(eq) = hmeanUp[eq];
+    for (int eq = 0; eq < num_equation_; eq++) iUp(eq) = hmeanUp[eq];
     mixture->GetConservativesFromPrimitives(iUp, iState);
 
     //     double gamma = mixture->GetSpecificHeatRatio();
@@ -150,7 +150,7 @@ InletBC::InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rs
     //
     //     for (int d = 0; d < dim; d++) iState[1 + d] *= iState[0];
     //     iState[1 + dim] = rE;
-    for (int eq = 0; eq < num_equation; eq++) hboundaryU[eq + i * num_equation] = iState[eq];
+    for (int eq = 0; eq < num_equation_; eq++) hboundaryU[eq + i * num_equation_] = iState[eq];
   }
   bdrUInit = false;
   bdrN = 0;
@@ -158,55 +158,55 @@ InletBC::InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rs
   // init. unit tangent vector tangent1
   tangent1.UseDevice(true);
   tangent2.UseDevice(true);
-  tangent1.SetSize(dim);
-  tangent2.SetSize(dim);
+  tangent1.SetSize(dim_);
+  tangent2.SetSize(dim_);
   tangent1 = 0.;
   tangent2 = 0.;
   auto htan1 = tangent1.HostWrite();
   auto htan2 = tangent2.HostWrite();
   Array<double> coords1, coords2;
-  for (int d = 0; d < dim; d++) {
+  for (int d = 0; d < dim_; d++) {
     coords1.Append(coords[d]);
     coords2.Append(coords[d + 3]);
   }
 
   double modVec = 0.;
-  for (int d = 0; d < dim; d++) {
+  for (int d = 0; d < dim_; d++) {
     modVec += (coords2[d] - coords1[d]) * (coords2[d] - coords1[d]);
     htan1[d] = coords2[d] - coords1[d];
   }
-  for (int d = 0; d < dim; d++) htan1[d] *= 1. / sqrt(modVec);
+  for (int d = 0; d < dim_; d++) htan1[d] *= 1. / sqrt(modVec);
 
   Vector unitNorm;
   unitNorm.UseDevice(false);
-  unitNorm.SetSize(dim);
+  unitNorm.SetSize(dim_);
   unitNorm = normal;
   {
     double mod = 0.;
-    for (int d = 0; d < dim; d++) mod += normal[d] * normal[d];
+    for (int d = 0; d < dim_; d++) mod += normal[d] * normal[d];
     unitNorm *= 1. / sqrt(mod);
   }
-  if (dim == 3) {
+  if (dim_ == 3) {
     htan2[0] = unitNorm[1] * htan1[2] - unitNorm[2] * htan1[1];
     htan2[1] = unitNorm[2] * htan1[0] - unitNorm[0] * htan1[2];
     htan2[2] = unitNorm[0] * htan1[1] - unitNorm[1] * htan1[0];
   }
 
-  DenseMatrix M(dim, dim);
-  for (int d = 0; d < dim; d++) {
+  DenseMatrix M(dim_, dim_);
+  for (int d = 0; d < dim_; d++) {
     M(0, d) = unitNorm[d];
     M(1, d) = htan1[d];
-    if (dim == 3) M(2, d) = htan2[d];
+    if (dim_ == 3) M(2, d) = htan2[d];
   }
 
-  DenseMatrix invM(dim, dim);
+  DenseMatrix invM(dim_, dim_);
   mfem::CalcInverse(M, invM);
 
   inverseNorm2cartesian.UseDevice(true);
-  inverseNorm2cartesian.SetSize(dim * dim);
+  inverseNorm2cartesian.SetSize(dim_ * dim_);
   auto hinv = inverseNorm2cartesian.HostWrite();
-  for (int i = 0; i < dim; i++)
-    for (int j = 0; j < dim; j++) hinv[i + j * dim] = invM(i, j);
+  for (int i = 0; i < dim_; i++)
+    for (int j = 0; j < dim_; j++) hinv[i + j * dim_] = invM(i, j);
 
   initBdrElemsShape();
 
@@ -218,7 +218,7 @@ InletBC::InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rs
 
 void InletBC::initBdrElemsShape() {
   bdrShape.UseDevice(true);
-  int Nbdr = boundaryU.Size() / num_equation;
+  int Nbdr = boundaryU.Size() / num_equation_;
   bdrShape.SetSize(maxIntPoints * maxDofs * Nbdr);
   bdrShape = 0.;
   auto hbdrShape = bdrShape.HostWrite();
@@ -286,7 +286,7 @@ void InletBC::initBdrElemsShape() {
 
   bdrUp.UseDevice(true);
   int size_bdrUp = bdrElemsQ.Size() / 2;
-  bdrUp.SetSize(size_bdrUp * num_equation * maxIntPoints);
+  bdrUp.SetSize(size_bdrUp * num_equation_ * maxIntPoints);
   bdrUp = 0.;
   bdrUp.Read();
 #endif
@@ -310,9 +310,9 @@ void InletBC::initBCs() {
     }
 
 #ifdef _GPU_
-    interpolated_Ubdr_.UseDevice(true);
-    interpolated_Ubdr_.SetSize(num_equation * maxIntPoints * listElems.Size());
-    interpolated_Ubdr_ = 0.;
+    face_flux_.UseDevice(true);
+    face_flux_.SetSize(num_equation_ * maxIntPoints * listElems.Size());
+    face_flux_ = 0.;
 #endif
 
     BCinit = true;
@@ -409,7 +409,7 @@ void InletBC::initBoundaryU(ParGridFunction *Up) {
       vfes->GetElementVDofs(Tr->Elem1No, dofs);
 
       // retreive data
-      elUp.SetSize(elDofs * num_equation);
+      elUp.SetSize(elDofs * num_equation_);
       Up->GetSubVector(dofs, elUp);
 
       int intorder = Tr->Elem1->OrderW() + 2 * vfes->GetFE(Tr->Elem1No)->GetOrder();
@@ -422,14 +422,14 @@ void InletBC::initBoundaryU(ParGridFunction *Up) {
         Tr->SetAllIntPoints(&ip);
         shape.SetSize(elDofs);
         vfes->GetFE(Tr->Elem1No)->CalcShape(Tr->GetElement1IntPoint(), shape);
-        Vector iUp(num_equation);
+        Vector iUp(num_equation_);
 
-        for (int eq = 0; eq < num_equation; eq++) {
+        for (int eq = 0; eq < num_equation_; eq++) {
           double sum = 0.;
           for (int d = 0; d < elDofs; d++) {
             sum += shape[d] * elUp(d + eq * elDofs);
           }
-          hboundaryU[eq + Nbdr * num_equation] = sum;
+          hboundaryU[eq + Nbdr * num_equation_] = sum;
         }
         Nbdr++;
       }
@@ -464,7 +464,7 @@ void InletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
 
   const int dofs = vfes->GetNDofs();
 
-  updateMean_gpu(Up, localMeanUp, num_equation, bdrElemsQ.Size() / 2, dofs, bdrUp, bdrElemsQ, bdrDofs, bdrShape,
+  updateMean_gpu(Up, localMeanUp, num_equation_, bdrElemsQ.Size() / 2, dofs, bdrUp, bdrElemsQ, bdrDofs, bdrShape,
                  maxIntPoints, maxDofs);
 
   if (!bdrUInit) initBoundaryU(Up);
@@ -487,7 +487,7 @@ void InletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
       vfes->GetElementVDofs(Tr->Elem1No, dofs);
 
       // retreive data
-      elUp.SetSize(elDofs * num_equation);
+      elUp.SetSize(elDofs * num_equation_);
       Up->GetSubVector(dofs, elUp);
 
       int intorder = Tr->Elem1->OrderW() + 2 * vfes->GetFE(Tr->Elem1No)->GetOrder();
@@ -500,15 +500,15 @@ void InletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
         Tr->SetAllIntPoints(&ip);
         shape.SetSize(elDofs);
         vfes->GetFE(Tr->Elem1No)->CalcShape(Tr->GetElement1IntPoint(), shape);
-        Vector iUp(num_equation);
+        Vector iUp(num_equation_);
 
-        for (int eq = 0; eq < num_equation; eq++) {
+        for (int eq = 0; eq < num_equation_; eq++) {
           double sum = 0.;
           for (int d = 0; d < elDofs; d++) {
             sum += shape[d] * elUp(d + eq * elDofs);
           }
           localMeanUp[eq] += sum;
-          if (!bdrUInit) boundaryU[eq + Nbdr * num_equation] = sum;
+          if (!bdrUInit) boundaryU[eq + Nbdr * num_equation_] = sum;
         }
         Nbdr++;
       }
@@ -517,22 +517,22 @@ void InletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
 #endif
 
   double *h_localMeanUp = localMeanUp.HostReadWrite();
-  int totNbdr = boundaryU.Size() / num_equation;
-  h_localMeanUp[num_equation] = static_cast<double>(totNbdr);
+  int totNbdr = boundaryU.Size() / num_equation_;
+  h_localMeanUp[num_equation_] = static_cast<double>(totNbdr);
 
   double *h_sum = glob_sum.HostWrite();
-  MPI_Allreduce(h_localMeanUp, h_sum, num_equation + 1, MPI_DOUBLE, MPI_SUM, groupsMPI->getComm(patchNumber));
+  MPI_Allreduce(h_localMeanUp, h_sum, num_equation_ + 1, MPI_DOUBLE, MPI_SUM, groupsMPI->getComm(patchNumber));
 
-  BoundaryCondition::copyValues(glob_sum, meanUp, 1. / h_sum[num_equation]);
+  BoundaryCondition::copyValues(glob_sum, meanUp, 1. / h_sum[num_equation_]);
 
   if (!bdrUInit) {
     // for(int i=0;i<Nbdr;i++)
-    Vector iState(num_equation), iUp(num_equation);
+    Vector iState(num_equation_), iUp(num_equation_);
     for (int i = 0; i < totNbdr; i++) {
-      for (int eq = 0; eq < num_equation; eq++) iUp[eq] = boundaryU[eq + i * num_equation];
+      for (int eq = 0; eq < num_equation_; eq++) iUp[eq] = boundaryU[eq + i * num_equation_];
       mixture->GetConservativesFromPrimitives(iUp, iState);
 
-      for (int eq = 0; eq < num_equation; eq++) boundaryU[eq + i * num_equation] = iState[eq];
+      for (int eq = 0; eq < num_equation_; eq++) boundaryU[eq + i * num_equation_] = iState[eq];
     }
     bdrUInit = true;
   }
@@ -543,11 +543,11 @@ void InletBC::integrationBC(Vector &y,  // output
                             ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                             Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs) {
   interpInlet_gpu(x, nodesIDs, posDofIds, shapesBC, normalsWBC,
-                  intPointsElIDBC, listElems, offsetsBoundaryU, maxIntPoints, maxDofs, dim, num_equation);
+                  intPointsElIDBC, listElems, offsetsBoundaryU, maxIntPoints, maxDofs);
 
   integrateInlets_gpu(y,  // output
                       x, nodesIDs, posDofIds, shapesBC, normalsWBC, intPointsElIDBC,
-                      listElems, offsetsBoundaryU, maxIntPoints, maxDofs, dim, num_equation);
+                      listElems, offsetsBoundaryU, maxIntPoints, maxDofs);
 }
 
 void InletBC::subsonicNonReflectingDensityVelocity(Vector &normal, Vector &stateIn, DenseMatrix &gradState,
@@ -558,34 +558,34 @@ void InletBC::subsonicNonReflectingDensityVelocity(Vector &normal, Vector &state
   Vector unitNorm = normal;
   {
     double mod = 0.;
-    for (int d = 0; d < dim; d++) mod += normal[d] * normal[d];
+    for (int d = 0; d < dim_; d++) mod += normal[d] * normal[d];
     unitNorm *= -1. / sqrt(mod);  // point into domain!!
   }
 
   // mean velocity in inlet normal and tangent directions
-  Vector meanVel(nvel);
+  Vector meanVel(nvel_);
   meanVel = 0.;
-  for (int d = 0; d < dim; d++) {
+  for (int d = 0; d < dim_; d++) {
     meanVel[0] += unitNorm[d] * meanUp[d + 1];
     meanVel[1] += tangent1[d] * meanUp[d + 1];
   }
-  if (dim == 3) {
+  if (dim_ == 3) {
     tangent2[0] = unitNorm[1] * tangent1[2] - unitNorm[2] * tangent1[1];
     tangent2[1] = unitNorm[2] * tangent1[0] - unitNorm[0] * tangent1[2];
     tangent2[2] = unitNorm[0] * tangent1[1] - unitNorm[1] * tangent1[0];
-    for (int d = 0; d < dim; d++) meanVel[2] += tangent2[d] * meanUp[d + 1];
+    for (int d = 0; d < dim_; d++) meanVel[2] += tangent2[d] * meanUp[d + 1];
   }
 
   // velocity difference between actual and desired values
-  Vector meanDV(nvel);
-  for (int d = 0; d < nvel; d++) meanDV[d] = meanUp[1 + d] - inputState[1 + d];
+  Vector meanDV(nvel_);
+  for (int d = 0; d < nvel_; d++) meanDV[d] = meanUp[1 + d] - inputState[1 + d];
 
   // normal gradients
-  Vector normGrad(num_equation);
+  Vector normGrad(num_equation_);
   normGrad = 0.;
-  for (int eq = 0; eq < num_equation; eq++) {
+  for (int eq = 0; eq < num_equation_; eq++) {
     // NOTE(kevin): for axisymmetric case, azimuthal normal component will be always zero.
-    for (int d = 0; d < dim; d++) normGrad[eq] += unitNorm[d] * gradState(eq, d);
+    for (int d = 0; d < dim_; d++) normGrad[eq] += unitNorm[d] * gradState(eq, d);
   }
   // gradient of pressure in normal direction
   double dpdn = mixture->ComputePressureDerivative(normGrad, stateIn, false);
@@ -593,28 +593,28 @@ void InletBC::subsonicNonReflectingDensityVelocity(Vector &normal, Vector &state
   const double speedSound = mixture->ComputeSpeedOfSound(meanUp);
 
   double meanK = 0.;
-  for (int d = 0; d < nvel; d++) meanK += meanUp[1 + d] * meanUp[1 + d];
+  for (int d = 0; d < nvel_; d++) meanK += meanUp[1 + d] * meanUp[1 + d];
   meanK *= 0.5;
 
   // compute outgoing characteristic
   double L1 = 0.;
-  for (int d = 0; d < dim; d++) L1 += unitNorm[d] * normGrad[1 + d];  // dVn/dn
+  for (int d = 0; d < dim_; d++) L1 += unitNorm[d] * normGrad[1 + d];  // dVn/dn
   L1 = dpdn - meanUp[0] * speedSound * L1;
   L1 *= meanVel[0] - speedSound;
 
   // estimate ingoing characteristic
   const double sigma = speedSound / refLength;
   double L5 = 0.;
-  for (int d = 0; d < dim; d++) L5 += meanDV[d] * unitNorm[d];
+  for (int d = 0; d < dim_; d++) L5 += meanDV[d] * unitNorm[d];
   L5 *= sigma * 2. * meanUp[0] * speedSound;
 
   double L3 = 0.;
-  for (int d = 0; d < dim; d++) L3 += meanDV[d] * tangent1[d];
+  for (int d = 0; d < dim_; d++) L3 += meanDV[d] * tangent1[d];
   L3 *= sigma;
 
   double L4 = 0.;
-  if (dim == 3) {
-    for (int d = 0; d < dim; d++) L4 += meanDV[d] * tangent2[d];
+  if (dim_ == 3) {
+    for (int d = 0; d < dim_; d++) L4 += meanDV[d] * tangent2[d];
     L4 *= sigma;
   }
 
@@ -633,11 +633,11 @@ void InletBC::subsonicNonReflectingDensityVelocity(Vector &normal, Vector &state
   bdrFlux[0] = d1;
   bdrFlux[1] = meanVel[0] * d1 + meanUp[0] * d2;
   bdrFlux[2] = meanVel[1] * d1 + meanUp[0] * d3;
-  if (nvel == 3) bdrFlux[3] = meanVel[2] * d1 + meanUp[0] * d4;
-  bdrFlux[1 + nvel] = meanUp[0] * meanVel[0] * d2;
-  bdrFlux[1 + nvel] += meanUp[0] * meanVel[1] * d3;
-  if (nvel == 3) bdrFlux[1 + nvel] += meanUp[0] * meanVel[2] * d4;
-  bdrFlux[1 + nvel] += meanK * d1 + d5 / (gamma - 1.);
+  if (nvel_ == 3) bdrFlux[3] = meanVel[2] * d1 + meanUp[0] * d4;
+  bdrFlux[1 + nvel_] = meanUp[0] * meanVel[0] * d2;
+  bdrFlux[1 + nvel_] += meanUp[0] * meanVel[1] * d3;
+  if (nvel_ == 3) bdrFlux[1 + nvel_] += meanUp[0] * meanVel[2] * d4;
+  bdrFlux[1 + nvel_] += meanK * d1 + d5 / (gamma - 1.);
 
   // flux gradients in other directions
   //   Vector fluxY(num_equation);
@@ -665,39 +665,39 @@ void InletBC::subsonicNonReflectingDensityVelocity(Vector &normal, Vector &state
   //     fluxY[3] = stateIn(3)/rho*dy_rv + rho*meanVt1*dy_E + dy_vp;
   //   }
 
-  Vector state2(num_equation);
-  for (int eq = 0; eq < num_equation; eq++) state2[eq] = boundaryU[eq + bdrN * num_equation];
+  Vector state2(num_equation_);
+  for (int eq = 0; eq < num_equation_; eq++) state2[eq] = boundaryU[eq + bdrN * num_equation_];
 
   Vector stateN = state2;
-  for (int d = 0; d < nvel; d++) stateN[1 + d] = 0.;
-  for (int d = 0; d < dim; d++) {
+  for (int d = 0; d < nvel_; d++) stateN[1 + d] = 0.;
+  for (int d = 0; d < dim_; d++) {
     stateN[1] += state2[1 + d] * unitNorm[d];
     stateN[2] += state2[1 + d] * tangent1[d];
-    if (dim == 3) stateN[3] += state2[1 + d] * tangent2[d];
+    if (dim_ == 3) stateN[3] += state2[1 + d] * tangent2[d];
   }
 
-  Vector newU(num_equation);
+  Vector newU(num_equation_);
   // for(int i=0; i<num_equation;i++) newU[i] = state2[i]- dt*(bdrFlux[i] /*+ fluxY[i]*/);
-  for (int i = 0; i < num_equation; i++) newU[i] = stateN[i] - dt * bdrFlux[i];
-  if (eqSystem == NS_PASSIVE) newU[num_equation - 1] = 0.;
+  for (int i = 0; i < num_equation_; i++) newU[i] = stateN[i] - dt * bdrFlux[i];
+  if (eqSystem == NS_PASSIVE) newU[num_equation_ - 1] = 0.;
 
   // transform back into x-y coords
   {
-    DenseMatrix M(dim, dim);
-    for (int d = 0; d < dim; d++) {
+    DenseMatrix M(dim_, dim_);
+    for (int d = 0; d < dim_; d++) {
       M(0, d) = unitNorm[d];
       M(1, d) = tangent1[d];
-      if (dim == 3) M(2, d) = tangent2[d];
+      if (dim_ == 3) M(2, d) = tangent2[d];
     }
 
-    DenseMatrix invM(dim, dim);
+    DenseMatrix invM(dim_, dim_);
     mfem::CalcInverse(M, invM);
-    Vector momN(dim), momX(dim);
-    for (int d = 0; d < dim; d++) momN[d] = newU[1 + d];
+    Vector momN(dim_), momX(dim_);
+    for (int d = 0; d < dim_; d++) momN[d] = newU[1 + d];
     invM.Mult(momN, momX);
-    for (int d = 0; d < dim; d++) newU[1 + d] = momX[d];
+    for (int d = 0; d < dim_; d++) newU[1 + d] = momX[d];
   }
-  for (int eq = 0; eq < num_equation; eq++) boundaryU[eq + bdrN * num_equation] = newU[eq];
+  for (int eq = 0; eq < num_equation_; eq++) boundaryU[eq + bdrN * num_equation_] = newU[eq];
   bdrN++;
 
   rsolver->Eval(stateIn, state2, normal, bdrFlux, true);
@@ -708,21 +708,21 @@ void InletBC::subsonicReflectingDensityVelocity(Vector &normal, Vector &stateIn,
   // whether it is equal to the gas temperature or not.
   const double p = mixture->ComputePressure(stateIn);
 
-  Vector state2(num_equation);
+  Vector state2(num_equation_);
   state2 = stateIn;
 
   state2[0] = inputState[0];
   state2[1] = inputState[0] * inputState[1];
   state2[2] = inputState[0] * inputState[2];
-  if (nvel == 3) state2[3] = inputState[0] * inputState[3];
+  if (nvel_ == 3) state2[3] = inputState[0] * inputState[3];
 
   if (eqSystem == NS_PASSIVE) {
-    state2[num_equation - 1] = 0.;
+    state2[num_equation_ - 1] = 0.;
   } else if (numActiveSpecies_ > 0) {
     for (int sp = 0; sp < numActiveSpecies_; sp++) {
       // NOTE: inlet BC does not specify total energy. therefore skips one index.
-      // NOTE: regardless of dimension, inletBC save the first 4 elements for density and velocity.
-      state2[nvel + 2 + sp] = inputState[4 + sp];
+      // NOTE: regardless of dim_ension, inletBC save the first 4 elements for density and velocity.
+      state2[nvel_ + 2 + sp] = inputState[4 + sp];
     }
   }
 
@@ -737,7 +737,7 @@ void InletBC::integrateInlets_gpu(Vector &y,
                                   const Array<int> &posDofIds,
                                   Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
                                   Array<int> &listElems, Array<int> &offsetsBoundaryU, const int &maxIntPoints,
-                                  const int &maxDofs, const int &dim, const int &num_equation) {
+                                  const int &maxDofs) {
 #ifdef _GPU_
   double *d_y = y.Write();
   const int *d_nodesIDs = nodesIDs.Read();
@@ -748,12 +748,15 @@ void InletBC::integrateInlets_gpu(Vector &y,
   const int *d_listElems = listElems.Read();
   const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
 
-  const double *d_interpUbdr = interpolated_Ubdr_.Read();
+  const double *d_flux = face_flux_.Read();
 
-  const int totDofs = x.Size() / num_equation;
+  const int totDofs = x.Size() / num_equation_;
   const int numBdrElem = listElems.Size();
 
   const InletType type = inletType_;
+
+  const int dim = dim_;
+  const int num_equation = num_equation_;
 
   MFEM_FORALL_2D(n, numBdrElem, maxDofs, 1, 1, {
     MFEM_SHARED double Fcontrib[216 * 5];
@@ -776,7 +779,7 @@ void InletBC::integrateInlets_gpu(Vector &y,
 
       // get interpolated data
       for (int eq = 0; eq < num_equation; eq++) {
-        Rflux[eq] = weight * d_interpUbdr[eq + q * num_equation + n * maxIntPoints * num_equation];
+        Rflux[eq] = weight * d_flux[eq + q * num_equation + n * maxIntPoints * num_equation];
       }
 
       // sum contributions to integral
@@ -800,8 +803,7 @@ void InletBC::integrateInlets_gpu(Vector &y,
 void InletBC::interpInlet_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
                               mfem::Vector &shapesBC,
                               mfem::Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
-                              Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs, const int &dim,
-                              const int &num_equation) {
+                              Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs) {
 #ifdef _GPU_
   const double *d_inputState = inputState.Read();
   const double *d_U = x.Read();
@@ -813,9 +815,9 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x, const Array<int> &nodesIDs,
   const int *d_listElems = listElems.Read();
   const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
 
-  double *d_interpUbdr = interpolated_Ubdr_.Write();
+  double *d_flux = face_flux_.Write();
 
-  const int totDofs = x.Size() / num_equation;
+  const int totDofs = x.Size() / num_equation_;
   const int numBdrElem = listElems.Size();
 
   const double Rg = mixture->GetGasConstant();
@@ -824,6 +826,9 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x, const Array<int> &nodesIDs,
   const WorkingFluid fluid = mixture->GetWorkingFluid();
 
   const InletType type = inletType_;
+
+  const int dim = dim_;
+  const int num_equation = num_equation_;
 
   // MFEM_FORALL(n, numBdrElem, {
   MFEM_FORALL_2D(n, numBdrElem, maxIntPoints, 1, 1, {
@@ -870,7 +875,7 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x, const Array<int> &nodesIDs,
 
       // save to global memory
       for (int eq = 0; eq < num_equation; eq++) {
-        d_interpUbdr[eq + q * num_equation + n * maxIntPoints * num_equation] = Rflux[eq];
+        d_flux[eq + q * num_equation + n * maxIntPoints * num_equation] = Rflux[eq];
       }
     }  // end loop over intergration points
   });

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -752,8 +752,6 @@ void InletBC::integrateInlets_gpu(Vector &y,
   const int totDofs = x.Size() / num_equation_;
   const int numBdrElem = listElems.Size();
 
-  const InletType type = inletType_;
-
   const int dim = dim_;
   const int num_equation = num_equation_;
   const int maxIntPoints = maxIntPoints_;
@@ -761,10 +759,9 @@ void InletBC::integrateInlets_gpu(Vector &y,
 
   MFEM_FORALL_2D(n, numBdrElem, maxDofs, 1, 1, {
     MFEM_SHARED double Fcontrib[216 * 5];
-    double Rflux[5], u1[5], u2[5], nor[3];
+    double Rflux[5];
 
     const int el = d_listElems[n];
-    const int offsetBdrU = d_offsetBoundaryU[n];
     const int Q = d_intPointsElIDBC[2 * el];
     const int elID = d_intPointsElIDBC[2 * el + 1];
     const int elOffset = d_posDofIds[2 * elID];

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -542,12 +542,10 @@ void InletBC::integrationBC(Vector &y,  // output
                             const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
                             ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                             Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs) {
-  interpInlet_gpu(x, nodesIDs, posDofIds, shapesBC, normalsWBC,
-                  intPointsElIDBC, listElems, offsetsBoundaryU);
+  interpInlet_gpu(x, nodesIDs, posDofIds, shapesBC, normalsWBC, intPointsElIDBC, listElems, offsetsBoundaryU);
 
   integrateInlets_gpu(y,  // output
-                      x, nodesIDs, posDofIds, shapesBC, normalsWBC, intPointsElIDBC,
-                      listElems, offsetsBoundaryU);
+                      x, nodesIDs, posDofIds, shapesBC, normalsWBC, intPointsElIDBC, listElems, offsetsBoundaryU);
 }
 
 void InletBC::subsonicNonReflectingDensityVelocity(Vector &normal, Vector &stateIn, DenseMatrix &gradState,
@@ -732,9 +730,7 @@ void InletBC::subsonicReflectingDensityVelocity(Vector &normal, Vector &stateIn,
   rsolver->Eval(stateIn, state2, normal, bdrFlux, true);
 }
 
-void InletBC::integrateInlets_gpu(Vector &y,
-                                  const Vector &x, const Array<int> &nodesIDs,
-                                  const Array<int> &posDofIds,
+void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
                                   Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
                                   Array<int> &listElems, Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
@@ -799,9 +795,8 @@ void InletBC::integrateInlets_gpu(Vector &y,
 }
 
 void InletBC::interpInlet_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
-                              mfem::Vector &shapesBC,
-                              mfem::Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
-                              Array<int> &offsetsBoundaryU) {
+                              mfem::Vector &shapesBC, mfem::Vector &normalsWBC, Array<int> &intPointsElIDBC,
+                              Array<int> &listElems, Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   const double *d_inputState = inputState.Read();
   const double *d_U = x.Read();
@@ -829,7 +824,6 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x, const Array<int> &nodesIDs,
   const int num_equation = num_equation_;
   const int maxIntPoints = maxIntPoints_;
   const int maxDofs = maxDofs_;
-
 
   // MFEM_FORALL(n, numBdrElem, {
   MFEM_FORALL_2D(n, numBdrElem, maxIntPoints, 1, 1, {

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -111,14 +111,12 @@ class InletBC : public BoundaryCondition {
   // functions for BC integration on GPU
 
   void integrateInlets_gpu(Vector &y,  // output
-                           const Vector &x, const Array<int> &nodesIDs,
-                           const Array<int> &posDofIds,
-                           Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
-                           Array<int> &listElems, Array<int> &offsetsBoundaryU);
-  void interpInlet_gpu(const Vector &x,
-                       const Array<int> &nodesIDs, const Array<int> &posDofIds,
-                       Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
-                       Array<int> &listElems, Array<int> &offsetsBoundaryU);
+                           const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds, Vector &shapesBC,
+                           Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
+                           Array<int> &offsetsBoundaryU);
+  void interpInlet_gpu(const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds, Vector &shapesBC,
+                       Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
+                       Array<int> &offsetsBoundaryU);
 
 #ifdef _GPU_
   static MFEM_HOST_DEVICE void computeSubDenseVel(const double *u1, double *u2, const double *nor,

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -118,11 +118,11 @@ class InletBC : public BoundaryCondition {
                                   Array<int> &listElems, Array<int> &offsetsBoundaryU, const int &maxIntPoints,
                                   const int &maxDofs, const int &dim, const int &num_equation, GasMixture *mixture,
                                   Equations &eqSystem);
-  void interpInlet_gpu(const InletType type, const Vector &inputState, Vector &interpolated_Ubdr,
-                       const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
-                       ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
-                       Array<int> &intPointsElIDBC, Array<int> &listElems, Array<int> &offsetsBoundaryU,
-                       const int &maxIntPoints, const int &maxDofs, const int &dim, const int &num_equation);
+  void interpInlet_gpu(const InletType type, const Vector &inputState, Vector &interpolated_Ubdr, const Vector &x,
+                       const Array<int> &nodesIDs, const Array<int> &posDofIds, ParGridFunction *Up,
+                       ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
+                       Array<int> &listElems, Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs,
+                       const int &dim, const int &num_equation);
 
 #ifdef _GPU_
   static MFEM_HOST_DEVICE void computeSubDenseVel(const double *u1, double *u2, const double *nor,

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -48,7 +48,7 @@ class InletBC : public BoundaryCondition {
  private:
   MPI_Groups *groupsMPI;
 
-  const InletType inletType;
+  const InletType inletType_;
 
   // In/out conditions specified in the configuration file
   Vector inputState;
@@ -110,17 +110,15 @@ class InletBC : public BoundaryCondition {
 
   // functions for BC integration on GPU
 
-  static void integrateInlets_gpu(const InletType type, const Vector &inputState, const double &dt,
-                                  Vector &y,  // output
-                                  const Vector &x, Vector &interpolated_Ubdr, const Array<int> &nodesIDs,
-                                  const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp,
-                                  Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
-                                  Array<int> &listElems, Array<int> &offsetsBoundaryU, const int &maxIntPoints,
-                                  const int &maxDofs, const int &dim, const int &num_equation, GasMixture *mixture,
-                                  Equations &eqSystem);
-  void interpInlet_gpu(const InletType type, const Vector &inputState, Vector &interpolated_Ubdr, const Vector &x,
-                       const Array<int> &nodesIDs, const Array<int> &posDofIds, ParGridFunction *Up,
-                       ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
+  void integrateInlets_gpu(Vector &y,  // output
+                           const Vector &x, const Array<int> &nodesIDs,
+                           const Array<int> &posDofIds,
+                           Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
+                           Array<int> &listElems, Array<int> &offsetsBoundaryU, const int &maxIntPoints,
+                           const int &maxDofs, const int &dim, const int &num_equation);
+  void interpInlet_gpu(const Vector &x,
+                       const Array<int> &nodesIDs, const Array<int> &posDofIds,
+                       Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
                        Array<int> &listElems, Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs,
                        const int &dim, const int &num_equation);
 

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -115,12 +115,11 @@ class InletBC : public BoundaryCondition {
                            const Array<int> &posDofIds,
                            Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
                            Array<int> &listElems, Array<int> &offsetsBoundaryU, const int &maxIntPoints,
-                           const int &maxDofs, const int &dim, const int &num_equation);
+                           const int &maxDofs);
   void interpInlet_gpu(const Vector &x,
                        const Array<int> &nodesIDs, const Array<int> &posDofIds,
                        Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
-                       Array<int> &listElems, Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs,
-                       const int &dim, const int &num_equation);
+                       Array<int> &listElems, Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs);
 
 #ifdef _GPU_
   static MFEM_HOST_DEVICE void computeSubDenseVel(const double *u1, double *u2, const double *nor,

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -66,8 +66,8 @@ class InletBC : public BoundaryCondition {
   Array<int> bdrElemsQ;  // element dofs and face num. of integration points
   Array<int> bdrDofs;    // indexes of the D
   Vector bdrShape;       // shape functions evaluated at the integration points
-  const int &maxIntPoints;
-  const int &maxDofs;
+  const int &maxIntPoints_;
+  const int &maxDofs_;
 
   // local vector for mean calculation
   Vector localMeanUp;
@@ -114,12 +114,11 @@ class InletBC : public BoundaryCondition {
                            const Vector &x, const Array<int> &nodesIDs,
                            const Array<int> &posDofIds,
                            Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
-                           Array<int> &listElems, Array<int> &offsetsBoundaryU, const int &maxIntPoints,
-                           const int &maxDofs);
+                           Array<int> &listElems, Array<int> &offsetsBoundaryU);
   void interpInlet_gpu(const Vector &x,
                        const Array<int> &nodesIDs, const Array<int> &posDofIds,
                        Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
-                       Array<int> &listElems, Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs);
+                       Array<int> &listElems, Array<int> &offsetsBoundaryU);
 
 #ifdef _GPU_
   static MFEM_HOST_DEVICE void computeSubDenseVel(const double *u1, double *u2, const double *nor,

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -118,11 +118,11 @@ class InletBC : public BoundaryCondition {
                                   Array<int> &listElems, Array<int> &offsetsBoundaryU, const int &maxIntPoints,
                                   const int &maxDofs, const int &dim, const int &num_equation, GasMixture *mixture,
                                   Equations &eqSystem);
-  static void interpInlet_gpu(const InletType type, const Vector &inputState, Vector &interpolated_Ubdr,
-                              const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
-                              ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
-                              Array<int> &intPointsElIDBC, Array<int> &listElems, Array<int> &offsetsBoundaryU,
-                              const int &maxIntPoints, const int &maxDofs, const int &dim, const int &num_equation);
+  void interpInlet_gpu(const InletType type, const Vector &inputState, Vector &interpolated_Ubdr,
+                       const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
+                       ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
+                       Array<int> &intPointsElIDBC, Array<int> &listElems, Array<int> &offsetsBoundaryU,
+                       const int &maxIntPoints, const int &maxDofs, const int &dim, const int &num_equation);
 
 #ifdef _GPU_
   static MFEM_HOST_DEVICE void computeSubDenseVel(const double *u1, double *u2, const double *nor,

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -1049,7 +1049,6 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const Array<int>
     double Rflux[20];
 
     const int el = d_listElems[n];
-    const int offsetBdrU = d_offsetBoundaryU[n];
 
     const int Q    = d_intPointsElIDBC[2 * el  ];
     const int elID = d_intPointsElIDBC[2 * el + 1];

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -552,12 +552,11 @@ void OutletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
 void OutletBC::integrationBC(Vector &y, const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
                              ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                              Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs) {
-  interpOutlet_gpu(x, nodesIDs, posDofIds, Up,
-                   gradUp, shapesBC, normalsWBC, intPointsElIDBC, listElems, offsetsBoundaryU);
+  interpOutlet_gpu(x, nodesIDs, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, listElems,
+                   offsetsBoundaryU);
 
   integrateOutlets_gpu(y,  // output
-                       x, nodesIDs, posDofIds, shapesBC, normalsWBC,
-                       intPointsElIDBC, listElems, offsetsBoundaryU);
+                       x, nodesIDs, posDofIds, shapesBC, normalsWBC, intPointsElIDBC, listElems, offsetsBoundaryU);
 }
 
 void OutletBC::subsonicNonReflectingPressure(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector &bdrFlux) {
@@ -1016,10 +1015,9 @@ void OutletBC::subsonicNonRefPWMassFlow(Vector &normal, Vector &stateIn, DenseMa
   rsolver->Eval(stateIn, state2, normal, bdrFlux, true);
 }
 
-void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const Array<int> &nodesIDs,
-                                    const Array<int> &posDofIds,
-                                    Vector &shapesBC, Vector &normalsWBC,
-                                    Array<int> &intPointsElIDBC, Array<int> &listElems, Array<int> &offsetsBoundaryU) {
+void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
+                                    Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
+                                    Array<int> &listElems, Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   double *d_y = y.Write();
   const double *d_U = x.Read();
@@ -1191,8 +1189,8 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const Array<int> &nodesID
           break;
         case OutletType::SUB_MF_NR:
           computeNRSubMassFlow_serial(offsetBdrU + q, &u1[0], &gradUp1[0], d_meanUp, dtloc, &u2[0], d_boundaryU,
-                                      d_inputState, &nor[0], d_tang1, d_tang2, d_inv, rL, area, gamma, Rg, elDof,
-                                      dim, num_equation, es);
+                                      d_inputState, &nor[0], d_tang1, d_tang2, d_inv, rL, area, gamma, Rg, elDof, dim,
+                                      num_equation, es);
           break;
         case OutletType::SUB_MF_NR_PW:
           printf("OUTLET SUB_MF_NR_PW BC NOT IMPLEMENTED");

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -1145,6 +1145,11 @@ void OutletBC::interpOutlet_gpu(const OutletType type, const mfem::Array<double>
 
   const WorkingFluid fluid = mixture->GetWorkingFluid();
 
+  const double rL = this->refLength;
+  const double A = this->area;
+  const double dtloc = this->dt;
+  const Equations es = this->eqSystem;
+
   // MFEM_FORALL(n, numBdrElem, {
   MFEM_FORALL_2D(n, numBdrElem, maxIntPoints, 1, 1, {
     //
@@ -1200,14 +1205,14 @@ void OutletBC::interpOutlet_gpu(const OutletType type, const mfem::Array<double>
           computeSubPressure_gpu_serial(&u1[0], &u2[0], &nor[0], d_inputState[0], gamma, Rg, dim, num_equation, fluid);
           break;
         case OutletType::SUB_P_NR:
-          computeNRSubPress_serial(offsetBdrU + q, &u1[0], &gradUp1[0], d_meanUp, dt, &u2[0], d_boundaryU,
-                                   &d_inputState[0], &nor[0], d_tang1, d_tang2, d_inv, refLength, gamma, Rg, elDof, dim,
-                                   num_equation, eqSystem);
+          computeNRSubPress_serial(offsetBdrU + q, &u1[0], &gradUp1[0], d_meanUp, dtloc, &u2[0], d_boundaryU,
+                                   &d_inputState[0], &nor[0], d_tang1, d_tang2, d_inv, rL, gamma, Rg, elDof, dim,
+                                   num_equation, es);
           break;
         case OutletType::SUB_MF_NR:
-          computeNRSubMassFlow_serial(offsetBdrU + q, &u1[0], &gradUp1[0], d_meanUp, dt, &u2[0], d_boundaryU,
-                                      d_inputState, &nor[0], d_tang1, d_tang2, d_inv, refLength, area, gamma, Rg, elDof,
-                                      dim, num_equation, eqSystem);
+          computeNRSubMassFlow_serial(offsetBdrU + q, &u1[0], &gradUp1[0], d_meanUp, dtloc, &u2[0], d_boundaryU,
+                                      d_inputState, &nor[0], d_tang1, d_tang2, d_inv, rL, A, gamma, Rg, elDof,
+                                      dim, num_equation, es);
           break;
         case OutletType::SUB_MF_NR_PW:
           printf("OUTLET SUB_MF_NR_PW BC NOT IMPLEMENTED");

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -130,12 +130,12 @@ class OutletBC : public BoundaryCondition {
                                    const int &dim, const int &num_equation, GasMixture *mixture,
                                    const double &refLength, const double &area);
 
-  static void interpOutlet_gpu(const OutletType type, const Array<double> &inputState, Vector &interpolated_Ubdr,
-                               Vector &interpolatedGradUpbdr_, const Vector &x, const Array<int> &nodesIDs,
-                               const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp,
-                               Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
-                               Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs,
-                               const int &dim, const int &num_equation);
+  void interpOutlet_gpu(const OutletType type, const Array<double> &inputState, Vector &interpolated_Ubdr,
+                        Vector &interpolatedGradUpbdr_, const Vector &x, const Array<int> &nodesIDs,
+                        const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp,
+                        Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
+                        Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs,
+                        const int &dim, const int &num_equation);
 
 #ifdef _GPU_  // GPU functions
   static MFEM_HOST_DEVICE void computeSubPressure(const double *u1, double *u2, const double *nor, const double &press,

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -132,10 +132,10 @@ class OutletBC : public BoundaryCondition {
 
   void interpOutlet_gpu(const OutletType type, const Array<double> &inputState, Vector &interpolated_Ubdr,
                         Vector &interpolatedGradUpbdr_, const Vector &x, const Array<int> &nodesIDs,
-                        const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp,
-                        Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
-                        Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs,
-                        const int &dim, const int &num_equation);
+                        const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC,
+                        Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
+                        Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs, const int &dim,
+                        const int &num_equation);
 
 #ifdef _GPU_  // GPU functions
   static MFEM_HOST_DEVICE void computeSubPressure(const double *u1, double *u2, const double *nor, const double &press,

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -64,8 +64,8 @@ class OutletBC : public BoundaryCondition {
   Array<int> bdrElemsQ;  // element dofs and face num. of integration points
   Array<int> bdrDofs;    // indexes of the D
   Vector bdrShape;       // shape functions evaluated at the integration points
-  const int &maxIntPoints;
-  const int &maxDofs;
+  const int &maxIntPoints_;
+  const int &maxDofs_;
 
   // local vector for mean calculation
   Vector localMeanUp;
@@ -122,12 +122,12 @@ class OutletBC : public BoundaryCondition {
                             const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
                             Vector &shapesBC,
                             Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
-                            Array<int> &offsetBoundaryU, const int &maxIntPoints, const int &maxDofs);
+                            Array<int> &offsetBoundaryU);
 
   void interpOutlet_gpu(const Vector &x, const Array<int> &nodesIDs,
                         const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC,
                         Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
-                        Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs);
+                        Array<int> &offsetsBoundaryU);
 
 #ifdef _GPU_  // GPU functions
   static MFEM_HOST_DEVICE void computeSubPressure(const double *u1, double *u2, const double *nor, const double &press,

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -119,15 +119,13 @@ class OutletBC : public BoundaryCondition {
   // functions for BC integration on GPU
 
   void integrateOutlets_gpu(Vector &y,  // output
-                            const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
-                            Vector &shapesBC,
+                            const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds, Vector &shapesBC,
                             Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
                             Array<int> &offsetBoundaryU);
 
-  void interpOutlet_gpu(const Vector &x, const Array<int> &nodesIDs,
-                        const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC,
-                        Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
-                        Array<int> &offsetsBoundaryU);
+  void interpOutlet_gpu(const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds, ParGridFunction *Up,
+                        ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
+                        Array<int> &listElems, Array<int> &offsetsBoundaryU);
 
 #ifdef _GPU_  // GPU functions
   static MFEM_HOST_DEVICE void computeSubPressure(const double *u1, double *u2, const double *nor, const double &press,

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -122,14 +122,12 @@ class OutletBC : public BoundaryCondition {
                             const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
                             Vector &shapesBC,
                             Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
-                            Array<int> &offsetBoundaryU, const int &maxIntPoints, const int &maxDofs,
-                            const int &dim, const int &num_equation);
+                            Array<int> &offsetBoundaryU, const int &maxIntPoints, const int &maxDofs);
 
   void interpOutlet_gpu(const Vector &x, const Array<int> &nodesIDs,
                         const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC,
                         Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
-                        Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs, const int &dim,
-                        const int &num_equation);
+                        Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs);
 
 #ifdef _GPU_  // GPU functions
   static MFEM_HOST_DEVICE void computeSubPressure(const double *u1, double *u2, const double *nor, const double &press,

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -47,7 +47,7 @@ class OutletBC : public BoundaryCondition {
  private:
   MPI_Groups *groupsMPI;
 
-  const OutletType outletType;
+  const OutletType outletType_;
 
   // In/out conditions specified in the configuration file
   const Array<double> inputState;
@@ -73,7 +73,7 @@ class OutletBC : public BoundaryCondition {
   Vector glob_sum;
 
   // area of the outlet
-  double area;
+  double area_;
   bool parallelAreaComputed;
 
   // Unit trangent vector 1 & 2
@@ -118,20 +118,14 @@ class OutletBC : public BoundaryCondition {
 
   // functions for BC integration on GPU
 
-  static void integrateOutlets_gpu(const OutletType type, Equations &eqSystem, const Array<double> &inputState,
-                                   const double &dt,
-                                   Vector &y,  // output
-                                   const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
-                                   ParGridFunction *Up, ParGridFunction *gradUp, Vector &meanUp, Vector &boundaryU,
-                                   Vector &interpolated_Ubdr, Vector &interpolatedGradUpbdr_, Vector &tangent1,
-                                   Vector &tangent2, Vector &inverseNorm2cartesian, Vector &shapesBC,
-                                   Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
-                                   Array<int> &offsetBoundaryU, const int &maxIntPoints, const int &maxDofs,
-                                   const int &dim, const int &num_equation, GasMixture *mixture,
-                                   const double &refLength, const double &area);
+  void integrateOutlets_gpu(Vector &y,  // output
+                            const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
+                            Vector &shapesBC,
+                            Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
+                            Array<int> &offsetBoundaryU, const int &maxIntPoints, const int &maxDofs,
+                            const int &dim, const int &num_equation);
 
-  void interpOutlet_gpu(const OutletType type, const Array<double> &inputState, Vector &interpolated_Ubdr,
-                        Vector &interpolatedGradUpbdr_, const Vector &x, const Array<int> &nodesIDs,
+  void interpOutlet_gpu(const Vector &x, const Array<int> &nodesIDs,
                         const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC,
                         Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
                         Array<int> &offsetsBoundaryU, const int &maxIntPoints, const int &maxDofs, const int &dim,

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -311,17 +311,16 @@ RHSoperator::~RHSoperator() {
 void RHSoperator::Mult(const Vector &x, Vector &y) const {
   max_char_speed = 0.;
 
-#ifdef _GPU_
-  // start transfer of U bdr data
-  initNBlockDataTransfer(x, vfes, transferU);
-#endif
   // Update primite varibales
   updatePrimitives(x);
 #ifdef _GPU_
   // GPU version requires the exchange of data before gradient computation
   initNBlockDataTransfer(*Up, vfes, transferUp);
+  initNBlockDataTransfer(x, vfes, transferU);
+
   gradients->computeGradients_domain();
   waitAllDataTransfer(vfes, transferUp);
+
   gradients->computeGradients_bdr();
   initNBlockDataTransfer(*gradUp, gradUpfes, transferGradUp);
 #else
@@ -332,6 +331,7 @@ void RHSoperator::Mult(const Vector &x, Vector &y) const {
   if (bcIntegrator != NULL) bcIntegrator->updateBCMean(Up);
 
 #ifdef _GPU_
+  z = 0.;
   A->Mult_domain(x, z);
 
   waitAllDataTransfer(vfes, transferU);
@@ -889,6 +889,9 @@ void RHSoperator::initNBlockDataTransfer(const Vector &x, ParFiniteElementSpace 
   if (pfes->GetFaceNbrVSize() <= 0) {
     return;
   }
+#ifdef HAVE_GRVY
+  grvy_timer_begin(__func__);
+#endif
 
   ParMesh *pmesh = pfes->GetParMesh();
 
@@ -915,11 +918,11 @@ void RHSoperator::initNBlockDataTransfer(const Vector &x, ParFiniteElementSpace 
   });
 
   bool mpi_gpu_aware = Device::GetGPUAwareMPI();
-  //    auto send_data_ptr = mpi_gpu_aware ? send_data.Read() : send_data.HostRead();
-  //    auto face_nbr_data_ptr = mpi_gpu_aware ? face_nbr_data.Write() :
-  //                             face_nbr_data.HostWrite();
-  auto send_data_ptr = dataTransfer.send_data.HostRead();
-  auto face_nbr_data_ptr = dataTransfer.face_nbr_data.HostWrite();
+  //std::cout << "mpi_gpu_aware = " << mpi_gpu_aware << std::endl;
+  auto send_data_ptr = mpi_gpu_aware ? dataTransfer.send_data.Read() : dataTransfer.send_data.HostRead();
+  auto face_nbr_data_ptr = mpi_gpu_aware ? dataTransfer.face_nbr_data.Write() : dataTransfer.face_nbr_data.HostWrite();
+  // auto send_data_ptr = dataTransfer.send_data.HostRead();
+  // auto face_nbr_data_ptr = dataTransfer.face_nbr_data.HostWrite();
 
   for (int fn = 0; fn < dataTransfer.num_face_nbrs; fn++) {
     int nbr_rank = pmesh->GetFaceNbrRank(fn);
@@ -931,15 +934,27 @@ void RHSoperator::initNBlockDataTransfer(const Vector &x, ParFiniteElementSpace 
     MPI_Irecv(&face_nbr_data_ptr[recv_offset[fn]], recv_offset[fn + 1] - recv_offset[fn], MPI_DOUBLE, nbr_rank, tag,
               MyComm, &dataTransfer.requests[fn + dataTransfer.num_face_nbrs]);
   }
+
+
+#ifdef HAVE_GRVY
+  grvy_timer_end(__func__);
+#endif
 }
 
 void RHSoperator::waitAllDataTransfer(ParFiniteElementSpace *pfes, dataTransferArrays &dataTransfer) {
   if (pfes->GetFaceNbrVSize() <= 0) {
     return;
   }
+#ifdef HAVE_GRVY
+  grvy_timer_begin(__func__);
+#endif
 
   MPI_Waitall(dataTransfer.num_face_nbrs, dataTransfer.requests, dataTransfer.statuses);
   MPI_Waitall(dataTransfer.num_face_nbrs, dataTransfer.requests + dataTransfer.num_face_nbrs, dataTransfer.statuses);
+#ifdef HAVE_GRVY
+  grvy_timer_end(__func__);
+#endif
+
 }
 
 void RHSoperator::computeMeanTimeDerivatives(Vector &y) const {

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -142,6 +142,7 @@ void Tps::parseCommandLineArgs(int argc, char *argv[]) {
 void Tps::chooseDevices() {
 #ifdef _GPU_
   device_.Configure(deviceConfig_, rank_ % numGpusPerRank_);
+  device_.SetGPUAwareMPI(true); // TODO: determine based on config???
 #endif
 
   if (isRank0_) {

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -147,7 +147,7 @@ void Tps::chooseDevices() {
 #ifdef _GPU_
   device_.Configure(deviceConfig_, rank_ % numGpusPerRank_);
 
-  int mpi_gpu_aware = 0; //false;
+  int mpi_gpu_aware = 0;  // false;
 #if _CUDA_ && defined(MPIX_CUDA_AWARE_SUPPORT)
   // check for cuda-aware mpi (if possible)
   mpi_gpu_aware = MPIX_Query_cuda_support();

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -371,17 +371,18 @@ void WallBC::integrateWalls_gpu(const WallType type, const double &wallTemp, Vec
       const int el_bdry = d_listElems[n];
       const int Q = d_intPointsElIDBC[2 * el_bdry];
 
+      el = d_intPointsElIDBC[2 * el_bdry + 1];
+
+      elOffset = d_posDofIds[2 * el];
+      elDof = d_posDofIds[2 * el + 1];
+
       if (!elemDataRecovered) {
-        el = d_intPointsElIDBC[2 * el_bdry + 1];
-
-        elOffset = d_posDofIds[2 * el];
-        elDof = d_posDofIds[2 * el + 1];
-
-        for (int i = 0; i < elDof; i++) {
+        MFEM_FOREACH_THREAD(i, x, elDof) {
           for (int eq = 0; eq < num_equation; eq++) {
             Fcontrib[i + eq * elDof] = 0.;
           }
         }
+        MFEM_SYNC_THREAD;
         elemDataRecovered = true;
       }
 

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -119,12 +119,10 @@ void WallBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradSt
 void WallBC::integrationBC(Vector &y, const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
                            ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                            Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs) {
-  interpWalls_gpu(x, nodesIDs, posDofIds, Up, gradUp,
-                  shapesBC, normalsWBC, intPointsElIDBC, maxDofs);
+  interpWalls_gpu(x, nodesIDs, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, maxDofs);
 
   integrateWalls_gpu(y,  // output
-                     x, nodesIDs, posDofIds, shapesBC,
-                     normalsWBC, intPointsElIDBC, maxDofs);
+                     x, nodesIDs, posDofIds, shapesBC, normalsWBC, intPointsElIDBC, maxDofs);
 }
 
 void WallBC::computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius,
@@ -308,11 +306,8 @@ void WallBC::computeIsothermalWallFlux(Vector &normal, Vector &stateIn, DenseMat
   }
 }
 
-void WallBC::integrateWalls_gpu(Vector &y, const Vector &x,
-                                const Array<int> &nodesIDs,
-                                const Array<int> &posDofIds,
-                                Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
-                                const int &maxDofs) {
+void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
+                                Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, const int &maxDofs) {
 #ifdef _GPU_
   double *d_y = y.Write();
   //   const double *d_U = x.Read();
@@ -406,10 +401,9 @@ void WallBC::integrateWalls_gpu(Vector &y, const Vector &x,
 #endif
 }
 
-void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs,
-                             const Array<int> &posDofIds, mfem::ParGridFunction *Up, mfem::ParGridFunction *gradUp,
-                             mfem::Vector &shapesBC, mfem::Vector &normalsWBC, Array<int> &intPointsElIDBC,
-                             const int &maxDofs) {
+void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
+                             mfem::ParGridFunction *Up, mfem::ParGridFunction *gradUp, mfem::Vector &shapesBC,
+                             mfem::Vector &normalsWBC, Array<int> &intPointsElIDBC, const int &maxDofs) {
 #ifdef _GPU_
   double *d_flux = face_flux_.Write();
 

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -445,8 +445,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs,
   // el_wall is index within wall boundary elements?
   MFEM_FORALL_2D(el_wall, wallElems.Size() / 7, maxIntPoints, 1, 1, {
     double u1[5], u2[5], nor[3], Rflux[5], vF1[5 * 3], vF2[5 * 3];
-    double gradUp1[5 * 3], gradUp2[5 * 3];
-    double Ui[216], gradUpi[216 * 3];
+    double gradUp1[5 * 3];
     double shape[216];
     int index_i[216];
 

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -350,16 +350,14 @@ void WallBC::integrateWalls_gpu(const WallType type, const double &wallTemp, Vec
   const WorkingFluid fluid = mixture->GetWorkingFluid();
 
   // clang-format on
-  MFEM_FORALL(el_wall, wallElems.Size() / 7, {
+  //MFEM_FORALL(el_wall, wallElems.Size() / 7, {
+  MFEM_FORALL_2D(el_wall, wallElems.Size() / 7, maxDofs, 1, 1, {
     // double Fcontrib[216 * 20];
     // double shape[216];
     // double Rflux[20], u1[20], u2[20], nor[3], gradUpi[20 * 3];
     // double vF1[20 * 3], vF2[20 * 3];
-    double Fcontrib[216 * 5];
-    double shape[216];
-    double Rflux[5], u1[5], u2[5], nor[3], gradUpi[5 * 3];
-    double vF1[5 * 3], vF2[5 * 3];
-    double weight;
+    MFEM_SHARED double Fcontrib[216 * 5];
+    double Rflux[5];
 
     const int numFaces = d_wallElems[0 + el_wall * 7];
     bool elemDataRecovered = false;
@@ -388,53 +386,30 @@ void WallBC::integrateWalls_gpu(const WallType type, const double &wallTemp, Vec
       }
 
       for (int q = 0; q < Q; q++) {  // loop over int. points
-        for (int i = 0; i < elDof; i++) shape[i] = d_shapesBC[i + q * maxDofs + el_bdry * maxIntPoints * maxDofs];
-        for (int d = 0; d < dim; d++) nor[d] = d_normW[d + q * (dim + 1) + el_bdry * maxIntPoints * (dim + 1)];
-        weight = d_normW[dim + q * (dim + 1) + el_bdry * maxIntPoints * (dim + 1)];
+        const double weight = d_normW[dim + q * (dim + 1) + el_bdry * maxIntPoints * (dim + 1)];
 
-        for (int eq = 0; eq < num_equation; eq++) {  // recover interpolated data
-          u1[eq] = d_interpolU[eq + q * num_equation + n * maxIntPoints * num_equation];
-          for (int d = 0; d < dim; d++)
-            gradUpi[eq + d * num_equation] =
-                d_interpGrads[eq + d * num_equation + q * dim * num_equation + n * maxIntPoints * dim * num_equation];
-        }
-
-        // compute mirror state
-        switch (type) {
-          case WallType::INV:
-            computeInvWallState_gpu_serial(&u1[0], &u2[0], &nor[0], dim, num_equation);
-            break;
-          case WallType::VISC_ISOTH:
-            computeIsothermalState_gpu_serial(&u1[0], &u2[0], &nor[0], wallTemp, gamma, Rg, dim, num_equation, fluid);
-            break;
-          case WallType::VISC_ADIAB:
-            break;
-        }
-
-        // evaluate flux
-        RiemannSolver::riemannLF_serial_gpu(&u1[0], &u2[0], &Rflux[0], &nor[0], gamma, Rg, dim, num_equation);
-        Fluxes::viscousFlux_serial_gpu(&vF1[0], &u1[0], &gradUpi[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,
-                                       num_equation);
-        Fluxes::viscousFlux_serial_gpu(&vF2[0], &u2[0], &gradUpi[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,
-                                       num_equation);
-
-        // add visc flux contribution
         for (int eq = 0; eq < num_equation; eq++)
-          for (int d = 0; d < dim; d++)
-            Rflux[eq] -= 0.5 * (vF2[eq + d * num_equation] + vF1[eq + d * num_equation]) * nor[d];
+          Rflux[eq] = weight * d_interpolU[eq + q * num_equation + n * maxIntPoints * num_equation];
 
         // sum contributions to integral
-        for (int i = 0; i < elDof; i++) {
-          for (int eq = 0; eq < num_equation; eq++) Fcontrib[i + eq * elDof] -= Rflux[eq] * shape[i] * weight;
+        //for (int i = 0; i < elDof; i++) {
+        MFEM_FOREACH_THREAD(i, x, elDof) {
+          const double shape = d_shapesBC[i + q * maxDofs + el_bdry * maxIntPoints * maxDofs];
+          for (int eq = 0; eq < num_equation; eq++) {
+            Fcontrib[i + eq * elDof] -= Rflux[eq] * shape;
+          }
         }
+        MFEM_SYNC_THREAD;
       }
     }
 
     // add to global data
-    for (int i = 0; i < elDof; i++) {
+    //for (int i = 0; i < elDof; i++) {
+    MFEM_FOREACH_THREAD(i, x, elDof) {
       const int indexi = d_nodesIDs[elOffset + i];
       for (int eq = 0; eq < num_equation; eq++) d_y[indexi + eq * totDofs] += Fcontrib[i + eq * elDof];
     }
+    MFEM_SYNC_THREAD;
   });
 #endif
 }
@@ -462,12 +437,24 @@ void WallBC::interpWalls_gpu(const WallType type, const double &wallTemp, mfem::
   const int totDofs = x.Size() / num_equation;
   const int numBdrElem = listElems.Size();
 
+  const double Rg = mixture->GetGasConstant();
+  const double gamma = mixture->GetSpecificHeatRatio();
+  const double viscMult = mixture->GetViscMultiplyer();
+  const double bulkViscMult = mixture->GetBulkViscMultiplyer();
+  const double Pr = mixture->GetPrandtlNum();
+  const double Sc = mixture->GetSchmidtNum();
+
+  const WorkingFluid fluid = mixture->GetWorkingFluid();
+
   // clang-format on
   // el_wall is index within wall boundary elements?
   MFEM_FORALL_2D(el_wall, wallElems.Size() / 7, maxIntPoints, 1, 1,
       {
+        double u1[5], u2[5], nor[3], Rflux[5], vF1[5 * 3], vF2[5 * 3];
+        double gradUp1[5 * 3], gradUp2[5 * 3];
         double Ui[216], gradUpi[216 * 3];
         double shape[216];
+        int index_i[216];
 
         const int numFaces = d_wallElems[0 + el_wall * 7];
 
@@ -480,36 +467,76 @@ void WallBC::interpWalls_gpu(const WallType type, const double &wallTemp, mfem::
           const int elOffset = d_posDofIds[2 * el];
           const int elDof = d_posDofIds[2 * el + 1];
 
-          for (int eq = 0; eq < num_equation; eq++) {
-            for (int i = 0; i < elDof; i++) {
-              // load data
-              const int indexi = d_nodesIDs[elOffset + i];
-              Ui[i] = d_U[indexi + eq * totDofs];
-              for (int d = 0; d < dim; d++)
-                gradUpi[i + d * elDof] = d_gradUp[indexi + eq * totDofs + d * num_equation * totDofs];
+          for (int i = 0; i < elDof; i++) {
+            index_i[i] = d_nodesIDs[elOffset + i];
+          }
+
+          MFEM_FOREACH_THREAD(q, x, Q) {
+            // zero state and gradient at this quad point
+            for (int eq = 0; eq < num_equation; eq++) {
+              u1[eq] = 0.;
+              for (int d = 0; d < dim; d++) {
+                gradUp1[eq + d * num_equation] = 0.;
+              }
             }
 
-            MFEM_FOREACH_THREAD(q, x, Q) {
-              for (int j = 0; j < elDof; j++) shape[j] = d_shapesBC[j + q * maxDofs + el_bdry * maxIntPoints * maxDofs];
+            // extract shape functions at this quad point
+            for (int j = 0; j < elDof; j++) {
+              shape[j] = d_shapesBC[j + q * maxDofs + el_bdry * maxIntPoints * maxDofs];
+            }
 
-              double u1 = 0.;
-              for (int j = 0; j < elDof; j++) u1 += shape[j] * Ui[j];
+            // extract normal vector at this quad point
+            for (int d = 0; d < dim; d++) {
+              nor[d] = d_normW[d + q * (dim + 1) + el_bdry * maxIntPoints * (dim + 1)];
+            }
 
-              double gUp[3];
-              for (int d = 0; d < dim; d++) {
-                gUp[d] = 0.;
-                for (int j = 0; j < elDof; j++) gUp[d] += gradUpi[j + d * elDof] * shape[j];
+            // interpolate to this quad point
+            for (int eq = 0; eq < num_equation; eq++) {
+              for (int i = 0; i < elDof; i++) {
+                const int indexi = index_i[i];
+                u1[eq] += d_U[indexi + eq * totDofs] * shape[i];
+                for (int d = 0; d < dim; d++)
+                  gradUp1[eq + d * num_equation] += d_gradUp[indexi + eq * totDofs + d * num_equation * totDofs] * shape[i];
               }
+            }
 
-              // save to global
-              d_interpolU[eq + q * num_equation + n * maxIntPoints * num_equation] = u1;
+            // // save to global
+            // d_interpolU[eq + q * num_equation + n * maxIntPoints * num_equation] = u1;
 
-              for (int d = 0; d < dim; d++) {
-                d_interpGrads[eq + d * num_equation + q * dim * num_equation + n * maxIntPoints * dim * num_equation] =
-                    gUp[d];
-              }
-            }  // end quadrature point loop
-          }    // end equation loop
+            // for (int d = 0; d < dim; d++) {
+            //   d_interpGrads[eq + d * num_equation + q * dim * num_equation + n * maxIntPoints * dim * num_equation] =
+            //     gUp[d];
+            // }
+
+            // compute mirror state
+            switch (type) {
+              case WallType::INV:
+                computeInvWallState_gpu_serial(&u1[0], &u2[0], &nor[0], dim, num_equation);
+                break;
+              case WallType::VISC_ISOTH:
+                computeIsothermalState_gpu_serial(&u1[0], &u2[0], &nor[0], wallTemp, gamma, Rg, dim, num_equation, fluid);
+                break;
+              case WallType::VISC_ADIAB:
+                break;
+            }
+
+            // evaluate flux
+            RiemannSolver::riemannLF_serial_gpu(&u1[0], &u2[0], &Rflux[0], &nor[0], gamma, Rg, dim, num_equation);
+            Fluxes::viscousFlux_serial_gpu(&vF1[0], &u1[0], &gradUp1[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,
+                                           num_equation);
+            Fluxes::viscousFlux_serial_gpu(&vF2[0], &u2[0], &gradUp1[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,
+                                           num_equation);
+
+            // add visc flux contribution
+            for (int eq = 0; eq < num_equation; eq++)
+              for (int d = 0; d < dim; d++)
+                Rflux[eq] -= 0.5 * (vF2[eq + d * num_equation] + vF1[eq + d * num_equation]) * nor[d];
+
+            // store flux (TODO: change variable name)
+            for (int eq = 0; eq < num_equation; eq++)
+              d_interpolU[eq + q * num_equation + n * maxIntPoints * num_equation] = Rflux[eq];
+
+          }  // end quadrature point loop
         }      // end face loop
       });      // end element loop
 #endif

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -463,8 +463,8 @@ void WallBC::interpWalls_gpu(const WallType type, const double &wallTemp, mfem::
   const int numBdrElem = listElems.Size();
 
   // clang-format on
-  MFEM_FORALL(
-      el_wall, wallElems.Size() / 7,  // el_wall is index within wall boundary elements?
+  // el_wall is index within wall boundary elements?
+  MFEM_FORALL_2D(el_wall, wallElems.Size() / 7, maxIntPoints, 1, 1,
       {
         double Ui[216], gradUpi[216 * 3];
         double shape[216];
@@ -489,7 +489,7 @@ void WallBC::interpWalls_gpu(const WallType type, const double &wallTemp, mfem::
                 gradUpi[i + d * elDof] = d_gradUp[indexi + eq * totDofs + d * num_equation * totDofs];
             }
 
-            for (int q = 0; q < Q; q++) {
+            MFEM_FOREACH_THREAD(q, x, Q) {
               for (int j = 0; j < elDof; j++) shape[j] = d_shapesBC[j + q * maxDofs + el_bdry * maxIntPoints * maxDofs];
 
               double u1 = 0.;

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -92,12 +92,12 @@ class WallBC : public BoundaryCondition {
                                  const Equations &eqSystem, const int &maxIntPoints, const int &maxDofs, const int &dim,
                                  const int &num_equation, GasMixture *mixture);
 
-  static void interpWalls_gpu(const WallType type, const double &wallTemp, Vector &interpolated_Ubdr_,
-                              Vector &interpolatedGradUpbdr_, const Vector &x, const Array<int> &nodesIDs,
-                              const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp,
-                              Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &wallElems,
-                              Array<int> &listElems, const int &maxIntPoints, const int &maxDofs, const int &dim,
-                              const int &num_equation);
+  void interpWalls_gpu(const WallType type, const double &wallTemp, Vector &interpolated_Ubdr_,
+                       Vector &interpolatedGradUpbdr_, const Vector &x, const Array<int> &nodesIDs,
+                       const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp,
+                       Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &wallElems,
+                       Array<int> &listElems, const int &maxIntPoints, const int &maxDofs, const int &dim,
+                       const int &num_equation);
 
 #ifdef _GPU_
   static MFEM_HOST_DEVICE void computeInvWallState(const double *u1, double *u2, const double *nor, const int &dim,

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -87,13 +87,12 @@ class WallBC : public BoundaryCondition {
                           const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
                           Vector &shapesBC, Vector &normalsWBC,
                           Array<int> &intPointsElIDBC, Array<int> &wallElems, Array<int> &listElems,
-                          const Equations &eqSystem, const int &maxIntPoints, const int &maxDofs, const int &dim,
-                          const int &num_equation);
+                          const Equations &eqSystem, const int &maxIntPoints, const int &maxDofs);
 
   void interpWalls_gpu(const Vector &x, const Array<int> &nodesIDs,
                        const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC,
                        Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &wallElems, Array<int> &listElems,
-                       const int &maxIntPoints, const int &maxDofs, const int &dim, const int &num_equation);
+                       const int &maxIntPoints, const int &maxDofs);
 
 #ifdef _GPU_
   static MFEM_HOST_DEVICE void computeInvWallState(const double *u1, double *u2, const double *nor, const int &dim,

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -94,10 +94,9 @@ class WallBC : public BoundaryCondition {
 
   void interpWalls_gpu(const WallType type, const double &wallTemp, Vector &interpolated_Ubdr_,
                        Vector &interpolatedGradUpbdr_, const Vector &x, const Array<int> &nodesIDs,
-                       const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp,
-                       Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &wallElems,
-                       Array<int> &listElems, const int &maxIntPoints, const int &maxDofs, const int &dim,
-                       const int &num_equation);
+                       const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC,
+                       Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &wallElems, Array<int> &listElems,
+                       const int &maxIntPoints, const int &maxDofs, const int &dim, const int &num_equation);
 
 #ifdef _GPU_
   static MFEM_HOST_DEVICE void computeInvWallState(const double *u1, double *u2, const double *nor, const int &dim,

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -45,11 +45,11 @@ using namespace mfem;
 class WallBC : public BoundaryCondition {
  private:
   // The type of wall
-  const WallType wallType;
+  const WallType wallType_;
 
   Fluxes *fluxClass;
 
-  double wallTemp;
+  double wallTemp_;
 
   const Array<int> &intPointsElIDBC;
   const int &maxIntPoints;
@@ -83,17 +83,14 @@ class WallBC : public BoundaryCondition {
                              ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                              Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs);
 
-  static void integrateWalls_gpu(const WallType type, const double &wallTemp,
-                                 Vector &y,  // output
-                                 const Vector &x, Vector &interpolated_Ubdr_, Vector &interpolatedGradUpbdr_,
-                                 const Array<int> &nodesIDs, const Array<int> &posDofIds, ParGridFunction *Up,
-                                 ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
-                                 Array<int> &intPointsElIDBC, Array<int> &wallElems, Array<int> &listElems,
-                                 const Equations &eqSystem, const int &maxIntPoints, const int &maxDofs, const int &dim,
-                                 const int &num_equation, GasMixture *mixture);
+  void integrateWalls_gpu(Vector &y,  // output
+                          const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
+                          Vector &shapesBC, Vector &normalsWBC,
+                          Array<int> &intPointsElIDBC, Array<int> &wallElems, Array<int> &listElems,
+                          const Equations &eqSystem, const int &maxIntPoints, const int &maxDofs, const int &dim,
+                          const int &num_equation);
 
-  void interpWalls_gpu(const WallType type, const double &wallTemp, Vector &interpolated_Ubdr_,
-                       Vector &interpolatedGradUpbdr_, const Vector &x, const Array<int> &nodesIDs,
+  void interpWalls_gpu(const Vector &x, const Array<int> &nodesIDs,
                        const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC,
                        Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &wallElems, Array<int> &listElems,
                        const int &maxIntPoints, const int &maxDofs, const int &dim, const int &num_equation);

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -52,7 +52,7 @@ class WallBC : public BoundaryCondition {
   double wallTemp_;
 
   const Array<int> &intPointsElIDBC;
-  const int &maxIntPoints;
+  const int &maxIntPoints_;
 
   Array<int> wallElems;
   void buildWallElemsArray(const Array<int> &intPointsElIDBC);
@@ -86,13 +86,13 @@ class WallBC : public BoundaryCondition {
   void integrateWalls_gpu(Vector &y,  // output
                           const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
                           Vector &shapesBC, Vector &normalsWBC,
-                          Array<int> &intPointsElIDBC, Array<int> &wallElems, Array<int> &listElems,
-                          const Equations &eqSystem, const int &maxIntPoints, const int &maxDofs);
+                          Array<int> &intPointsElIDBC,
+                          const int &maxDofs);
 
   void interpWalls_gpu(const Vector &x, const Array<int> &nodesIDs,
                        const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC,
-                       Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &wallElems, Array<int> &listElems,
-                       const int &maxIntPoints, const int &maxDofs);
+                       Vector &normalsWBC, Array<int> &intPointsElIDBC,
+                       const int &maxDofs);
 
 #ifdef _GPU_
   static MFEM_HOST_DEVICE void computeInvWallState(const double *u1, double *u2, const double *nor, const int &dim,

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -84,14 +84,11 @@ class WallBC : public BoundaryCondition {
                              Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs);
 
   void integrateWalls_gpu(Vector &y,  // output
-                          const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
-                          Vector &shapesBC, Vector &normalsWBC,
-                          Array<int> &intPointsElIDBC,
-                          const int &maxDofs);
+                          const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds, Vector &shapesBC,
+                          Vector &normalsWBC, Array<int> &intPointsElIDBC, const int &maxDofs);
 
-  void interpWalls_gpu(const Vector &x, const Array<int> &nodesIDs,
-                       const Array<int> &posDofIds, ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC,
-                       Vector &normalsWBC, Array<int> &intPointsElIDBC,
+  void interpWalls_gpu(const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds, ParGridFunction *Up,
+                       ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
                        const int &maxDofs);
 
 #ifdef _GPU_

--- a/tps_config.h.in
+++ b/tps_config.h.in
@@ -45,6 +45,9 @@
 /* Define if you have the MPI library. */
 #undef HAVE_MPI
 
+/* Enable MPI extensions declared in mpi-ext.h */
+#undef HAVE_MPI_EXT
+
 /* Define if OPENBLAS is available */
 #undef HAVE_OPENBLAS
 


### PR DESCRIPTION
#### Purpose
The modifications of the `_GPU_` code path in #123, #128, and #130 led to improvements in serial performance but negatively affected scaling.  This PR aims to improve the parallel efficiency back to levels near what was observed before #123 was merged.

#### Approach
Modifications were targeted at `_GPU_` functions that were observed to scale poorly.  Ususally these modifications were intended to increase the level of gpu parallelism to better exploit the gpu at small element counts.  Often this takes the form of replacing a single `MFEM_FORALL` over the relevant number of elements with a nested `MFEM_FORALL_2D` / `MFEM_FOREACH_THREAD` approach.  For an example, see 40a03d5.

Additionally, the ability to use a gpu-aware mpi stack was added.  This has a small but non-negligible effect, especially as the number of elements per mpi task becomes smaller.

#### Performance
We analyze scaling on `lassen` for a relatively small case at relatively small numbers of mpi tasks, but this is sufficient to show the performance differences of interest.

##### Test case
The test case is a modified version of the cylinder regression test case.  We run with `p=3`, and to increase the element count, the mesh is uniformly refined once.  The diff between the cylinder regression input file and the case used here is given below:
```
[oliver33@lassen709:tps]$ diff test/inputs/input.dtconst.cyl.ini test/inputs/input.dtconst.cyl100.ini
6c6,7
< order = 1
---
> refinement_levels = 1
> order = 3
9,10c10,11
< maxIters = 4
< outputFreq = 5
---
> maxIters = 2000
> outputFreq = 2000
21c22
< cfl = 0.80
---
> cfl = 0.12
52a54,55
> [gpu]
> numGpusPerRank = 4
```

##### SHAs tested
Five variants of the code were tested, as listed below:
  * `b7ee7c0`: #50 merge commit; showed performance results for this at Y1 PSAAP review
  * `3991918`: v1.1
  * `bf2c631`: #119 merge; nothing particularly special about this, but it is before any of recent gpu refactoring
  * `7e3e3b9`: Last commit on #130; gpu refactoring prior to any scaling considerations
  * `23abbf2`: Last commit on this PR

##### Results without cuda-aware mpi
Results without cuda-aware mpi are shown below.
![lassen-scaling](https://user-images.githubusercontent.com/4238008/169874343-a50c9684-406f-4ff9-818c-5ba807f28378.png)
Items of interest include:
  * Wall-clock time per step has been significantly reduced
    - Relative to `b7ee7c0` more than 4x improvement on 1 node and approx 3.5x improvement on 8 nodes
    - Relative to `bf2c631`, 2.75x improvement on 1 node and 2.5x improvement on 8 nodes
  * Parallel efficiency is significantly degraded from `bf2c631` to `7e3e3b9` (e.g., from approx 78% to 37% on 8 nodes)
  * Most, but not quite all, of this loss is recovered by changes in this PR (e.g., back up to 74% on 8 nodes)

##### Results with cuda-aware mpi
To use the cuda-aware mpi on lassen, we add `-M "-gpu"` to the `lrun` line of the job script.  Then, the machinery added in 21b239f will automatically take advantage of the cuda-aware mpi capabilities in `tps` and `mfem`.

Not all previous SHAs have been retested with the cuda-aware mpi.  This is partially due to the fact that the changes in 21b239f are required for `tps` to take advantage of the cuda-aware mpi.  These changes could be applied to previous code states to see the effect, but this has not been done.  Instead, the table below shows the effect on wall time per time step (in seconds) just for 23abbf2:

| Lassen nodes | regular mpi | cuda-aware mpi |
| --- | --- | --- |
| 1   | 0.106 | 0.104 |
| 2   | 0.0570 | 0.0547 |
| 4   | 0.0313 | 0.0297 |
| 8   | 0.0179 | 0.0167 |
| 16   | 0.0118 | 0.0108 |

A small effect that increases with node count is observed.  Absolute time per step is reduced by 6.7% at 8 nodes and 8.5% at 16 nodes, which leads to slightly better parallel efficiencies (e.g., at 16 nodes cuda-aware mpi improves to 60%, versus 56% for regular mpi).

#### Known Issues
When using the cuda-aware MPI on `lassen`, `tps` runs do not end cleanly.  While the simulations appear to complete successfully (and `./soln_differ` run by hand shows no differences for the regression tests), an error occurs somewhere during the tear-down process.  In particular, we see
```
Cuda failure /__SMPI_build_dir_______________________________________/ibmsrc/pami/ibm-pami/buildtools/pami_build_port/../pami/components/devices/shmem/ShmemDevice.h:425: 'driver shutting down'
```
reported from each mpi task.