### PR TITLE
Gpu dryair transport

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -367,7 +367,6 @@ void M2ulPhyS::initVariables() {
       break;
   }
   assert(mixture != NULL);
-
 #if defined(_CUDA_)
   GasMixture **d_mixture_tmp;
   cudaMalloc((void **)&d_mixture_tmp, sizeof(GasMixture **));
@@ -979,6 +978,7 @@ M2ulPhyS::~M2ulPhyS() {
 #endif
 
 #ifdef _HIP_
+  hipFree(d_transport);
   hipFree(d_mixture);
 #endif
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -158,7 +158,7 @@ __global__ void instantiateDeviceTransport(GasMixture *mixture, const double vis
   transport = new (transport) DryAirTransport(mixture, viscosity_multiplier, bulk_viscosity);
 }
 
-__global__ void freeDeviceMixture(GasMixture *transport) {
+__global__ void freeDeviceTransport(TransportProperties *transport) {
   transport->~TransportProperties();  // explicit destructor call b/c placement new above
 }
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -960,6 +960,7 @@ M2ulPhyS::~M2ulPhyS() {
   delete chemistry_;
   delete mixture;
 #if defined(_CUDA_) || defined(_HIP_)
+  freeDeviceTransport<<<1, 1>>>(d_transport);
   freeDeviceMixture<<<1, 1>>>(d_mixture);
 #endif
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -389,6 +389,7 @@ void M2ulPhyS::initVariables() {
   instantiateDeviceTransport<<<1, 1>>>(d_mixture, config.GetViscMult(), config.GetBulkViscMult(), d_transport);
 #else
   d_mixture = mixture;
+  d_transport = transportPtr;
 #endif
 
   order = config.GetSolutionOrder();
@@ -491,7 +492,7 @@ void M2ulPhyS::initVariables() {
 #if defined(_CUDA_)
   Fluxes **d_flux_tmp;
   cudaMalloc((void **)&d_flux_tmp, sizeof(Fluxes **));
-  instantiateDeviceFluxes<<<1, 1>>>(d_mixture, eqSystem, transportPtr, num_equation, dim, config.isAxisymmetric(),
+  instantiateDeviceFluxes<<<1, 1>>>(d_mixture, eqSystem, d_transport, num_equation, dim, config.isAxisymmetric(),
                                     d_flux_tmp);
   cudaMemcpy(&fluxClass, d_flux_tmp, sizeof(Fluxes *), cudaMemcpyDeviceToHost);
   cudaFree(d_flux_tmp);
@@ -505,7 +506,7 @@ void M2ulPhyS::initVariables() {
   cudaFree(d_riemann_tmp);
 #elif defined(_HIP_)
   hipMalloc((void **)&fluxClass, sizeof(Fluxes));
-  instantiateDeviceFluxes<<<1, 1>>>(d_mixture, eqSystem, transportPtr, num_equation, dim, config.isAxisymmetric(),
+  instantiateDeviceFluxes<<<1, 1>>>(d_mixture, eqSystem, d_transport, num_equation, dim, config.isAxisymmetric(),
                                     fluxClass);
 
   hipMalloc((void **)&rsolver, sizeof(RiemannSolver));

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -970,13 +970,14 @@ M2ulPhyS::~M2ulPhyS() {
   hipFree(fluxClass);
 #endif
 
-  delete transportPtr;
-  delete chemistry_;
-  delete mixture;
 #if defined(_CUDA_) || defined(_HIP_)
   freeDeviceTransport<<<1, 1>>>(transportPtr);
   freeDeviceMixture<<<1, 1>>>(d_mixture);
+#else
+  delete transportPtr;
 #endif
+  delete chemistry_;
+  delete mixture;
 
 #ifdef _HIP_
   hipFree(transportPtr);

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -146,8 +146,8 @@ class M2ulPhyS : public TPS::Solver {
   GasMixture *mixture;    // valid on host
   GasMixture *d_mixture;  // valid on device, when available; otherwise = mixture
 
-  TransportProperties *transportPtr = NULL; // valid on host
-  TransportProperties *d_transport = NULL;  // valid on device, when available; otherwise = transportPtr
+  TransportProperties *transportPtr = NULL; // valid on both host and device
+  // TransportProperties *d_transport = NULL;  // valid on device, when available; otherwise = transportPtr
 
   Chemistry *chemistry_ = NULL;
 

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -180,8 +180,8 @@ class M2ulPhyS : public TPS::Solver {
   ParFiniteElementSpace *vfes;
 
   // nodes IDs and indirection array
-  const int maxIntPoints = 64;  // corresponding to HEX face with p=5
-  const int maxDofs = 216;      // corresponding to HEX with p=5
+  const int maxIntPoints = gpudata::MAXINTPOINTS;  // corresponding to HEX face with p=5
+  const int maxDofs = gpudata::MAXDOFS;      // corresponding to HEX with p=5
 
   volumeFaceIntegrationArrays gpuArrays;
 

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -146,7 +146,8 @@ class M2ulPhyS : public TPS::Solver {
   GasMixture *mixture;    // valid on host
   GasMixture *d_mixture;  // valid on device, when available; otherwise = mixture
 
-  TransportProperties *transportPtr = NULL;
+  TransportProperties *transportPtr = NULL; // valid on host
+  TransportProperties *d_transport = NULL;  // valid on device, when available; otherwise = transportPtr
 
   Chemistry *chemistry_ = NULL;
 

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -146,7 +146,7 @@ class M2ulPhyS : public TPS::Solver {
   GasMixture *mixture;    // valid on host
   GasMixture *d_mixture;  // valid on device, when available; otherwise = mixture
 
-  TransportProperties *transportPtr = NULL; // valid on both host and device
+  TransportProperties *transportPtr = NULL;  // valid on both host and device
   // TransportProperties *d_transport = NULL;  // valid on device, when available; otherwise = transportPtr
 
   Chemistry *chemistry_ = NULL;
@@ -181,7 +181,7 @@ class M2ulPhyS : public TPS::Solver {
 
   // nodes IDs and indirection array
   const int maxIntPoints = gpudata::MAXINTPOINTS;  // corresponding to HEX face with p=5
-  const int maxDofs = gpudata::MAXDOFS;      // corresponding to HEX with p=5
+  const int maxDofs = gpudata::MAXDOFS;            // corresponding to HEX with p=5
 
   volumeFaceIntegrationArrays gpuArrays;
 

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -87,7 +87,7 @@ class ArgonMinimalTransport : public TransportProperties {
   ArgonMinimalTransport(GasMixture *_mixture, RunConfiguration &_runfile);
   ArgonMinimalTransport(GasMixture *_mixture);
 
-  virtual ~ArgonMinimalTransport() {}
+  MFEM_HOST_DEVICE virtual ~ArgonMinimalTransport() {}
 
   int getIonIndex() { return ionIndex_; }
 
@@ -154,7 +154,7 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
  public:
   ArgonMixtureTransport(GasMixture *_mixture, RunConfiguration &_runfile);
 
-  virtual ~ArgonMixtureTransport() {}
+  MFEM_HOST_DEVICE virtual ~ArgonMixtureTransport() {}
 
   double collisionIntegral(const int _spI, const int _spJ, const int l, const int r, const collisionInputs collInputs);
 

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -101,8 +101,12 @@ class ArgonMinimalTransport : public TransportProperties {
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
-  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-                                              double *transportBuffer, double *diffusionVelocity) { exit(-1); return; }
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
+                                                               const double *Efield, double *transportBuffer,
+                                                               double *diffusionVelocity) {
+    exit(-1);
+    return;
+  }
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
@@ -167,8 +171,12 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
-  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-                                              double *transportBuffer, double *diffusionVelocity) { exit(-1); return; }
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
+                                                               const double *Efield, double *transportBuffer,
+                                                               double *diffusionVelocity) {
+    exit(-1);
+    return;
+  }
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -101,7 +101,8 @@ class ArgonMinimalTransport : public TransportProperties {
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
-  // Vector &outputUp);
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
+                                              double *transportBuffer, double *diffusionVelocity) { exit(-1); return; }
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
@@ -166,6 +167,8 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
+                                              double *transportBuffer, double *diffusionVelocity) { exit(-1); return; }
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -39,8 +39,13 @@
 using namespace mfem;
 
 namespace gpudata {
+  // nodes IDs and indirection array
+  const int MAXINTPOINTS = 64;  // corresponding to HEX face with p=5
+  const int MAXDOFS = 216;      // corresponding to HEX with p=5
+
   const int MAXDIM = 3;
-  const int MAXSPECIES = 20;
+  const int MAXSPECIES = 15;
+  const int MAXEQUATIONS = MAXDIM + 2 + MAXSPECIES; // momentum + two energies + species
 }
 
 enum Equations {

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -39,14 +39,14 @@
 using namespace mfem;
 
 namespace gpudata {
-  // nodes IDs and indirection array
-  const int MAXINTPOINTS = 64;  // corresponding to HEX face with p=5
-  const int MAXDOFS = 216;      // corresponding to HEX with p=5
+// nodes IDs and indirection array
+const int MAXINTPOINTS = 64;  // corresponding to HEX face with p=5
+const int MAXDOFS = 216;      // corresponding to HEX with p=5
 
-  const int MAXDIM = 3;
-  const int MAXSPECIES = 15;
-  const int MAXEQUATIONS = MAXDIM + 2 + MAXSPECIES; // momentum + two energies + species
-}
+const int MAXDIM = 3;
+const int MAXSPECIES = 15;
+const int MAXEQUATIONS = MAXDIM + 2 + MAXSPECIES;  // momentum + two energies + species
+}  // namespace gpudata
 
 enum Equations {
   EULER,      // Euler equations

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -38,6 +38,11 @@
 
 using namespace mfem;
 
+namespace gpudata {
+  const int MAXDIM = 3;
+  const int MAXSPECIES = 20;
+}
+
 enum Equations {
   EULER,      // Euler equations
   NS,         // Navier-Stokes equations

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -365,8 +365,8 @@ void DGNonLinearForm::evalFaceFlux_gpu() {
       d_flux->ComputeViscousFluxes(u1, gradUp1, 0.0, vFlux1);
       d_flux->ComputeViscousFluxes(u2, gradUp2, 0.0, vFlux2);
       // d_flux->ComputeViscousFluxes(d_uk_el1 + k * num_equation + iface * maxIntPoints * num_equation,
-      //                              d_grad_uk_el1 + k * dim * num_equation + iface * maxIntPoints * dim * num_equation,
-      //                              0.0, vFlux1);
+      //             d_grad_uk_el1 + k * dim * num_equation + iface * maxIntPoints * dim * num_equation,
+      //             0.0, vFlux1);
 #elif defined(_HIP_)
       Fluxes::viscousFlux_serial_gpu(&vFlux1[0], &u1[0], &gradUp1[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,
                                      num_equation);

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -312,10 +312,10 @@ void DGNonLinearForm::evalFaceFlux_gpu() {
   // clang-format off
   MFEM_FORALL(iface, Nf,
   {
-    double u1[5], gradUp1[5 * 3];
-    double u2[5], gradUp2[5 * 3];
-    double vFlux1[5 * 3], vFlux2[5 * 3];
-    double Rflux[5], nor[3];
+    double u1[gpudata::MAXEQUATIONS], gradUp1[gpudata::MAXEQUATIONS * gpudata::MAXDIM];
+    double u2[gpudata::MAXEQUATIONS], gradUp2[gpudata::MAXEQUATIONS * gpudata::MAXDIM];
+    double vFlux1[gpudata::MAXEQUATIONS * gpudata::MAXDIM], vFlux2[gpudata::MAXEQUATIONS * gpudata::MAXDIM];
+    double Rflux[gpudata::MAXEQUATIONS], nor[gpudata::MAXDIM];
 
     const int Q = d_elems12Q[3 * iface + 2];
     const int offsetShape1 = iface * maxIntPoints * (maxDofs + 1 + dim);

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -361,6 +361,7 @@ void DGNonLinearForm::evalFaceFlux_gpu() {
                          Rflux);
 
 #if defined(_CUDA_)
+      // TODO(kevin): implement radius.
       d_flux->ComputeViscousFluxes(u1, gradUp1, 0.0, vFlux1);
       d_flux->ComputeViscousFluxes(u2, gradUp2, 0.0, vFlux2);
       // d_flux->ComputeViscousFluxes(d_uk_el1 + k * num_equation + iface * maxIntPoints * num_equation,
@@ -699,6 +700,7 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
 
         // evaluate flux
 #if defined(_CUDA_)
+        // TODO(kevin): implement radius.
         d_rsolver->Eval_LF(u1, u2, nor, Rflux);
         d_flux->ComputeViscousFluxes(u1, gradUp1, 0.0, vFlux1);
         d_flux->ComputeViscousFluxes(u2, gradUp2, 0.0, vFlux2);

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -622,6 +622,8 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
   double *d_shared_flux = shared_flux.Write();
 
   const RiemannSolver *d_rsolver = rsolver_;
+  Fluxes *d_flux = fluxes;
+
   MFEM_FORALL_2D(el, parallelData->sharedElemsFaces.Size() / 7, maxIntPoints, 1, 1, {
     double l1[216], l2[216];
     double u1[5], u2[5];

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -187,6 +187,11 @@ void DryAir::computeSpeciesEnthalpies(const Vector &state, Vector &speciesEnthal
   return;
 }
 
+MFEM_HOST_DEVICE void DryAir::computeSpeciesEnthalpies(const double *state, double *speciesEnthalpies) {
+  for (int sp = 0; sp < numSpecies; sp++) speciesEnthalpies[sp] = 0.0;
+  return;
+}
+
 bool DryAir::StateIsPhysical(const mfem::Vector &state) {
   const double den = state(0);
   const Vector den_vel(state.GetData() + 1, nvel_);

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -119,7 +119,6 @@ MFEM_HOST_DEVICE DryAir::DryAir(const WorkingFluid f, const Equations eq_sys, co
   cp_div_pr = specific_heat_ratio * gas_constant / (Pr * (specific_heat_ratio - 1.));
   Sc = 0.71;
 #endif
-
   // TODO(kevin): replace Nconservative/Nprimitive.
   // add extra equation for passive scalar
   if (eq_sys == Equations::NS_PASSIVE) {

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -859,6 +859,13 @@ void PerfectMixture::computeSpeciesEnthalpies(const Vector &state, Vector &speci
   return;
 }
 
+MFEM_HOST_DEVICE void PerfectMixture::computeSpeciesEnthalpies(const double *state, double *speciesEnthalpies) {
+  // TODO(kevin): develop gpu version.
+  exit(-1);
+
+  return;
+}
+
 double PerfectMixture::ComputePressureDerivative(const Vector &dUp_dx, const Vector &Uin, bool primitive) {
   if (primitive) {
     return computePressureDerivativeFromPrimitives(dUp_dx, Uin);

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -865,7 +865,7 @@ void PerfectMixture::computeSpeciesEnthalpies(const Vector &state, Vector &speci
 
 MFEM_HOST_DEVICE void PerfectMixture::computeSpeciesEnthalpies(const double *state, double *speciesEnthalpies) {
   // TODO(kevin): develop gpu version.
-  exit(-1);
+  printf("ERROR: PerfextMixture::computeSpeciesEnthalpies is not yet developed for gpu!");
 
   return;
 }

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -107,6 +107,10 @@ MFEM_HOST_DEVICE DryAir::DryAir(const WorkingFluid f, const Equations eq_sys, co
 
   SetNumActiveSpecies();
   SetNumEquations();
+#ifdef _GPU_
+  assert(nvel_ <= gpudata::MAXDIM);
+  assert(numSpecies <= gpudata::MAXSPECIES);
+#endif
 
   gas_constant = 287.058;
 

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -159,6 +159,7 @@ class GasMixture {
     mfem_error("computeSpeciesPrimitives not implemented");
   }
   virtual void computeSpeciesEnthalpies(const Vector &state, Vector &speciesEnthalpies) = 0;
+  MFEM_HOST_DEVICE virtual void computeSpeciesEnthalpies(const double *state, double *speciesEnthalpies) = 0;
 
   virtual void GetPrimitivesFromConservatives(const Vector &conserv, Vector &primit) = 0;
   virtual void GetConservativesFromPrimitives(const Vector &primit, Vector &conserv) = 0;
@@ -294,6 +295,7 @@ class DryAir : public GasMixture {
   virtual double Temperature(double *rho, double *p, int nsp = 1) { return p[0] / gas_constant / rho[0]; }
 
   virtual void computeSpeciesEnthalpies(const Vector &state, Vector &speciesEnthalpies);
+  MFEM_HOST_DEVICE virtual void computeSpeciesEnthalpies(const double *state, double *speciesEnthalpies);
 
   virtual void GetPrimitivesFromConservatives(const Vector &conserv, Vector &primit);
   virtual void GetConservativesFromPrimitives(const Vector &primit, Vector &conserv);

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -193,8 +193,8 @@ class GasMixture {
   // TODO(kevin): Need to remove these and fix wherever they are used.
   // We cannot use these for multi species (heat ratio of which species?)
   // These are used in forcingTerm, Fluxes ASSUMING that the fluid is single species.
-  virtual double GetSpecificHeatRatio() { return specific_heat_ratio; }
-  virtual double GetGasConstant() { return gas_constant; }
+  MFEM_HOST_DEVICE virtual double GetSpecificHeatRatio() { return specific_heat_ratio; }
+  MFEM_HOST_DEVICE virtual double GetGasConstant() { return gas_constant; }
 #else
   virtual double GetSpecificHeatRatio() = 0;
   virtual double GetGasConstant() = 0;
@@ -309,8 +309,8 @@ class DryAir : public GasMixture {
   // Physicality check (at end)
   virtual bool StateIsPhysical(const Vector &state);
 
-  virtual double GetSpecificHeatRatio() { return specific_heat_ratio; }
-  virtual double GetGasConstant() { return gas_constant; }
+  MFEM_HOST_DEVICE virtual double GetSpecificHeatRatio() { return specific_heat_ratio; }
+  MFEM_HOST_DEVICE virtual double GetGasConstant() { return gas_constant; }
 
   virtual void ComputeMassFractionGradient(const double rho, const Vector &numberDensities, const DenseMatrix &gradUp,
                                            DenseMatrix &massFractionGrad) {
@@ -551,8 +551,8 @@ class PerfectMixture : public GasMixture {
   virtual double getSpecificGasConstant(int species) { return specificGasConstants_(species); }
 
   // Kevin: these are mixture heat ratio and gas constant. need to change argument.
-  virtual double GetSpecificHeatRatio() { return molarCP_(numSpecies - 1) / molarCV_(numSpecies - 1); }
-  virtual double GetGasConstant() { return specificGasConstants_(numSpecies - 1); }
+  MFEM_HOST_DEVICE virtual double GetSpecificHeatRatio() { return molarCP_(numSpecies - 1) / molarCV_(numSpecies - 1); }
+  MFEM_HOST_DEVICE virtual double GetGasConstant() { return specificGasConstants_(numSpecies - 1); }
 
   virtual double computeHeaviesHeatCapacity(const double *n_sp, const double &nB);
   virtual double computeAmbipolarElectronNumberDensity(const double *n_sp);

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -580,6 +580,7 @@ class PerfectMixture : public GasMixture {
                                        const double n_B, double &T_h, double &T_e);
 
   virtual void computeSpeciesEnthalpies(const Vector &state, Vector &speciesEnthalpies);
+  MFEM_HOST_DEVICE virtual void computeSpeciesEnthalpies(const double *state, double *speciesEnthalpies);
 
   // TODO(kevin): Kevin - I don't think we should use this for boundary condition.
   virtual double Temperature(double *rho, double *p, int nsp = 1) { return p[0] / rho[0] / GetGasConstant(); }

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -125,12 +125,12 @@ class GasMixture {
 
   WorkingFluid GetWorkingFluid() { return fluid; }
 
-  int GetNumSpecies() { return numSpecies; }
+  MFEM_HOST_DEVICE int GetNumSpecies() const { return numSpecies; }
   MFEM_HOST_DEVICE int GetNumActiveSpecies() const { return numActiveSpecies; }
-  int GetNumEquations() { return num_equation; }
+  MFEM_HOST_DEVICE int GetNumEquations() const { return num_equation; }
   MFEM_HOST_DEVICE int GetDimension() const { return dim; }
-  int GetNumVels() { return nvel_; }
-  bool IsAmbipolar() { return ambipolar; }
+  MFEM_HOST_DEVICE int GetNumVels() const { return nvel_; }
+  MFEM_HOST_DEVICE bool IsAmbipolar() const { return ambipolar; }
   MFEM_HOST_DEVICE bool IsTwoTemperature() const { return twoTemperature_; }
   virtual int getInputIndexOf(int mixtureIndex) { return 0; }
   // int getElectronMixtureIndex() { return (speciesMapping_.count("E")) ? speciesMapping_["E"] : -1; }

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -249,7 +249,8 @@ void Fluxes::ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp
   }
 }
 
-MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const double *gradUp, double radius, double *flux) {
+MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const double *gradUp, double radius,
+                                                   double *flux) {
   for (int d = 0; d < dim; d++) {
     for (int eq = 0; eq < num_equation; eq++) {
       flux[eq + d * num_equation] = 0.;
@@ -289,8 +290,8 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
       double qeFlux = ke * gradUp[num_equation - 1 + d * num_equation];
       flux[1 + nvel + d * num_equation] += qeFlux;
       flux[num_equation - 1 + d * num_equation] += qeFlux;
-      flux[num_equation - 1 + d * num_equation] -= speciesEnthalpies[numSpecies - 2]
-                                                    * diffusionVelocity[numSpecies - 2 + d * numSpecies];
+      flux[num_equation - 1 + d * num_equation] -=
+          speciesEnthalpies[numSpecies - 2] * diffusionVelocity[numSpecies - 2 + d * numSpecies];
     }
   } else {
     k += ke;
@@ -309,7 +310,8 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
     }
     divV += gradUp[(1 + i) + i * num_equation];
   }
-  for (int i = 0; i < dim; i++) for (int j = 0; j < dim; j++) stress[i + j * dim] *= visc;
+  for (int i = 0; i < dim; i++)
+    for (int j = 0; j < dim; j++) stress[i + j * dim] *= visc;
 
   if (axisymmetric_ && radius > 0) {
     divV += ur / radius;
@@ -342,8 +344,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
   // stress.Mult(vel, vtmp);
   for (int i = 0; i < dim; i++) {
     vtmp[i] = 0.0;
-    for (int j = 0; j < dim; j++)
-      vtmp[i] += stress[i + j * dim] * vel[j];
+    for (int j = 0; j < dim; j++) vtmp[i] += stress[i + j * dim] * vel[j];
   }
 
   for (int d = 0; d < dim; d++) {
@@ -351,8 +352,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
     flux[(1 + nvel) + d * num_equation] += k * gradUp[(1 + nvel) + d * num_equation];
     // compute diffusive enthalpy flux.
     for (int sp = 0; sp < numSpecies; sp++) {
-      flux[(1 + nvel) + d * num_equation] -= speciesEnthalpies[sp]
-                                              * diffusionVelocity[sp + d * numSpecies];
+      flux[(1 + nvel) + d * num_equation] -= speciesEnthalpies[sp] * diffusionVelocity[sp + d * numSpecies];
     }
   }
 
@@ -370,8 +370,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
     // NOTE: diffusionVelocity is set to be (numSpecies,nvel)-matrix.
     // however only dim-components are used for flux.
     for (int d = 0; d < dim; d++)
-      flux[(nvel + 2 + sp) + d * num_equation] = -state[nvel + 2 + sp]
-                                                  * diffusionVelocity[sp + d * numSpecies];
+      flux[(nvel + 2 + sp) + d * num_equation] = -state[nvel + 2 + sp] * diffusionVelocity[sp + d * numSpecies];
   }
 }
 

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -251,7 +251,7 @@ void Fluxes::ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp
 
 MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const double *gradUp, double radius, double *flux) {
   for (int d = 0; d < dim; d++) {
-    for (int eq = 0; eq < num_equations; eq++) {
+    for (int eq = 0; eq < num_equation; eq++) {
       flux[eq + d * num_equation] = 0.;
     }
   }

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -259,24 +259,24 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
     return;
   }
 
-  double vel[dim];
-  double vtmp[dim];
-  double stress[dim * dim];
+  double vel[gpudata::MAXDIM];
+  double vtmp[gpudata::MAXDIM];
+  double stress[gpudata::MAXDIM * gpudata::MAXDIM];
 
   // TODO(kevin): update E-field with EM coupling.
-  double Efield[nvel];
+  double Efield[gpudata::MAXDIM];
   for (int v = 0; v < nvel; v++) Efield[v] = 0.0;
 
   const int numSpecies = mixture->GetNumSpecies();
   const int numActiveSpecies = mixture->GetNumActiveSpecies();
   const bool twoTemperature = mixture->IsTwoTemperature();
 
-  double speciesEnthalpies[numSpecies];
+  double speciesEnthalpies[gpudata::MAXSPECIES];
   mixture->computeSpeciesEnthalpies(state, speciesEnthalpies);
 
   double transportBuffer[FluxTrns::NUM_FLUX_TRANS];
   // NOTE(kevin): in flux, only dim-components of diffusionVelocity will be used.
-  double diffusionVelocity[numSpecies * nvel];
+  double diffusionVelocity[gpudata::MAXSPECIES * gpudata::MAXDIM];
   transport->ComputeFluxTransportProperties(state, gradUp, Efield, transportBuffer, diffusionVelocity);
   const double visc = transportBuffer[FluxTrns::VISCOSITY];
   double bulkViscosity = transportBuffer[FluxTrns::BULK_VISCOSITY];
@@ -290,7 +290,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
       flux[1 + nvel + d * num_equation] += qeFlux;
       flux[num_equation - 1 + d * num_equation] += qeFlux;
       flux[num_equation - 1 + d * num_equation] -= speciesEnthalpies[numSpecies - 2]
-                                                    * diffusionVelocity[numSpecies - 2 + d * num_equation];
+                                                    * diffusionVelocity[numSpecies - 2 + d * gpudata::MAXSPECIES];
     }
   } else {
     k += ke;
@@ -305,20 +305,20 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
   double divV = 0.;
   for (int i = 0; i < dim; i++) {
     for (int j = 0; j < dim; j++) {
-      stress[i + j * dim] = gradUp[(1 + j) + i * num_equation] + gradUp[(1 + i) + j * num_equation];
+      stress[i + j * gpudata::MAXDIM] = gradUp[(1 + j) + i * num_equation] + gradUp[(1 + i) + j * num_equation];
     }
     divV += gradUp[(1 + i) + i * num_equation];
   }
-  for (int i = 0; i < dim; i++) for (int j = 0; j < dim; j++) stress[i + j * dim] *= visc;
+  for (int i = 0; i < dim; i++) for (int j = 0; j < dim; j++) stress[i + j * gpudata::MAXDIM] *= visc;
 
   if (axisymmetric_ && radius > 0) {
     divV += ur / radius;
   }
 
-  for (int i = 0; i < dim; i++) stress[i + i * dim] += bulkViscosity * divV;
+  for (int i = 0; i < dim; i++) stress[i + i * gpudata::MAXDIM] += bulkViscosity * divV;
 
   for (int i = 0; i < dim; i++)
-    for (int j = 0; j < dim; j++) flux[(1 + i) + j * num_equation] = stress[i + j * dim];
+    for (int j = 0; j < dim; j++) flux[(1 + i) + j * num_equation] = stress[i + j * gpudata::MAXDIM];
 
   double tau_tr = 0, tau_tz = 0;
   if (axisymmetric_) {
@@ -343,7 +343,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
   for (int i = 0; i < dim; i++) {
     vtmp[i] = 0.0;
     for (int j = 0; j < dim; j++)
-      vtmp[i] += stress[i + j * dim] * vel[j];
+      vtmp[i] += stress[i + j * gpudata::MAXDIM] * vel[j];
   }
 
   for (int d = 0; d < dim; d++) {
@@ -352,7 +352,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
     // compute diffusive enthalpy flux.
     for (int sp = 0; sp < numSpecies; sp++) {
       flux[(1 + nvel) + d * num_equation] -= speciesEnthalpies[sp]
-                                              * diffusionVelocity[sp + d * num_equation];
+                                              * diffusionVelocity[sp + d * gpudata::MAXSPECIES];
     }
   }
 
@@ -371,7 +371,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
     // however only dim-components are used for flux.
     for (int d = 0; d < dim; d++)
       flux[(nvel + 2 + sp) + d * num_equation] = -state[nvel + 2 + sp]
-                                                  * diffusionVelocity[sp + d * num_equation];
+                                                  * diffusionVelocity[sp + d * gpudata::MAXSPECIES];
   }
 }
 

--- a/src/fluxes.hpp
+++ b/src/fluxes.hpp
@@ -78,6 +78,7 @@ class Fluxes {
   MFEM_HOST_DEVICE void ComputeConvectiveFluxes(const double *state, double *flux) const;
 
   void ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp, double radius, DenseMatrix &flux);
+  MFEM_HOST_DEVICE void ComputeViscousFluxes(const double *state, const double *gradUp, double radius, double *flux);
 
   // Compute viscous flux with prescribed boundary flux.
   void ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gradUp, double radius,

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -42,6 +42,17 @@ TransportProperties::TransportProperties(GasMixture *_mixture) : mixture(_mixtur
   num_equation = mixture->GetNumEquations();
 }
 
+MFEM_HOST_DEVICE TransportProperties::TransportProperties(GasMixture *_mixture) {
+  mixture = _mixture
+  numSpecies = mixture->GetNumSpecies();
+  dim = mixture->GetDimension();
+  nvel_ = mixture->GetNumVels();
+  numActiveSpecies = mixture->GetNumActiveSpecies();
+  ambipolar = mixture->IsAmbipolar();
+  twoTemperature_ = mixture->IsTwoTemperature();
+  num_equation = mixture->GetNumEquations();
+}
+
 void TransportProperties::correctMassDiffusionFlux(const Vector &Y_sp, DenseMatrix &diffusionVelocity) {
   // Correction Velocity
   Vector Vc(nvel_);

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -189,7 +189,7 @@ MFEM_HOST_DEVICE void DryAirTransport::ComputeFluxTransportProperties(const doub
   // diffusionVelocity.SetSize(numSpecies, nvel_);
   for (int v = 0; v < nvel_; v++) {
     for (int sp = 0; sp < numSpecies; sp++) {
-      diffusionVelocity[sp + v * numSpecies] = 0.0;
+      diffusionVelocity[sp + v * gpudata::MAXSPECIES] = 0.0;
     }
   }
   if (numActiveSpecies > 0) {
@@ -205,12 +205,12 @@ MFEM_HOST_DEVICE void DryAirTransport::ComputeFluxTransportProperties(const doub
           dY -= state[2 + nvel_ + sp] / state[0] * gradUp[0 + d * num_equation];
           dY /= state[0];
 
-          diffusionVelocity[sp + d * numSpecies] = diffusivity * dY / state[2 + nvel_ + sp];
+          diffusionVelocity[sp + d * gpudata::MAXSPECIES] = diffusivity * dY / state[2 + nvel_ + sp];
         }
       }
 
       for (int d = 0; d < nvel_; d++) {
-        assert(!isnan(diffusionVelocity[0 + d * num_equation]));
+        assert(!isnan(diffusionVelocity[0 + d * gpudata::MAXSPECIES]));
       }
     }
   }

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -32,8 +32,8 @@
 
 #include "transport_properties.hpp"
 
-MFEM_HOST_DEVICE TransportProperties::TransportProperties(GasMixture *_mixture) {
-  mixture = _mixture;
+MFEM_HOST_DEVICE TransportProperties::TransportProperties(GasMixture *_mixture)
+    : mixture(_mixture) {
   numSpecies = mixture->GetNumSpecies();
   dim = mixture->GetDimension();
   nvel_ = mixture->GetNumVels();
@@ -121,13 +121,17 @@ void TransportProperties::CurtissHirschfelder(const Vector &X_sp, const Vector &
 //////// Dry Air mixture
 //////////////////////////////////////////////////////
 
-DryAirTransport::DryAirTransport(GasMixture *_mixture, RunConfiguration &_runfile) : TransportProperties(_mixture) {
-  visc_mult = _runfile.GetViscMult();
-  bulk_visc_mult = _runfile.GetBulkViscMult();
+DryAirTransport::DryAirTransport(GasMixture *_mixture, RunConfiguration &_runfile)
+    : DryAirTransport(_mixture, _runfile.GetViscMult(), _runfile.GetBulkViscMult()) {}
+
+MFEM_HOST_DEVICE DryAirTransport::DryAirTransport(GasMixture *_mixture, const double viscosity_multiplier,
+                                                  const double bulk_viscosity) : TransportProperties(_mixture) {
+  visc_mult = viscosity_multiplier;
+  bulk_visc_mult = bulk_viscosity;
 
   Pr = 0.71;
   Sc = 0.71;
-  gas_constant = UNIVERSALGASCONSTANT / mixture->GetGasParams(0, GasParams::SPECIES_MW);
+  gas_constant = mixture->GetGasConstant();
   const double specific_heat_ratio = mixture->GetSpecificHeatRatio();
   cp_div_pr = specific_heat_ratio * gas_constant / (Pr * (specific_heat_ratio - 1.));
 }

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -189,7 +189,10 @@ MFEM_HOST_DEVICE void DryAirTransport::ComputeFluxTransportProperties(const doub
   // diffusionVelocity.SetSize(numSpecies, nvel_);
   for (int v = 0; v < nvel_; v++) {
     for (int sp = 0; sp < numSpecies; sp++) {
-      diffusionVelocity[sp + v * gpudata::MAXSPECIES] = 0.0;
+      // While the size of the array is set up to gpudata::MAXSPECIES,
+      // indexing does not have to follow the actual size,
+      // as long as it does not go beyond the size of array.
+      diffusionVelocity[sp + v * numSpecies] = 0.0;
     }
   }
   if (numActiveSpecies > 0) {
@@ -205,12 +208,12 @@ MFEM_HOST_DEVICE void DryAirTransport::ComputeFluxTransportProperties(const doub
           dY -= state[2 + nvel_ + sp] / state[0] * gradUp[0 + d * num_equation];
           dY /= state[0];
 
-          diffusionVelocity[sp + d * gpudata::MAXSPECIES] = diffusivity * dY / state[2 + nvel_ + sp];
+          diffusionVelocity[sp + d * numSpecies] = diffusivity * dY / state[2 + nvel_ + sp];
         }
       }
 
       for (int d = 0; d < nvel_; d++) {
-        assert(!isnan(diffusionVelocity[0 + d * gpudata::MAXSPECIES]));
+        assert(!isnan(diffusionVelocity[0 + d * numSpecies]));
       }
     }
   }

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -32,18 +32,8 @@
 
 #include "transport_properties.hpp"
 
-TransportProperties::TransportProperties(GasMixture *_mixture) : mixture(_mixture) {
-  numSpecies = mixture->GetNumSpecies();
-  dim = mixture->GetDimension();
-  nvel_ = mixture->GetNumVels();
-  numActiveSpecies = mixture->GetNumActiveSpecies();
-  ambipolar = mixture->IsAmbipolar();
-  twoTemperature_ = mixture->IsTwoTemperature();
-  num_equation = mixture->GetNumEquations();
-}
-
 MFEM_HOST_DEVICE TransportProperties::TransportProperties(GasMixture *_mixture) {
-  mixture = _mixture
+  mixture = _mixture;
   numSpecies = mixture->GetNumSpecies();
   dim = mixture->GetDimension();
   nvel_ = mixture->GetNumVels();

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -32,8 +32,7 @@
 
 #include "transport_properties.hpp"
 
-MFEM_HOST_DEVICE TransportProperties::TransportProperties(GasMixture *_mixture)
-    : mixture(_mixture) {
+MFEM_HOST_DEVICE TransportProperties::TransportProperties(GasMixture *_mixture) : mixture(_mixture) {
   numSpecies = mixture->GetNumSpecies();
   dim = mixture->GetDimension();
   nvel_ = mixture->GetNumVels();
@@ -125,7 +124,8 @@ DryAirTransport::DryAirTransport(GasMixture *_mixture, RunConfiguration &_runfil
     : DryAirTransport(_mixture, _runfile.GetViscMult(), _runfile.GetBulkViscMult()) {}
 
 MFEM_HOST_DEVICE DryAirTransport::DryAirTransport(GasMixture *_mixture, const double viscosity_multiplier,
-                                                  const double bulk_viscosity) : TransportProperties(_mixture) {
+                                                  const double bulk_viscosity)
+    : TransportProperties(_mixture) {
   visc_mult = viscosity_multiplier;
   bulk_visc_mult = bulk_viscosity;
 
@@ -203,8 +203,7 @@ MFEM_HOST_DEVICE void DryAirTransport::ComputeFluxTransportProperties(const doub
       for (int d = 0; d < dim; d++) {
         if (fabs(state[2 + nvel_ + sp]) > 1e-10) {
           // compute mass fraction gradient
-          double dY = UNIVERSALGASCONSTANT / mixture->GetGasConstant()
-                      * gradUp[2 + nvel_ + sp + d * num_equation];
+          double dY = UNIVERSALGASCONSTANT / mixture->GetGasConstant() * gradUp[2 + nvel_ + sp + d * num_equation];
           dY -= state[2 + nvel_ + sp] / state[0] * gradUp[0 + d * num_equation];
           dY /= state[0];
 

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -144,6 +144,8 @@ class DryAirTransport : public TransportProperties {
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
+                                              double *transportBuffer, double *diffusionVelocity);
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                                 const Vector &Efield, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -87,7 +87,8 @@ class TransportProperties {
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity) = 0;
-  // Vector &outputUp);
+  // virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
+  //                                             double *transportBuffer, double *diffusionVelocity) = 0;
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
@@ -136,6 +137,8 @@ class DryAirTransport : public TransportProperties {
 
  public:
   DryAirTransport(GasMixture *_mixture, RunConfiguration &_runfile);
+  MFEM_HOST_DEVICE DryAirTransport(GasMixture *_mixture, const double viscosity_multiplier,
+                                   const double bulk_viscosity);
 
   MFEM_HOST_DEVICE virtual ~DryAirTransport() {}
 

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -69,8 +69,10 @@ class TransportProperties {
 
  public:
   TransportProperties(GasMixture *_mixture);
+  MFEM_HOST_DEVICE TransportProperties(GasMixture *_mixture);
 
   virtual ~TransportProperties() {}
+  MFEM_HOST_DEVICE virtual ~TransportProperties() {}
 
   // Currently, diffusion velocity is evaluated together with transport properties,
   // though diffusion velocity can vary according to models we use.

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -87,8 +87,9 @@ class TransportProperties {
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity) = 0;
-  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-                                              double *transportBuffer, double *diffusionVelocity) = 0;
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
+                                                               const double *Efield, double *transportBuffer,
+                                                               double *diffusionVelocity) = 0;
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
@@ -144,8 +145,9 @@ class DryAirTransport : public TransportProperties {
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
-  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-                                              double *transportBuffer, double *diffusionVelocity);
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
+                                                               const double *Efield, double *transportBuffer,
+                                                               double *diffusionVelocity);
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                                 const Vector &Efield, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
@@ -185,8 +187,12 @@ class ConstantTransport : public TransportProperties {
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
-  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-                                              double *transportBuffer, double *diffusionVelocity) { exit(-1); return; }
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
+                                                               const double *Efield, double *transportBuffer,
+                                                               double *diffusionVelocity) {
+    exit(-1);
+    return;
+  }
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                                 const Vector &Efield, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -68,10 +68,10 @@ class TransportProperties {
   const double Xeps_ = 1.0e-30;
 
  public:
-  TransportProperties(GasMixture *_mixture);
+  // TransportProperties(GasMixture *_mixture);
   MFEM_HOST_DEVICE TransportProperties(GasMixture *_mixture);
 
-  virtual ~TransportProperties() {}
+  // virtual ~TransportProperties() {}
   MFEM_HOST_DEVICE virtual ~TransportProperties() {}
 
   // Currently, diffusion velocity is evaluated together with transport properties,
@@ -137,7 +137,7 @@ class DryAirTransport : public TransportProperties {
  public:
   DryAirTransport(GasMixture *_mixture, RunConfiguration &_runfile);
 
-  virtual ~DryAirTransport() {}
+  MFEM_HOST_DEVICE virtual ~DryAirTransport() {}
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
@@ -176,7 +176,7 @@ class ConstantTransport : public TransportProperties {
  public:
   ConstantTransport(GasMixture *_mixture, RunConfiguration &_runfile);
 
-  virtual ~ConstantTransport() {}
+  MFEM_HOST_DEVICE virtual ~ConstantTransport() {}
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -87,8 +87,8 @@ class TransportProperties {
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity) = 0;
-  // virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-  //                                             double *transportBuffer, double *diffusionVelocity) = 0;
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
+                                              double *transportBuffer, double *diffusionVelocity) = 0;
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
@@ -185,6 +185,8 @@ class ConstantTransport : public TransportProperties {
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
+                                              double *transportBuffer, double *diffusionVelocity) { exit(-1); return; }
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                                 const Vector &Efield, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -516,8 +516,8 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, 
   const int num_equation = num_equation_;
   const int maxIntPoints = maxIntPoints_;
 
-  const RiemannSolver *d_rsolver = rsolver_;
-  Fluxes *d_fluxclass = fluxes;
+  const RiemannSolver *d_rsolver = rsolver;
+  Fluxes *d_fluxclass = fluxClass;
 
   // clang-format on
   // el_wall is index within wall boundary elements?
@@ -588,7 +588,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, 
 #if defined(_CUDA_)
         d_rsolver->Eval_LF(u1, u2, nor, Rflux);
         d_fluxclass->ComputeViscousFluxes(u1, gradUp1, 0.0, vF1);
-        d_fluxclass->ComputeViscousFluxes(u2, gradUp2, 0.0, vF2);
+        d_fluxclass->ComputeViscousFluxes(u2, gradUp1, 0.0, vF2);
 #elif defined(_HIP_)
         RiemannSolver::riemannLF_serial_gpu(&u1[0], &u2[0], &Rflux[0], &nor[0], gamma, Rg, dim, num_equation);
         Fluxes::viscousFlux_serial_gpu(&vF1[0], &u1[0], &gradUp1[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -586,6 +586,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, 
 
         // evaluate flux
 #if defined(_CUDA_)
+        // TODO(kevin): implement radius.
         d_rsolver->Eval_LF(u1, u2, nor, Rflux);
         d_fluxclass->ComputeViscousFluxes(u1, gradUp1, 0.0, vF1);
         d_fluxclass->ComputeViscousFluxes(u2, gradUp1, 0.0, vF2);

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -584,7 +584,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, 
             break;
         }
 
-        // evaluate flux
+          // evaluate flux
 #if defined(_CUDA_)
         // TODO(kevin): implement radius.
         d_rsolver->Eval_LF(u1, u2, nor, Rflux);

--- a/test/cyl3d.gpu.test
+++ b/test/cyl3d.gpu.test
@@ -26,7 +26,7 @@ setup() {
 
 @test "[$TEST] run tps with input -> $RUNFILE" {
     rm -f $SOLN_FILE
-    ../src/tps --runFile $RUNFILE
+    ../src/tps --runFile $RUNFILE &> run.log
 
     test -s $SOLN_FILE
 }


### PR DESCRIPTION
- Initialization of `TransportProperties` class in the gpu device.
- `MFEM_HOST_DEVICE` methods for `DryAirTransport` class.
- `MFEM_HOST_DEVICE Fluxes::ComputeViscousFluxes`
  - radius is not implemented yet, so axisymmetric case is still not supported.
  - Marked the place where the radius needs to be implmented, with `// TODO(kevin): implement radius.`.
- Only `Fluxes::viscousFluxes_serial_gpu` is replaced. There are other places where `Fluxes::viscousFluxes_gpu` is used.
- Almost everywhere, arrays that are used in `MFEM_FORALL` loop are defined with hard-coded integers. These integers are now globally defined in `gpudata` namespace in `dataStructures.hpp`. Currently there are:
  1. `const int MAXINTPOINTS = 64;`
  2. `const int MAXDOFS = 216;`
  3. `const int MAXDIM = 3;`
  4. `const int MAXSPECIES = 5;`
  5. `const int MAXEQUATIONS = MAXDIM + 2 + MAXSPECIES;`
There are still other hard-coded arrays, such as `gpuArrays.elemFaces` and `gpuArrays.elems12Q`. These are still to be replaced later.
- Currently due to the issue #145 , `_HIP_` path cannot be developed further with virtual method of objects. Everything works fine in `_CUDA_` path. The gpu path is now separated by these two paths and `_HIP_` path will remain unsupported for plasma.