### PR TITLE
Update hip build to generate relocatable device code (w/ -fgpu-rdc)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -191,8 +191,10 @@ if test x$ENABLE_GPU != xyes; then
    AX_HIP_CHECK()
    AM_CONDITIONAL(GPU_ENABLED,test x$ENABLE_HIP = xyes)
 
-   dnl Absolutely insist that libtool has CC=hipcc for tag=CXX
-   _LT_TAGVAR(compiler,CXX)='hipcc'
+   if test x$ENABLE_HIP = xyes; then
+       dnl Absolutely insist that   libtool has CC=hipcc for tag=CXX
+       _LT_TAGVAR(compiler,CXX)='hipcc'
+   fi
 fi
 AM_CONDITIONAL(HIP_ENABLED,test x$ENABLE_HIP = xyes)
 

--- a/configure.ac
+++ b/configure.ac
@@ -190,6 +190,9 @@ ENABLE_HIP=no
 if test x$ENABLE_GPU != xyes; then
    AX_HIP_CHECK()
    AM_CONDITIONAL(GPU_ENABLED,test x$ENABLE_HIP = xyes)
+
+   dnl Absolutely insist that libtool has CC=hipcc for tag=CXX
+   _LT_TAGVAR(compiler,CXX)='hipcc'
 fi
 AM_CONDITIONAL(HIP_ENABLED,test x$ENABLE_HIP = xyes)
 

--- a/m4/hip.m4
+++ b/m4/hip.m4
@@ -40,6 +40,7 @@ AC_DEFUN([AX_HIP_CHECK],[
         if test "x$HIPCC" = "xno" ; then
            AC_MSG_ERROR([hipcc must be available, please update PATH accordingly.])
         fi
+        CC=hipcc # setting CC=hipcc forces libtool to link with hipcc
         CXX=hipcc
         HIP_CXXFLAGS="-I$MPI_DIR/include"
         HIP_LDFLAGS="-L$MPI_DIR/lib -lmpi"

--- a/m4/hip.m4
+++ b/m4/hip.m4
@@ -40,7 +40,7 @@ AC_DEFUN([AX_HIP_CHECK],[
         if test "x$HIPCC" = "xno" ; then
            AC_MSG_ERROR([hipcc must be available, please update PATH accordingly.])
         fi
-        CC=hipcc # setting CC=hipcc forces libtool to link with hipcc
+        CC=hipcc
         CXX=hipcc
         HIP_CXXFLAGS="-I$MPI_DIR/include"
         HIP_LDFLAGS="-L$MPI_DIR/lib -lmpi"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,7 @@ AM_CPPFLAGS += -dc $(CUDA_CXXFLAGS)
 endif
 
 if HIP_ENABLED
-AM_CPPFLAGS += $(HIP_CXXFLAGS)
+AM_CPPFLAGS += -fgpu-rdc $(HIP_CXXFLAGS)
 endif
 
 if GSLIB_ENABLED
@@ -23,6 +23,10 @@ bin_PROGRAMS         = tps
 tps_SOURCES          = main.cpp
 tps_LDADD            = libtps.la
 tps_LDFLAGS         += $(PYTHON_LIBS) $(MFEM_LIBS)
+
+if HIP_ENABLED
+tps_LDFLAGS += -fgpu-rdc
+endif
 
 # C++ solver library sources
 cxx_sources          = averaging_and_rms.cpp faceGradientIntegration.cpp M2ulPhyS.cpp rhs_operator.cpp wallBC.cpp \
@@ -52,6 +56,8 @@ libtps_la_SOURCES    = $(cxx_sources) $(mfem_extra_sources) $(headers) $(mfem_ex
 libtps_la_LIBADD     = $(MFEM_LIBS)
 libtps_la_LIBADD    += $(HDF5_LIBS)
 libtps_la_LIBADD    += $(GRVY_LIBS)
+
+libtps_la_LDFLAGS   =
 
 if SLURM_ENABLED
 libtps_la_LIBADD    += -lslurm
@@ -87,6 +93,8 @@ endif
 
 if HIP_ENABLED
 libtps_la_LIBADD    += $(HIP_LDFLAGS)
+# Need link to have -fgpu-rdc.  Protect with -Xcompiler to libtool does not strip.
+libtps_la_LDFLAGS += -Xcompiler -fgpu-rdc
 endif
 
 if GSLIB_ENABLED


### PR DESCRIPTION
This is analogous to #135.  For hip, the necessary flag is `-fgpu-rdc`.  No intermediate "device link" step is necessary as was the case for cuda, but the shared library link must be done with `hipcc`.