### PR TITLE
Refactoring DryAir from `_CUDA_` path

### DIFF
--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -113,7 +113,7 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
     if (patchInMesh) {
       WallData wallData = config.GetWallData(w);
 
-      wallBCmap[patchType.first] = new WallBC(rsolver, mixture, _runFile.GetEquationSystem(), fluxClass, vfes, intRules,
+      wallBCmap[patchType.first] = new WallBC(rsolver, mixture, d_mixture, _runFile.GetEquationSystem(), fluxClass, vfes, intRules,
                                               _dt, dim, num_equation, patchType.first, patchType.second, wallData,
                                               intPointsElIDBC, _maxIntPoints, config.isAxisymmetric());
     }

--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -38,11 +38,11 @@
 #include "wallBC.hpp"
 
 BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes,
-                           IntegrationRules *_intRules, RiemannSolver *rsolver_, double &_dt, GasMixture *_mixture, GasMixture *d_mixture,
-                           Fluxes *_fluxClass, ParGridFunction *_Up, ParGridFunction *_gradUp, Vector &_shapesBC,
-                           Vector &_normalsWBC, Array<int> &_intPointsElIDBC, const int _dim, const int _num_equation,
-                           double &_max_char_speed, RunConfiguration &_runFile, Array<int> &local_attr,
-                           const int &_maxIntPoints, const int &_maxDofs)
+                           IntegrationRules *_intRules, RiemannSolver *rsolver_, double &_dt, GasMixture *_mixture,
+                           GasMixture *d_mixture, Fluxes *_fluxClass, ParGridFunction *_Up, ParGridFunction *_gradUp,
+                           Vector &_shapesBC, Vector &_normalsWBC, Array<int> &_intPointsElIDBC, const int _dim,
+                           const int _num_equation, double &_max_char_speed, RunConfiguration &_runFile,
+                           Array<int> &local_attr, const int &_maxIntPoints, const int &_maxDofs)
     : groupsMPI(_groupsMPI),
       config(_runFile),
       rsolver(rsolver_),
@@ -77,9 +77,9 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
     if (attrInMesh) {
       Array<double> data = config.GetInletData(in);
       inletBCmap[patchANDtype.first] =
-          new InletBC(groupsMPI, _runFile.GetEquationSystem(), rsolver, mixture, d_mixture, vfes, intRules, _dt, dim, num_equation,
-                      patchANDtype.first, config.GetReferenceLength(), patchANDtype.second, data, _maxIntPoints,
-                      _maxDofs, config.isAxisymmetric());
+          new InletBC(groupsMPI, _runFile.GetEquationSystem(), rsolver, mixture, d_mixture, vfes, intRules, _dt, dim,
+                      num_equation, patchANDtype.first, config.GetReferenceLength(), patchANDtype.second, data,
+                      _maxIntPoints, _maxDofs, config.isAxisymmetric());
     }
   }
 
@@ -113,9 +113,9 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
     if (patchInMesh) {
       WallData wallData = config.GetWallData(w);
 
-      wallBCmap[patchType.first] = new WallBC(rsolver, mixture, d_mixture, _runFile.GetEquationSystem(), fluxClass, vfes, intRules,
-                                              _dt, dim, num_equation, patchType.first, patchType.second, wallData,
-                                              intPointsElIDBC, _maxIntPoints, config.isAxisymmetric());
+      wallBCmap[patchType.first] = new WallBC(rsolver, mixture, d_mixture, _runFile.GetEquationSystem(), fluxClass,
+                                              vfes, intRules, _dt, dim, num_equation, patchType.first, patchType.second,
+                                              wallData, intPointsElIDBC, _maxIntPoints, config.isAxisymmetric());
     }
   }
 

--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -77,7 +77,7 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
     if (attrInMesh) {
       Array<double> data = config.GetInletData(in);
       inletBCmap[patchANDtype.first] =
-          new InletBC(groupsMPI, _runFile.GetEquationSystem(), rsolver, mixture, vfes, intRules, _dt, dim, num_equation,
+          new InletBC(groupsMPI, _runFile.GetEquationSystem(), rsolver, mixture, d_mixture, vfes, intRules, _dt, dim, num_equation,
                       patchANDtype.first, config.GetReferenceLength(), patchANDtype.second, data, _maxIntPoints,
                       _maxDofs, config.isAxisymmetric());
     }

--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -38,7 +38,7 @@
 #include "wallBC.hpp"
 
 BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes,
-                           IntegrationRules *_intRules, RiemannSolver *rsolver_, double &_dt, GasMixture *_mixture,
+                           IntegrationRules *_intRules, RiemannSolver *rsolver_, double &_dt, GasMixture *_mixture, GasMixture *d_mixture,
                            Fluxes *_fluxClass, ParGridFunction *_Up, ParGridFunction *_gradUp, Vector &_shapesBC,
                            Vector &_normalsWBC, Array<int> &_intPointsElIDBC, const int _dim, const int _num_equation,
                            double &_max_char_speed, RunConfiguration &_runFile, Array<int> &local_attr,
@@ -94,7 +94,7 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
     if (attrInMesh) {
       Array<double> data = config.GetOutletData(o);
       outletBCmap[patchANDtype.first] =
-          new OutletBC(groupsMPI, _runFile.GetEquationSystem(), rsolver, mixture, vfes, intRules, _dt, dim,
+          new OutletBC(groupsMPI, _runFile.GetEquationSystem(), rsolver, mixture, d_mixture, vfes, intRules, _dt, dim,
                        num_equation, patchANDtype.first, config.GetReferenceLength(), patchANDtype.second, data,
                        _maxIntPoints, _maxDofs, config.isAxisymmetric());
     }

--- a/src/BCintegrator.hpp
+++ b/src/BCintegrator.hpp
@@ -89,7 +89,7 @@ class BCintegrator : public NonlinearFormIntegrator {
 
  public:
   BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules,
-               RiemannSolver *rsolver_, double &_dt, GasMixture *mixture, Fluxes *_fluxClass, ParGridFunction *_Up,
+               RiemannSolver *rsolver_, double &_dt, GasMixture *mixture, GasMixture *d_mixture, Fluxes *_fluxClass, ParGridFunction *_Up,
                ParGridFunction *_gradUp, Vector &_shapesBC, Vector &_normalsWBC, Array<int> &_intPointsElIDBC,
                const int _dim, const int _num_equation, double &_max_char_speed, RunConfiguration &_runFile,
                Array<int> &local_bdr_attr, const int &_maxIntPoints, const int &_maxDofs);

--- a/src/BCintegrator.hpp
+++ b/src/BCintegrator.hpp
@@ -89,10 +89,10 @@ class BCintegrator : public NonlinearFormIntegrator {
 
  public:
   BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules,
-               RiemannSolver *rsolver_, double &_dt, GasMixture *mixture, GasMixture *d_mixture, Fluxes *_fluxClass, ParGridFunction *_Up,
-               ParGridFunction *_gradUp, Vector &_shapesBC, Vector &_normalsWBC, Array<int> &_intPointsElIDBC,
-               const int _dim, const int _num_equation, double &_max_char_speed, RunConfiguration &_runFile,
-               Array<int> &local_bdr_attr, const int &_maxIntPoints, const int &_maxDofs);
+               RiemannSolver *rsolver_, double &_dt, GasMixture *mixture, GasMixture *d_mixture, Fluxes *_fluxClass,
+               ParGridFunction *_Up, ParGridFunction *_gradUp, Vector &_shapesBC, Vector &_normalsWBC,
+               Array<int> &_intPointsElIDBC, const int _dim, const int _num_equation, double &_max_char_speed,
+               RunConfiguration &_runFile, Array<int> &local_bdr_attr, const int &_maxIntPoints, const int &_maxDofs);
   ~BCintegrator();
 
   virtual void AssembleFaceVector(const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &Tr,

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -367,7 +367,6 @@ void M2ulPhyS::initVariables() {
       break;
   }
   assert(mixture != NULL);
-
 #if defined(_CUDA_)
   GasMixture **d_mixture_tmp;
   cudaMalloc((void **)&d_mixture_tmp, sizeof(GasMixture **));
@@ -979,6 +978,7 @@ M2ulPhyS::~M2ulPhyS() {
 #endif
 
 #ifdef _HIP_
+  hipFree(d_transport);
   hipFree(d_mixture);
 #endif
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -158,7 +158,7 @@ __global__ void instantiateDeviceTransport(GasMixture *mixture, const double vis
   transport = new (transport) DryAirTransport(mixture, viscosity_multiplier, bulk_viscosity);
 }
 
-__global__ void freeDeviceMixture(GasMixture *transport) {
+__global__ void freeDeviceTransport(TransportProperties *transport) {
   transport->~TransportProperties();  // explicit destructor call b/c placement new above
 }
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -528,7 +528,7 @@ void M2ulPhyS::initVariables() {
 
   bcIntegrator = NULL;
   if (local_attr.Size() > 0) {
-    bcIntegrator = new BCintegrator(groupsMPI, mesh, vfes, intRules, rsolver, dt, mixture, fluxClass, Up, gradUp,
+    bcIntegrator = new BCintegrator(groupsMPI, mesh, vfes, intRules, rsolver, dt, mixture, d_mixture, fluxClass, Up, gradUp,
                                     shapesBC, normalsWBC, intPointsElIDBC, dim, num_equation, max_char_speed, config,
                                     local_attr, maxIntPoints, maxDofs);
   }

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -960,6 +960,7 @@ M2ulPhyS::~M2ulPhyS() {
   delete chemistry_;
   delete mixture;
 #if defined(_CUDA_) || defined(_HIP_)
+  freeDeviceTransport<<<1, 1>>>(d_transport);
   freeDeviceMixture<<<1, 1>>>(d_mixture);
 #endif
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -448,9 +448,10 @@ void M2ulPhyS::initVariables() {
   initIndirectionArrays();
   initSolutionAndVisualizationVectors();
 
-#ifdef _GPU_
+#if defined(_CUDA_)
   average = new Averaging(Up, mesh, fec, fes, dfes, vfes, eqSystem, d_mixture, num_equation, dim, config, groupsMPI);
 #else
+  // NOTE(kevin): _HIP_ path does not use device mixture.
   average = new Averaging(Up, mesh, fec, fes, dfes, vfes, eqSystem, mixture, num_equation, dim, config, groupsMPI);
 #endif
   average->read_meanANDrms_restart_files();

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -448,7 +448,11 @@ void M2ulPhyS::initVariables() {
   initIndirectionArrays();
   initSolutionAndVisualizationVectors();
 
+#ifdef _GPU_
+  average = new Averaging(Up, mesh, fec, fes, dfes, vfes, eqSystem, d_mixture, num_equation, dim, config, groupsMPI);
+#else
   average = new Averaging(Up, mesh, fec, fes, dfes, vfes, eqSystem, mixture, num_equation, dim, config, groupsMPI);
+#endif
   average->read_meanANDrms_restart_files();
 
   // NOTE: this should also be completed by the GasMixture class

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -389,6 +389,7 @@ void M2ulPhyS::initVariables() {
   instantiateDeviceTransport<<<1, 1>>>(d_mixture, config.GetViscMult(), config.GetBulkViscMult(), d_transport);
 #else
   d_mixture = mixture;
+  d_transport = transportPtr;
 #endif
 
   order = config.GetSolutionOrder();
@@ -491,7 +492,7 @@ void M2ulPhyS::initVariables() {
 #if defined(_CUDA_)
   Fluxes **d_flux_tmp;
   cudaMalloc((void **)&d_flux_tmp, sizeof(Fluxes **));
-  instantiateDeviceFluxes<<<1, 1>>>(d_mixture, eqSystem, transportPtr, num_equation, dim, config.isAxisymmetric(),
+  instantiateDeviceFluxes<<<1, 1>>>(d_mixture, eqSystem, d_transport, num_equation, dim, config.isAxisymmetric(),
                                     d_flux_tmp);
   cudaMemcpy(&fluxClass, d_flux_tmp, sizeof(Fluxes *), cudaMemcpyDeviceToHost);
   cudaFree(d_flux_tmp);
@@ -505,7 +506,7 @@ void M2ulPhyS::initVariables() {
   cudaFree(d_riemann_tmp);
 #elif defined(_HIP_)
   hipMalloc((void **)&fluxClass, sizeof(Fluxes));
-  instantiateDeviceFluxes<<<1, 1>>>(d_mixture, eqSystem, transportPtr, num_equation, dim, config.isAxisymmetric(),
+  instantiateDeviceFluxes<<<1, 1>>>(d_mixture, eqSystem, d_transport, num_equation, dim, config.isAxisymmetric(),
                                     fluxClass);
 
   hipMalloc((void **)&rsolver, sizeof(RiemannSolver));

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -592,7 +592,7 @@ void M2ulPhyS::initVariables() {
 
   rhsOperator =
       new RHSoperator(iter, dim, num_equation, order, eqSystem, max_char_speed, intRules, intRuleType, fluxClass,
-                      mixture, chemistry_, transportPtr, vfes, gpuArrays, maxIntPoints, maxDofs, A, Aflux, mesh,
+                      mixture, d_mixture, chemistry_, transportPtr, vfes, gpuArrays, maxIntPoints, maxDofs, A, Aflux, mesh,
                       spaceVaryViscMult, U, Up, gradUp, gradUpfes, gradUp_A, bcIntegrator, isSBP, alpha, config);
 
   CFL = config.GetCFLNumber();

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1269,6 +1269,9 @@ void M2ulPhyS::solve() {
     const int vis_steps = config.GetNumItersOutput();
     if (iter % vis_steps == 0) {
       // dump history
+      // NOTE(kevin): this routine is currently obsolete.
+      // It computes `dof`-averaged state and time-derivative, which are useless at this point.
+      // This will not be supported.
       writeHistoryFile();
 
 #ifdef HAVE_MASA

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -533,9 +533,9 @@ void M2ulPhyS::initVariables() {
 
   bcIntegrator = NULL;
   if (local_attr.Size() > 0) {
-    bcIntegrator = new BCintegrator(groupsMPI, mesh, vfes, intRules, rsolver, dt, mixture, d_mixture, fluxClass, Up, gradUp,
-                                    shapesBC, normalsWBC, intPointsElIDBC, dim, num_equation, max_char_speed, config,
-                                    local_attr, maxIntPoints, maxDofs);
+    bcIntegrator = new BCintegrator(groupsMPI, mesh, vfes, intRules, rsolver, dt, mixture, d_mixture, fluxClass, Up,
+                                    gradUp, shapesBC, normalsWBC, intPointsElIDBC, dim, num_equation, max_char_speed,
+                                    config, local_attr, maxIntPoints, maxDofs);
   }
 
   // A->SetAssemblyLevel(AssemblyLevel::PARTIAL);
@@ -597,8 +597,8 @@ void M2ulPhyS::initVariables() {
 
   rhsOperator =
       new RHSoperator(iter, dim, num_equation, order, eqSystem, max_char_speed, intRules, intRuleType, fluxClass,
-                      mixture, d_mixture, chemistry_, transportPtr, vfes, gpuArrays, maxIntPoints, maxDofs, A, Aflux, mesh,
-                      spaceVaryViscMult, U, Up, gradUp, gradUpfes, gradUp_A, bcIntegrator, isSBP, alpha, config);
+                      mixture, d_mixture, chemistry_, transportPtr, vfes, gpuArrays, maxIntPoints, maxDofs, A, Aflux,
+                      mesh, spaceVaryViscMult, U, Up, gradUp, gradUpfes, gradUp_A, bcIntegrator, isSBP, alpha, config);
 
   CFL = config.GetCFLNumber();
   rhsOperator->SetTime(time);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -970,13 +970,14 @@ M2ulPhyS::~M2ulPhyS() {
   hipFree(fluxClass);
 #endif
 
-  delete transportPtr;
-  delete chemistry_;
-  delete mixture;
 #if defined(_CUDA_) || defined(_HIP_)
   freeDeviceTransport<<<1, 1>>>(transportPtr);
   freeDeviceMixture<<<1, 1>>>(d_mixture);
+#else
+  delete transportPtr;
 #endif
+  delete chemistry_;
+  delete mixture;
 
 #ifdef _HIP_
   hipFree(transportPtr);

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -146,8 +146,8 @@ class M2ulPhyS : public TPS::Solver {
   GasMixture *mixture;    // valid on host
   GasMixture *d_mixture;  // valid on device, when available; otherwise = mixture
 
-  TransportProperties *transportPtr = NULL; // valid on host
-  TransportProperties *d_transport = NULL;  // valid on device, when available; otherwise = transportPtr
+  TransportProperties *transportPtr = NULL; // valid on both host and device
+  // TransportProperties *d_transport = NULL;  // valid on device, when available; otherwise = transportPtr
 
   Chemistry *chemistry_ = NULL;
 

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -180,8 +180,8 @@ class M2ulPhyS : public TPS::Solver {
   ParFiniteElementSpace *vfes;
 
   // nodes IDs and indirection array
-  const int maxIntPoints = 64;  // corresponding to HEX face with p=5
-  const int maxDofs = 216;      // corresponding to HEX with p=5
+  const int maxIntPoints = gpudata::MAXINTPOINTS;  // corresponding to HEX face with p=5
+  const int maxDofs = gpudata::MAXDOFS;      // corresponding to HEX with p=5
 
   volumeFaceIntegrationArrays gpuArrays;
 

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -304,8 +304,12 @@ class M2ulPhyS : public TPS::Solver {
   void uniformInitialConditions();
   void initGradUp();
 
-  // i/o routines
+  // NOTE(kevin): this routine is currently obsolete.
+  // It computes `dof`-averaged state and time-derivative, which are useless at this point.
+  // This will not be supported.
   void writeHistoryFile();
+
+  // i/o routines
   void write_restart_files();
   void read_restart_files();
   void read_partitioned_soln_data(hid_t file, string varName, size_t index, double *data);

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -146,7 +146,7 @@ class M2ulPhyS : public TPS::Solver {
   GasMixture *mixture;    // valid on host
   GasMixture *d_mixture;  // valid on device, when available; otherwise = mixture
 
-  TransportProperties *transportPtr = NULL; // valid on both host and device
+  TransportProperties *transportPtr = NULL;  // valid on both host and device
   // TransportProperties *d_transport = NULL;  // valid on device, when available; otherwise = transportPtr
 
   Chemistry *chemistry_ = NULL;
@@ -181,7 +181,7 @@ class M2ulPhyS : public TPS::Solver {
 
   // nodes IDs and indirection array
   const int maxIntPoints = gpudata::MAXINTPOINTS;  // corresponding to HEX face with p=5
-  const int maxDofs = gpudata::MAXDOFS;      // corresponding to HEX with p=5
+  const int maxDofs = gpudata::MAXDOFS;            // corresponding to HEX with p=5
 
   volumeFaceIntegrationArrays gpuArrays;
 

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -87,7 +87,7 @@ class ArgonMinimalTransport : public TransportProperties {
   ArgonMinimalTransport(GasMixture *_mixture, RunConfiguration &_runfile);
   ArgonMinimalTransport(GasMixture *_mixture);
 
-  virtual ~ArgonMinimalTransport() {}
+  MFEM_HOST_DEVICE virtual ~ArgonMinimalTransport() {}
 
   int getIonIndex() { return ionIndex_; }
 
@@ -154,7 +154,7 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
  public:
   ArgonMixtureTransport(GasMixture *_mixture, RunConfiguration &_runfile);
 
-  virtual ~ArgonMixtureTransport() {}
+  MFEM_HOST_DEVICE virtual ~ArgonMixtureTransport() {}
 
   double collisionIntegral(const int _spI, const int _spJ, const int l, const int r, const collisionInputs collInputs);
 

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -101,8 +101,12 @@ class ArgonMinimalTransport : public TransportProperties {
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
-  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-                                              double *transportBuffer, double *diffusionVelocity) { exit(-1); return; }
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
+                                                               const double *Efield, double *transportBuffer,
+                                                               double *diffusionVelocity) {
+    exit(-1);
+    return;
+  }
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
@@ -167,8 +171,12 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
-  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-                                              double *transportBuffer, double *diffusionVelocity) { exit(-1); return; }
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
+                                                               const double *Efield, double *transportBuffer,
+                                                               double *diffusionVelocity) {
+    exit(-1);
+    return;
+  }
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -101,7 +101,8 @@ class ArgonMinimalTransport : public TransportProperties {
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
-  // Vector &outputUp);
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
+                                              double *transportBuffer, double *diffusionVelocity) { exit(-1); return; }
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
@@ -166,6 +167,8 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
+                                              double *transportBuffer, double *diffusionVelocity) { exit(-1); return; }
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.

--- a/src/averaging_and_rms.cpp
+++ b/src/averaging_and_rms.cpp
@@ -92,6 +92,9 @@ Averaging::Averaging(ParGridFunction *_Up, ParMesh *_mesh, FiniteElementCollecti
     paraviewMean->RegisterField("rms", rms);
     if (eqSystem == NS_PASSIVE) paraviewMean->RegisterField("passScalar", meanScalar);
 
+    // NOTE(kevin): this variable is currently obsolete.
+    // It represents `dof`-averaged state, which is useless at this point.
+    // This will not be supported.
     local_sums.UseDevice(true);
     local_sums.SetSize(5 + 6);
     local_sums = 0.;
@@ -291,6 +294,9 @@ void Averaging::initiMeanAndRMS() {
   }
 }
 
+// NOTE(kevin): this routine is currently obsolete.
+// It computes `dof`-averaged state and time-derivative, which are useless at this point.
+// This will not be supported.
 const double *Averaging::getLocalSums() {
 #ifdef _GPU_
   sumValues_gpu(*meanUp, *rms, local_sums, tmp_vector, num_equation, dim);
@@ -328,8 +334,10 @@ void Averaging::addSample_gpu(ParGridFunction *meanUp, ParGridFunction *rms, int
   const double Rg = mixture->GetGasConstant();
 
   MFEM_FORALL(n, Ndof, {
-    double meanVel[3], vel[3];
-    double nUp[20];  // NOTE: lets make sure we don't have more than 20 eq.
+    double meanVel[gpudata::MAXDIM], vel[gpudata::MAXDIM]; // double meanVel[3], vel[3];
+    // double nUp[20];  // NOTE: lets make sure we don't have more than 20 eq.
+    // NOTE(kevin): (presumably) marc left this hidden note here..
+    double nUp[gpudata::MAXEQUATIONS];
 
     for (int eq = 0; eq < num_equation; eq++) {
       nUp[eq] = d_Up[n + eq * Ndof];
@@ -392,6 +400,9 @@ void Averaging::addSample_gpu(ParGridFunction *meanUp, ParGridFunction *rms, int
   });
 }
 
+// NOTE(kevin): this routine is currently obsolete.
+// It computes `dof`-averaged state and time-derivative, which are useless at this point.
+// This will not be supported.
 void Averaging::sumValues_gpu(const Vector &meanUp, const Vector &rms, Vector &local_sums, Vector &tmp_vector,
                               const int &num_equation, const int &dim) {
   const int NDof = meanUp.Size() / num_equation;

--- a/src/averaging_and_rms.cpp
+++ b/src/averaging_and_rms.cpp
@@ -330,9 +330,12 @@ void Averaging::addSample_gpu(ParGridFunction *meanUp, ParGridFunction *rms, int
 
   double dSamplesMean = (double)samplesMean;
 
-  // WorkingFluid fluid = mixture->GetWorkingFluid();
-  // const double Rg = mixture->GetGasConstant();
+#if defined(_HIP_)
+  WorkingFluid fluid = mixture->GetWorkingFluid();
+  const double Rg = mixture->GetGasConstant();
+#elif defined(_CUDA_)
   GasMixture *d_mixture = mixture;
+#endif
 
   MFEM_FORALL(n, Ndof, {
     double meanVel[gpudata::MAXDIM], vel[gpudata::MAXDIM]; // double meanVel[3], vel[3];
@@ -353,7 +356,14 @@ void Averaging::addSample_gpu(ParGridFunction *meanUp, ParGridFunction *rms, int
       if (eq != 1 + dim) {
         newMeanUp = (mVal + nUp[eq]) / (dSamplesMean + 1);
       } else {  // eq == 1+dim
+#if defined(_CUDA_)
         double p = d_mixture->ComputePressureFromPrimitives(nUp);
+#elif defined(_HIP_)
+        double p;
+        if (fluid == DRY_AIR) {
+          p = DryAir::ComputePressureFromPrimitives_gpu(&nUp[0], Rg, dim);
+        }
+#endif
         newMeanUp = (mVal + p) / (dSamplesMean + 1);
       }
 

--- a/src/averaging_and_rms.cpp
+++ b/src/averaging_and_rms.cpp
@@ -330,8 +330,9 @@ void Averaging::addSample_gpu(ParGridFunction *meanUp, ParGridFunction *rms, int
 
   double dSamplesMean = (double)samplesMean;
 
-  WorkingFluid fluid = mixture->GetWorkingFluid();
-  const double Rg = mixture->GetGasConstant();
+  // WorkingFluid fluid = mixture->GetWorkingFluid();
+  // const double Rg = mixture->GetGasConstant();
+  GasMixture *d_mixture = mixture;
 
   MFEM_FORALL(n, Ndof, {
     double meanVel[gpudata::MAXDIM], vel[gpudata::MAXDIM]; // double meanVel[3], vel[3];
@@ -352,10 +353,7 @@ void Averaging::addSample_gpu(ParGridFunction *meanUp, ParGridFunction *rms, int
       if (eq != 1 + dim) {
         newMeanUp = (mVal + nUp[eq]) / (dSamplesMean + 1);
       } else {  // eq == 1+dim
-        double p;
-        if (fluid == DRY_AIR) {
-          p = DryAir::ComputePressureFromPrimitives_gpu(&nUp[0], Rg, dim);
-        }
+        double p = d_mixture->ComputePressureFromPrimitives(nUp);
         newMeanUp = (mVal + p) / (dSamplesMean + 1);
       }
 

--- a/src/averaging_and_rms.cpp
+++ b/src/averaging_and_rms.cpp
@@ -338,7 +338,7 @@ void Averaging::addSample_gpu(ParGridFunction *meanUp, ParGridFunction *rms, int
 #endif
 
   MFEM_FORALL(n, Ndof, {
-    double meanVel[gpudata::MAXDIM], vel[gpudata::MAXDIM]; // double meanVel[3], vel[3];
+    double meanVel[gpudata::MAXDIM], vel[gpudata::MAXDIM];  // double meanVel[3], vel[3];
     // double nUp[20];  // NOTE: lets make sure we don't have more than 20 eq.
     // NOTE(kevin): (presumably) marc left this hidden note here..
     double nUp[gpudata::MAXEQUATIONS];

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -116,8 +116,8 @@ class Averaging {
 
   // GPU functions
 #ifdef _GPU_
-  static void addSample_gpu(ParGridFunction *meanUp, ParGridFunction *rms, int &samplesMean, GasMixture *mixture,
-                            const ParGridFunction *Up, const int &Ndof, const int &dim, const int &num_equation);
+  void addSample_gpu(ParGridFunction *meanUp, ParGridFunction *rms, int &samplesMean, GasMixture *mixture,
+                     const ParGridFunction *Up, const int &Ndof, const int &dim, const int &num_equation);
   static void sumValues_gpu(const Vector &meanUp, const Vector &rms, Vector &local_sums, Vector &tmp_vector,
                             const int &num_equation, const int &dim);
 #endif  // _GPU_

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -39,8 +39,13 @@
 using namespace mfem;
 
 namespace gpudata {
+  // nodes IDs and indirection array
+  const int MAXINTPOINTS = 64;  // corresponding to HEX face with p=5
+  const int MAXDOFS = 216;      // corresponding to HEX with p=5
+
   const int MAXDIM = 3;
-  const int MAXSPECIES = 20;
+  const int MAXSPECIES = 15;
+  const int MAXEQUATIONS = MAXDIM + 2 + MAXSPECIES; // momentum + two energies + species
 }
 
 enum Equations {

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -286,11 +286,30 @@ struct BoundaryViscousFluxData {
   */
   double primFlux[gpudata::MAXEQUATIONS];
   bool primFluxIdxs[gpudata::MAXEQUATIONS];
+
+  // NOTE(kevin): while auto-generated operator= works in the same way,
+  //              the function is still defined to be safe.
+  MFEM_HOST_DEVICE BoundaryViscousFluxData& operator=(const BoundaryViscousFluxData &rhs) {
+    for (int eq = 0; eq < gpudata::MAXEQUATIONS; eq++) {
+      primFlux[eq] = rhs.primFlux[eq];
+      primFluxIdxs[eq] = rhs.primFluxIdxs[eq];
+    }
+    for (int d = 0; d < gpudata::MAXDIM; d++) normal[d] = rhs.normal[d];
+    return *this;
+  }
 };
 
 struct BoundaryPrimitiveData {
   double prim[gpudata::MAXEQUATIONS];
   bool primIdxs[gpudata::MAXEQUATIONS];
+
+  MFEM_HOST_DEVICE BoundaryPrimitiveData& operator=(const BoundaryPrimitiveData &rhs) {
+    for (int eq = 0; eq < gpudata::MAXEQUATIONS; eq++) {
+      prim[eq] = rhs.prim[eq];
+      primIdxs[eq] = rhs.primIdxs[eq];
+    }
+    return *this;
+  }
 };
 
 #endif  // DATASTRUCTURES_HPP_

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -44,7 +44,7 @@ const int MAXINTPOINTS = 64;  // corresponding to HEX face with p=5
 const int MAXDOFS = 216;      // corresponding to HEX with p=5
 
 const int MAXDIM = 3;
-const int MAXSPECIES = 15;
+const int MAXSPECIES = 5;
 const int MAXEQUATIONS = MAXDIM + 2 + MAXSPECIES;  // momentum + two energies + species
 }  // namespace gpudata
 

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -39,14 +39,14 @@
 using namespace mfem;
 
 namespace gpudata {
-  // nodes IDs and indirection array
-  const int MAXINTPOINTS = 64;  // corresponding to HEX face with p=5
-  const int MAXDOFS = 216;      // corresponding to HEX with p=5
+// nodes IDs and indirection array
+const int MAXINTPOINTS = 64;  // corresponding to HEX face with p=5
+const int MAXDOFS = 216;      // corresponding to HEX with p=5
 
-  const int MAXDIM = 3;
-  const int MAXSPECIES = 15;
-  const int MAXEQUATIONS = MAXDIM + 2 + MAXSPECIES; // momentum + two energies + species
-}
+const int MAXDIM = 3;
+const int MAXSPECIES = 15;
+const int MAXEQUATIONS = MAXDIM + 2 + MAXSPECIES;  // momentum + two energies + species
+}  // namespace gpudata
 
 enum Equations {
   EULER,      // Euler equations

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -277,20 +277,20 @@ struct WallData {
 };
 
 struct BoundaryViscousFluxData {
-  Vector normal;
+  double normal[gpudata::MAXDIM];
   /* Primitive viscous flux index order:
    diffusion velocity - numSpecies,
    stress             - nvel,
    heavy_heat         - 1,
    electron_heat      - 1
   */
-  Vector primFlux;
-  Array<bool> primFluxIdxs;
+  double primFlux[gpudata::MAXEQUATIONS];
+  bool primFluxIdxs[gpudata::MAXEQUATIONS];
 };
 
 struct BoundaryPrimitiveData {
-  Vector prim;
-  Array<bool> primIdxs;
+  double prim[gpudata::MAXEQUATIONS];
+  bool primIdxs[gpudata::MAXEQUATIONS];
 };
 
 #endif  // DATASTRUCTURES_HPP_

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -38,6 +38,11 @@
 
 using namespace mfem;
 
+namespace gpudata {
+  const int MAXDIM = 3;
+  const int MAXSPECIES = 20;
+}
+
 enum Equations {
   EULER,      // Euler equations
   NS,         // Navier-Stokes equations

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -289,7 +289,7 @@ struct BoundaryViscousFluxData {
 
   // NOTE(kevin): while auto-generated operator= works in the same way,
   //              the function is still defined to be safe.
-  MFEM_HOST_DEVICE BoundaryViscousFluxData& operator=(const BoundaryViscousFluxData &rhs) {
+  MFEM_HOST_DEVICE BoundaryViscousFluxData &operator=(const BoundaryViscousFluxData &rhs) {
     for (int eq = 0; eq < gpudata::MAXEQUATIONS; eq++) {
       primFlux[eq] = rhs.primFlux[eq];
       primFluxIdxs[eq] = rhs.primFluxIdxs[eq];
@@ -303,7 +303,7 @@ struct BoundaryPrimitiveData {
   double prim[gpudata::MAXEQUATIONS];
   bool primIdxs[gpudata::MAXEQUATIONS];
 
-  MFEM_HOST_DEVICE BoundaryPrimitiveData& operator=(const BoundaryPrimitiveData &rhs) {
+  MFEM_HOST_DEVICE BoundaryPrimitiveData &operator=(const BoundaryPrimitiveData &rhs) {
     for (int eq = 0; eq < gpudata::MAXEQUATIONS; eq++) {
       prim[eq] = rhs.prim[eq];
       primIdxs[eq] = rhs.primIdxs[eq];

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -46,6 +46,8 @@ const int MAXDOFS = 216;      // corresponding to HEX with p=5
 const int MAXDIM = 3;
 const int MAXSPECIES = 5;
 const int MAXEQUATIONS = MAXDIM + 2 + MAXSPECIES;  // momentum + two energies + species
+// NOTE: (presumably from marc) lets make sure we don't have more than 20 eq.
+// NOTE(kevin): with MAXEQUATIONS=20, marvin fails with out-of-memery with 3 MPI process.
 }  // namespace gpudata
 
 enum Equations {

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -365,8 +365,8 @@ void DGNonLinearForm::evalFaceFlux_gpu() {
       d_flux->ComputeViscousFluxes(u1, gradUp1, 0.0, vFlux1);
       d_flux->ComputeViscousFluxes(u2, gradUp2, 0.0, vFlux2);
       // d_flux->ComputeViscousFluxes(d_uk_el1 + k * num_equation + iface * maxIntPoints * num_equation,
-      //                              d_grad_uk_el1 + k * dim * num_equation + iface * maxIntPoints * dim * num_equation,
-      //                              0.0, vFlux1);
+      //             d_grad_uk_el1 + k * dim * num_equation + iface * maxIntPoints * dim * num_equation,
+      //             0.0, vFlux1);
 #elif defined(_HIP_)
       Fluxes::viscousFlux_serial_gpu(&vFlux1[0], &u1[0], &gradUp1[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,
                                      num_equation);

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -628,15 +628,15 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
   Fluxes *d_flux = fluxes;
 
   MFEM_FORALL_2D(el, parallelData->sharedElemsFaces.Size() / 7, maxIntPoints, 1, 1, {
-    double l1[gpudata::MAXDOFS], l2[gpudata::MAXDOFS]; //double l1[216], l2[216];
-    double u1[gpudata::MAXEQUATIONS], u2[gpudata::MAXEQUATIONS]; //double u1[5], u2[5];
-    double gradUp1[gpudata::MAXDIM * gpudata::MAXEQUATIONS], //double gradUp1[3 * 5];
-           gradUp2[gpudata::MAXDIM * gpudata::MAXEQUATIONS], //gradUp2[3 * 5];
-           nor[gpudata::MAXDIM]; //nor[3];
-    double Rflux[gpudata::MAXEQUATIONS], //double Rflux[5];
-           vFlux1[gpudata::MAXDIM * gpudata::MAXEQUATIONS], //vFlux1[3 * 5];
-           vFlux2[gpudata::MAXDIM * gpudata::MAXEQUATIONS]; //vFlux2[3 * 5];
-    int index_i[gpudata::MAXDOFS]; //int index_i[216];
+    double l1[gpudata::MAXDOFS], l2[gpudata::MAXDOFS];            // double l1[216], l2[216];
+    double u1[gpudata::MAXEQUATIONS], u2[gpudata::MAXEQUATIONS];  // double u1[5], u2[5];
+    double gradUp1[gpudata::MAXDIM * gpudata::MAXEQUATIONS],      // double gradUp1[3 * 5];
+        gradUp2[gpudata::MAXDIM * gpudata::MAXEQUATIONS],         // gradUp2[3 * 5];
+        nor[gpudata::MAXDIM];                                     // nor[3];
+    double Rflux[gpudata::MAXEQUATIONS],                          // double Rflux[5];
+        vFlux1[gpudata::MAXDIM * gpudata::MAXEQUATIONS],          // vFlux1[3 * 5];
+        vFlux2[gpudata::MAXDIM * gpudata::MAXEQUATIONS];          // vFlux2[3 * 5];
+    int index_i[gpudata::MAXDOFS];                                // int index_i[216];
 
     const int el1 = d_sharedElemsFaces[0 + el * 7];
     const int numFaces = d_sharedElemsFaces[1 + el * 7];

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -312,10 +312,10 @@ void DGNonLinearForm::evalFaceFlux_gpu() {
   // clang-format off
   MFEM_FORALL(iface, Nf,
   {
-    double u1[5], gradUp1[5 * 3];
-    double u2[5], gradUp2[5 * 3];
-    double vFlux1[5 * 3], vFlux2[5 * 3];
-    double Rflux[5], nor[3];
+    double u1[gpudata::MAXEQUATIONS], gradUp1[gpudata::MAXEQUATIONS * gpudata::MAXDIM];
+    double u2[gpudata::MAXEQUATIONS], gradUp2[gpudata::MAXEQUATIONS * gpudata::MAXDIM];
+    double vFlux1[gpudata::MAXEQUATIONS * gpudata::MAXDIM], vFlux2[gpudata::MAXEQUATIONS * gpudata::MAXDIM];
+    double Rflux[gpudata::MAXEQUATIONS], nor[gpudata::MAXDIM];
 
     const int Q = d_elems12Q[3 * iface + 2];
     const int offsetShape1 = iface * maxIntPoints * (maxDofs + 1 + dim);

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -361,6 +361,7 @@ void DGNonLinearForm::evalFaceFlux_gpu() {
                          Rflux);
 
 #if defined(_CUDA_)
+      // TODO(kevin): implement radius.
       d_flux->ComputeViscousFluxes(u1, gradUp1, 0.0, vFlux1);
       d_flux->ComputeViscousFluxes(u2, gradUp2, 0.0, vFlux2);
       // d_flux->ComputeViscousFluxes(d_uk_el1 + k * num_equation + iface * maxIntPoints * num_equation,
@@ -699,6 +700,7 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
 
         // evaluate flux
 #if defined(_CUDA_)
+        // TODO(kevin): implement radius.
         d_rsolver->Eval_LF(u1, u2, nor, Rflux);
         d_flux->ComputeViscousFluxes(u1, gradUp1, 0.0, vFlux1);
         d_flux->ComputeViscousFluxes(u2, gradUp2, 0.0, vFlux2);

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -207,10 +207,10 @@ void DGNonLinearForm::faceIntegration_gpu(Vector &y, int elType, int elemOffset,
   // clang-format off
   MFEM_FORALL_2D(el, NumElemType, elDof, 1, 1,
   {
-    MFEM_SHARED double shape[gpudata::MAXDOFS]; // shape[216];
-    MFEM_SHARED double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS]; // Fcontrib[216 * 5];
-    double Rflux[gpudata::MAXEQUATIONS]; // double Rflux[5];
-    int indexes_i[gpudata::MAXDOFS]; // int indexes_i[216];
+    MFEM_SHARED double shape[gpudata::MAXDOFS];  // shape[216];
+    MFEM_SHARED double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS];  // Fcontrib[216 * 5];
+    double Rflux[gpudata::MAXEQUATIONS];  // double Rflux[5];
+    int indexes_i[gpudata::MAXDOFS];  // int indexes_i[216];
 
     const int eli = elemOffset + el;
     const int offsetEl1 = d_posDofIds[2 * eli];
@@ -543,9 +543,9 @@ void DGNonLinearForm::sharedFaceIntegration_gpu(Vector &y) {
 
   MFEM_FORALL_2D(el, parallelData->sharedElemsFaces.Size() / 7, maxDofs, 1, 1, {
     //
-    double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS]; //double Fcontrib[216 * 5];
-    double Rflux[gpudata::MAXEQUATIONS]; //double Rflux[5];
-    int index_i[gpudata::MAXDOFS]; //int index_i[216];
+    double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS];  // double Fcontrib[216 * 5];
+    double Rflux[gpudata::MAXEQUATIONS];  // double Rflux[5];
+    int index_i[gpudata::MAXDOFS];  // int index_i[216];
 
     const int el1      = d_sharedElemsFaces[0 + el * 7];
     const int offsetEl1 = d_posDofIds[2 * el1];

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -86,6 +86,7 @@ void DGNonLinearForm::setParallelData(parallelFacesIntegrationArrays *_parallelD
   shared_flux.UseDevice(true);
 
   int maxNumElems = parallelData->sharedElemsFaces.Size() / 7;  // elements with shared faces
+  // TODO(kevin): MAXNUMFACE
   shared_flux.SetSize(maxNumElems * 5 * maxIntPoints_ * num_equation_);
 }
 
@@ -567,7 +568,7 @@ void DGNonLinearForm::sharedFaceIntegration_gpu(Vector &y) {
           d_sharedShapeWnor1[maxDofs + k * (maxDofs + 1 + dim) + f * maxIntPoints * (maxDofs + 1 + dim)];
 
         for (int eq = 0; eq < num_equation; eq++) {
-          // NOTE: this 5 seems to be the max number of faces?
+          // TODO(kevin): MAXNUMFACE
           const int idxu = eq + k*num_equation + elFace*maxIntPoints*num_equation + el*5*maxIntPoints*num_equation;
           Rflux[eq] = d_shared_flux[idxu];
         }
@@ -726,6 +727,7 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
         }
 
         for (int eq = 0; eq < num_equation; eq++) {
+          // TODO(kevin): MAXNUMFACE
           const int idx =
               eq + k * num_equation + elFace * maxIntPoints * num_equation + el * 5 * maxIntPoints * num_equation;
           d_shared_flux[idx] = Rflux[eq];

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -622,6 +622,8 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
   double *d_shared_flux = shared_flux.Write();
 
   const RiemannSolver *d_rsolver = rsolver_;
+  Fluxes *d_flux = fluxes;
+
   MFEM_FORALL_2D(el, parallelData->sharedElemsFaces.Size() / 7, maxIntPoints, 1, 1, {
     double l1[216], l2[216];
     double u1[5], u2[5];

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -187,6 +187,11 @@ void DryAir::computeSpeciesEnthalpies(const Vector &state, Vector &speciesEnthal
   return;
 }
 
+MFEM_HOST_DEVICE void DryAir::computeSpeciesEnthalpies(const double *state, double *speciesEnthalpies) {
+  for (int sp = 0; sp < numSpecies; sp++) speciesEnthalpies[sp] = 0.0;
+  return;
+}
+
 bool DryAir::StateIsPhysical(const mfem::Vector &state) {
   const double den = state(0);
   const Vector den_vel(state.GetData() + 1, nvel_);

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -119,7 +119,6 @@ MFEM_HOST_DEVICE DryAir::DryAir(const WorkingFluid f, const Equations eq_sys, co
   cp_div_pr = specific_heat_ratio * gas_constant / (Pr * (specific_heat_ratio - 1.));
   Sc = 0.71;
 #endif
-
   // TODO(kevin): replace Nconservative/Nprimitive.
   // add extra equation for passive scalar
   if (eq_sys == Equations::NS_PASSIVE) {

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -310,7 +310,7 @@ void DryAir::GetPrimitivesFromConservatives(const Vector &conserv, Vector &primi
 
 MFEM_HOST_DEVICE void DryAir::GetPrimitivesFromConservatives(const double *conserv, double *primit) {
   double T = ComputeTemperature(conserv);
-  primit = conserv;
+  for (int eq = 0; eq < num_equation; eq++) primit[eq] = conserv[eq];
 
   for (int d = 0; d < nvel_; d++) primit[1 + d] /= conserv[0];
 

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -80,12 +80,12 @@ void GasMixture::computeStagnationState(const mfem::Vector &stateIn, mfem::Vecto
 void GasMixture::modifyStateFromPrimitive(const Vector &state, const BoundaryPrimitiveData &bcState,
                                           Vector &outputState) {
   outputState.SetSize(num_equation);
-  assert(bcState.prim.Size() == num_equation);
+  // assert(bcState.prim.Size() == num_equation);
 
   Vector prim(num_equation);
   GetPrimitivesFromConservatives(state, prim);
   for (int i = 0; i < num_equation; i++) {
-    if (bcState.primIdxs[i]) prim(i) = bcState.prim(i);
+    if (bcState.primIdxs[i]) prim(i) = bcState.prim[i];
   }
 
   GetConservativesFromPrimitives(prim, outputState);
@@ -1385,7 +1385,7 @@ void PerfectMixture::computeSheathBdrFlux(const Vector &state, BoundaryViscousFl
   double T_h, T_e;
   computeTemperaturesBase(state, &n_sp[0], n_sp[numSpecies - 2], n_sp[numSpecies - 1], T_h, T_e);
 
-  for (int sp = 0; sp < numSpecies; sp++) bcFlux.primFlux(sp) = 0.0;
+  for (int sp = 0; sp < numSpecies; sp++) bcFlux.primFlux[sp] = 0.0;
 
   // Compute Bohm velocity for positive ions.
   for (int sp = 0; sp < numSpecies; sp++) {
@@ -1394,21 +1394,21 @@ void PerfectMixture::computeSheathBdrFlux(const Vector &state, BoundaryViscousFl
       double msp = gasParams(sp, GasParams::SPECIES_MW);
       double VB = sqrt((T_h + Zsp * T_e) * UNIVERSALGASCONSTANT / msp);
       // TODO(kevin): need to check the sign (out of wall or into the wall)
-      bcFlux.primFlux(sp) = VB;
-      bcFlux.primFlux(numSpecies - 2) += Zsp * n_sp(sp) * VB;
-      bcFlux.primFlux(numSpecies - 1) -= msp * n_sp(sp) * VB;  // fully catalytic wall.
+      bcFlux.primFlux[sp] = VB;
+      bcFlux.primFlux[numSpecies - 2] += Zsp * n_sp(sp) * VB;
+      bcFlux.primFlux[numSpecies - 1] -= msp * n_sp(sp) * VB;  // fully catalytic wall.
     }
   }
-  bcFlux.primFlux(numSpecies - 2) /= n_sp(numSpecies - 2);
-  bcFlux.primFlux(numSpecies - 1) -=
-      gasParams(numSpecies - 2, GasParams::SPECIES_MW) * n_sp(numSpecies - 2) * bcFlux.primFlux(numSpecies - 2);
-  bcFlux.primFlux(numSpecies - 1) /= gasParams(numSpecies - 1, GasParams::SPECIES_MW) * n_sp(numSpecies - 1);
+  bcFlux.primFlux[numSpecies - 2] /= n_sp(numSpecies - 2);
+  bcFlux.primFlux[numSpecies - 1] -=
+      gasParams(numSpecies - 2, GasParams::SPECIES_MW) * n_sp(numSpecies - 2) * bcFlux.primFlux[numSpecies - 2];
+  bcFlux.primFlux[numSpecies - 1] /= gasParams(numSpecies - 1, GasParams::SPECIES_MW) * n_sp(numSpecies - 1);
 
   if (twoTemperature_) {
     double vTe = sqrt(8.0 * UNIVERSALGASCONSTANT * T_e / PI / gasParams(numSpecies - 2, GasParams::SPECIES_MW));
-    double gamma = -log(4.0 / vTe * bcFlux.primFlux(numSpecies - 2));
+    double gamma = -log(4.0 / vTe * bcFlux.primFlux[numSpecies - 2]);
 
-    bcFlux.primFlux(numSpecies + nvel_ + 1) =
-        bcFlux.primFlux(numSpecies - 2) * (gamma + 2.0) * n_sp(numSpecies - 2) * UNIVERSALGASCONSTANT * T_e;
+    bcFlux.primFlux[numSpecies + nvel_ + 1] =
+        bcFlux.primFlux[numSpecies - 2] * (gamma + 2.0) * n_sp(numSpecies - 2) * UNIVERSALGASCONSTANT * T_e;
   }
 }

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -859,6 +859,13 @@ void PerfectMixture::computeSpeciesEnthalpies(const Vector &state, Vector &speci
   return;
 }
 
+MFEM_HOST_DEVICE void PerfectMixture::computeSpeciesEnthalpies(const double *state, double *speciesEnthalpies) {
+  // TODO(kevin): develop gpu version.
+  exit(-1);
+
+  return;
+}
+
 double PerfectMixture::ComputePressureDerivative(const Vector &dUp_dx, const Vector &Uin, bool primitive) {
   if (primitive) {
     return computePressureDerivativeFromPrimitives(dUp_dx, Uin);

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -380,6 +380,8 @@ double DryAir::ComputePressureDerivative(const Vector &dUp_dx, const Vector &Uin
 
 double DryAir::ComputePressureFromPrimitives(const mfem::Vector &Up) { return gas_constant * Up[0] * Up[1 + nvel_]; }
 
+MFEM_HOST_DEVICE double DryAir::ComputePressureFromPrimitives(const double *Up) { return gas_constant * Up[0] * Up[1 + nvel_]; }
+
 void DryAir::computeStagnationState(const mfem::Vector &stateIn, mfem::Vector &stagnationState) {
   const double p = ComputePressure(stateIn);
 

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -385,6 +385,18 @@ void DryAir::modifyEnergyForPressure(const mfem::Vector &stateIn, mfem::Vector &
   stateOut(1 + nvel_) = p / (specific_heat_ratio - 1.) + ke;
 }
 
+MFEM_HOST_DEVICE void DryAir::modifyEnergyForPressure(const double *stateIn, double *stateOut, const double &p,
+                                                      bool modifyElectronEnergy) {
+printf("entered dry air modify.\n");
+  for (int eq = 0; eq < num_equation; eq++) stateOut[eq] = stateIn[eq];
+
+  double ke = 0.;
+  for (int d = 0; d < nvel_; d++) ke += stateIn[1 + d] * stateIn[1 + d];
+  ke *= 0.5 / stateIn[0];
+
+  stateOut[1 + nvel_] = p / (specific_heat_ratio - 1.) + ke;
+}
+
 // TODO(kevin): check if this works for axisymmetric case.
 void DryAir::computeConservedStateFromConvectiveFlux(const Vector &meanNormalFluxes, const Vector &normal,
                                                      Vector &conservedState) {

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -380,7 +380,9 @@ double DryAir::ComputePressureDerivative(const Vector &dUp_dx, const Vector &Uin
 
 double DryAir::ComputePressureFromPrimitives(const mfem::Vector &Up) { return gas_constant * Up[0] * Up[1 + nvel_]; }
 
-MFEM_HOST_DEVICE double DryAir::ComputePressureFromPrimitives(const double *Up) { return gas_constant * Up[0] * Up[1 + nvel_]; }
+MFEM_HOST_DEVICE double DryAir::ComputePressureFromPrimitives(const double *Up) {
+  return gas_constant * Up[0] * Up[1 + nvel_];
+}
 
 void DryAir::computeStagnationState(const mfem::Vector &stateIn, mfem::Vector &stagnationState) {
   const double p = ComputePressure(stateIn);

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -387,7 +387,6 @@ void DryAir::modifyEnergyForPressure(const mfem::Vector &stateIn, mfem::Vector &
 
 MFEM_HOST_DEVICE void DryAir::modifyEnergyForPressure(const double *stateIn, double *stateOut, const double &p,
                                                       bool modifyElectronEnergy) {
-printf("entered dry air modify.\n");
   for (int eq = 0; eq < num_equation; eq++) stateOut[eq] = stateIn[eq];
 
   double ke = 0.;

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -865,7 +865,7 @@ void PerfectMixture::computeSpeciesEnthalpies(const Vector &state, Vector &speci
 
 MFEM_HOST_DEVICE void PerfectMixture::computeSpeciesEnthalpies(const double *state, double *speciesEnthalpies) {
   // TODO(kevin): develop gpu version.
-  exit(-1);
+  printf("ERROR: PerfextMixture::computeSpeciesEnthalpies is not yet developed for gpu!");
 
   return;
 }

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -107,6 +107,10 @@ MFEM_HOST_DEVICE DryAir::DryAir(const WorkingFluid f, const Equations eq_sys, co
 
   SetNumActiveSpecies();
   SetNumEquations();
+#ifdef _GPU_
+  assert(nvel_ <= gpudata::MAXDIM);
+  assert(numSpecies <= gpudata::MAXSPECIES);
+#endif
 
   gas_constant = 287.058;
 

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -308,6 +308,22 @@ void DryAir::GetPrimitivesFromConservatives(const Vector &conserv, Vector &primi
   }
 }
 
+MFEM_HOST_DEVICE void DryAir::GetPrimitivesFromConservatives(const double *conserv, double *primit) {
+  double T = ComputeTemperature(conserv);
+  primit = conserv;
+
+  for (int d = 0; d < nvel_; d++) primit[1 + d] /= conserv[0];
+
+  primit[nvel_ + 1] = T;
+
+  // case of passive scalar
+  if (num_equation > nvel_ + 2) {
+    for (int n = 0; n < num_equation - nvel_ - 2; n++) {
+      primit[nvel_ + 2 + n] /= primit[0];
+    }
+  }
+}
+
 double DryAir::ComputeSpeedOfSound(const mfem::Vector &Uin, bool primitive) {
   double T;
 

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -159,6 +159,7 @@ class GasMixture {
     mfem_error("computeSpeciesPrimitives not implemented");
   }
   virtual void computeSpeciesEnthalpies(const Vector &state, Vector &speciesEnthalpies) = 0;
+  MFEM_HOST_DEVICE virtual void computeSpeciesEnthalpies(const double *state, double *speciesEnthalpies) = 0;
 
   virtual void GetPrimitivesFromConservatives(const Vector &conserv, Vector &primit) = 0;
   virtual void GetConservativesFromPrimitives(const Vector &primit, Vector &conserv) = 0;
@@ -294,6 +295,7 @@ class DryAir : public GasMixture {
   virtual double Temperature(double *rho, double *p, int nsp = 1) { return p[0] / gas_constant / rho[0]; }
 
   virtual void computeSpeciesEnthalpies(const Vector &state, Vector &speciesEnthalpies);
+  MFEM_HOST_DEVICE virtual void computeSpeciesEnthalpies(const double *state, double *speciesEnthalpies);
 
   virtual void GetPrimitivesFromConservatives(const Vector &conserv, Vector &primit);
   virtual void GetConservativesFromPrimitives(const Vector &primit, Vector &conserv);

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -173,11 +173,11 @@ class GasMixture {
   virtual void GetConservativesFromPrimitives(const Vector &primit, Vector &conserv) = 0;
 
   MFEM_HOST_DEVICE virtual void GetPrimitivesFromConservatives(const double *conserv, double *primit) {
-    mfem_error("GetPrimitivesFromConservatives is not implemented.");
+    printf("GetPrimitivesFromConservatives is not implemented.");
     return;
   }
   MFEM_HOST_DEVICE virtual void GetConservativesFromPrimitives(const double *primit, double *conserv) {
-    mfem_error("GetPrimitivesFromConservatives is not implemented.");
+    printf("GetPrimitivesFromConservatives is not implemented.");
     return;
   }
 
@@ -369,7 +369,7 @@ class DryAir : public GasMixture {
     mfem_error("computeSheathBdrFlux not implemented");
   }
   MFEM_HOST_DEVICE virtual void computeSheathBdrFlux(const double *state, BoundaryViscousFluxData &bcFlux) {
-    mfem_error("ERROR: computeSheathBdrFlux is not supposed to be executed for DryAir!");
+    printf("ERROR: computeSheathBdrFlux is not supposed to be executed for DryAir!");
     return;
   }
 

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -151,6 +151,10 @@ class GasMixture {
   }
 
   virtual double ComputePressureFromPrimitives(const Vector &Up) = 0;  // pressure from primitive variables
+  MFEM_HOST_DEVICE virtual double ComputePressureFromPrimitives(const double *Up) {
+    mfem_error("ComputePressureFromPrimitives is not implemented.");
+    return -1.0;
+  }
   virtual double ComputeTemperature(const Vector &state) = 0;
   MFEM_HOST_DEVICE virtual double ComputeTemperature(const double *state) {
     mfem_error("ComputeTemperature is not implemented.");
@@ -315,6 +319,7 @@ class DryAir : public GasMixture {
   MFEM_HOST_DEVICE virtual double ComputePressure(const double *state, double *electronPressure = NULL) const;
 
   virtual double ComputePressureFromPrimitives(const Vector &Up);
+  MFEM_HOST_DEVICE virtual double ComputePressureFromPrimitives(const double *Up);
   virtual double ComputeTemperature(const Vector &state);
   MFEM_HOST_DEVICE virtual double ComputeTemperature(const double *state);
   virtual double Temperature(double *rho, double *p, int nsp = 1) { return p[0] / gas_constant / rho[0]; }

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -193,8 +193,8 @@ class GasMixture {
   // TODO(kevin): Need to remove these and fix wherever they are used.
   // We cannot use these for multi species (heat ratio of which species?)
   // These are used in forcingTerm, Fluxes ASSUMING that the fluid is single species.
-  virtual double GetSpecificHeatRatio() { return specific_heat_ratio; }
-  virtual double GetGasConstant() { return gas_constant; }
+  MFEM_HOST_DEVICE virtual double GetSpecificHeatRatio() { return specific_heat_ratio; }
+  MFEM_HOST_DEVICE virtual double GetGasConstant() { return gas_constant; }
 #else
   virtual double GetSpecificHeatRatio() = 0;
   virtual double GetGasConstant() = 0;
@@ -309,8 +309,8 @@ class DryAir : public GasMixture {
   // Physicality check (at end)
   virtual bool StateIsPhysical(const Vector &state);
 
-  virtual double GetSpecificHeatRatio() { return specific_heat_ratio; }
-  virtual double GetGasConstant() { return gas_constant; }
+  MFEM_HOST_DEVICE virtual double GetSpecificHeatRatio() { return specific_heat_ratio; }
+  MFEM_HOST_DEVICE virtual double GetGasConstant() { return gas_constant; }
 
   virtual void ComputeMassFractionGradient(const double rho, const Vector &numberDensities, const DenseMatrix &gradUp,
                                            DenseMatrix &massFractionGrad) {
@@ -551,8 +551,8 @@ class PerfectMixture : public GasMixture {
   virtual double getSpecificGasConstant(int species) { return specificGasConstants_(species); }
 
   // Kevin: these are mixture heat ratio and gas constant. need to change argument.
-  virtual double GetSpecificHeatRatio() { return molarCP_(numSpecies - 1) / molarCV_(numSpecies - 1); }
-  virtual double GetGasConstant() { return specificGasConstants_(numSpecies - 1); }
+  MFEM_HOST_DEVICE virtual double GetSpecificHeatRatio() { return molarCP_(numSpecies - 1) / molarCV_(numSpecies - 1); }
+  MFEM_HOST_DEVICE virtual double GetGasConstant() { return specificGasConstants_(numSpecies - 1); }
 
   virtual double computeHeaviesHeatCapacity(const double *n_sp, const double &nB);
   virtual double computeAmbipolarElectronNumberDensity(const double *n_sp);

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -243,7 +243,10 @@ class GasMixture {
     mfem_error("modifyEnergyForPressure not implemented");
   }
   MFEM_HOST_DEVICE virtual void modifyEnergyForPressure(const double *stateIn, double *stateOut, const double &p,
-                                       bool modifyElectronEnergy = false) {}
+                                                        bool modifyElectronEnergy = false) {
+    mfem_error("modifyEnergyForPressure not implemented");
+    return;
+  }
 
   // Modify state with a prescribed condition at boundary.
   // TODO(kevin): it is possible to use this routine for all BCs, so no need of making so many functions as above.
@@ -345,7 +348,7 @@ class DryAir : public GasMixture {
   virtual void modifyEnergyForPressure(const Vector &stateIn, Vector &stateOut, const double &p,
                                        bool modifyElectronEnergy = false);
   MFEM_HOST_DEVICE virtual void modifyEnergyForPressure(const double *stateIn, double *stateOut, const double &p,
-                                       bool modifyElectronEnergy = false);
+                                                        bool modifyElectronEnergy = false);
 
   virtual void computeSheathBdrFlux(const Vector &state, BoundaryViscousFluxData &bcFlux) {
     mfem_error("computeSheathBdrFlux not implemented");

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -242,6 +242,9 @@ class GasMixture {
                                        bool modifyElectronEnergy = false) {
     mfem_error("modifyEnergyForPressure not implemented");
   }
+  MFEM_HOST_DEVICE virtual void modifyEnergyForPressure(const double *stateIn, double *stateOut, const double &p,
+                                       bool modifyElectronEnergy = false) {}
+
   // Modify state with a prescribed condition at boundary.
   // TODO(kevin): it is possible to use this routine for all BCs, so no need of making so many functions as above.
   void modifyStateFromPrimitive(const Vector &state, const BoundaryPrimitiveData &bcState, Vector &outputState);
@@ -340,6 +343,8 @@ class DryAir : public GasMixture {
   virtual void computeStagnationState(const Vector &stateIn, Vector &stagnationState);
   virtual void computeStagnantStateWithTemp(const Vector &stateIn, const double Temp, Vector &stateOut);
   virtual void modifyEnergyForPressure(const Vector &stateIn, Vector &stateOut, const double &p,
+                                       bool modifyElectronEnergy = false);
+  MFEM_HOST_DEVICE virtual void modifyEnergyForPressure(const double *stateIn, double *stateOut, const double &p,
                                        bool modifyElectronEnergy = false);
 
   virtual void computeSheathBdrFlux(const Vector &state, BoundaryViscousFluxData &bcFlux) {

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -172,6 +172,10 @@ class GasMixture {
     mfem_error("GetPrimitivesFromConservatives is not implemented.");
     return;
   }
+  MFEM_HOST_DEVICE virtual void GetConservativesFromPrimitives(const double *primit, double *conserv) {
+    mfem_error("GetPrimitivesFromConservatives is not implemented.");
+    return;
+  }
 
   virtual double ComputeSpeedOfSound(const Vector &Uin, bool primitive = true) = 0;
 
@@ -251,6 +255,7 @@ class GasMixture {
   // Modify state with a prescribed condition at boundary.
   // TODO(kevin): it is possible to use this routine for all BCs, so no need of making so many functions as above.
   void modifyStateFromPrimitive(const Vector &state, const BoundaryPrimitiveData &bcState, Vector &outputState);
+  MFEM_HOST_DEVICE void modifyStateFromPrimitive(const double *state, const BoundaryPrimitiveData &bcState, double *outputState);
   virtual void computeSheathBdrFlux(const Vector &state, BoundaryViscousFluxData &bcFlux) = 0;
 
   virtual double computeAmbipolarElectronNumberDensity(const double *n_sp) {
@@ -316,6 +321,7 @@ class DryAir : public GasMixture {
   virtual void GetPrimitivesFromConservatives(const Vector &conserv, Vector &primit);
   MFEM_HOST_DEVICE virtual void GetPrimitivesFromConservatives(const double *conserv, double *primit);
   virtual void GetConservativesFromPrimitives(const Vector &primit, Vector &conserv);
+  MFEM_HOST_DEVICE virtual void GetConservativesFromPrimitives(const double *primit, double *conserv);
 
   virtual double ComputeSpeedOfSound(const Vector &Uin, bool primitive = true);
 

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -257,6 +257,10 @@ class GasMixture {
   void modifyStateFromPrimitive(const Vector &state, const BoundaryPrimitiveData &bcState, Vector &outputState);
   MFEM_HOST_DEVICE void modifyStateFromPrimitive(const double *state, const BoundaryPrimitiveData &bcState, double *outputState);
   virtual void computeSheathBdrFlux(const Vector &state, BoundaryViscousFluxData &bcFlux) = 0;
+  MFEM_HOST_DEVICE virtual void computeSheathBdrFlux(const double *state, BoundaryViscousFluxData &bcFlux) {
+    mfem_error("computeSheathBdrFlux is not implemented");
+    return;
+  }
 
   virtual double computeAmbipolarElectronNumberDensity(const double *n_sp) {
     mfem_error("computeAmbipolarElectronNumberDensity not implemented");
@@ -358,6 +362,10 @@ class DryAir : public GasMixture {
 
   virtual void computeSheathBdrFlux(const Vector &state, BoundaryViscousFluxData &bcFlux) {
     mfem_error("computeSheathBdrFlux not implemented");
+  }
+  MFEM_HOST_DEVICE virtual void computeSheathBdrFlux(const double *state, BoundaryViscousFluxData &bcFlux) {
+    mfem_error("ERROR: computeSheathBdrFlux is not supposed to be executed for DryAir!");
+    return;
   }
 
   virtual void computeConservedStateFromConvectiveFlux(const Vector &meanNormalFluxes, const Vector &normal,

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -580,6 +580,7 @@ class PerfectMixture : public GasMixture {
                                        const double n_B, double &T_h, double &T_e);
 
   virtual void computeSpeciesEnthalpies(const Vector &state, Vector &speciesEnthalpies);
+  MFEM_HOST_DEVICE virtual void computeSpeciesEnthalpies(const double *state, double *speciesEnthalpies);
 
   // TODO(kevin): Kevin - I don't think we should use this for boundary condition.
   virtual double Temperature(double *rho, double *p, int nsp = 1) { return p[0] / rho[0] / GetGasConstant(); }

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -259,7 +259,8 @@ class GasMixture {
   // Modify state with a prescribed condition at boundary.
   // TODO(kevin): it is possible to use this routine for all BCs, so no need of making so many functions as above.
   void modifyStateFromPrimitive(const Vector &state, const BoundaryPrimitiveData &bcState, Vector &outputState);
-  MFEM_HOST_DEVICE void modifyStateFromPrimitive(const double *state, const BoundaryPrimitiveData &bcState, double *outputState);
+  MFEM_HOST_DEVICE void modifyStateFromPrimitive(const double *state, const BoundaryPrimitiveData &bcState,
+                                                 double *outputState);
   virtual void computeSheathBdrFlux(const Vector &state, BoundaryViscousFluxData &bcFlux) = 0;
   MFEM_HOST_DEVICE virtual void computeSheathBdrFlux(const double *state, BoundaryViscousFluxData &bcFlux) {
     mfem_error("computeSheathBdrFlux is not implemented");

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -152,7 +152,10 @@ class GasMixture {
 
   virtual double ComputePressureFromPrimitives(const Vector &Up) = 0;  // pressure from primitive variables
   virtual double ComputeTemperature(const Vector &state) = 0;
-  MFEM_HOST_DEVICE virtual double ComputeTemperature(const double *state) = 0;
+  MFEM_HOST_DEVICE virtual double ComputeTemperature(const double *state) {
+    mfem_error("ComputeTemperature is not implemented.");
+    return -1.0;
+  }
   virtual double Temperature(double *rho, double *p,
                              int nsp) = 0;  // temperature given densities and pressures of all species
 
@@ -165,7 +168,10 @@ class GasMixture {
   virtual void GetPrimitivesFromConservatives(const Vector &conserv, Vector &primit) = 0;
   virtual void GetConservativesFromPrimitives(const Vector &primit, Vector &conserv) = 0;
 
-  MFEM_HOST_DEVICE virtual void GetPrimitivesFromConservatives(const double *conserv, double *primit) = 0;
+  MFEM_HOST_DEVICE virtual void GetPrimitivesFromConservatives(const double *conserv, double *primit) {
+    mfem_error("GetPrimitivesFromConservatives is not implemented.");
+    return;
+  }
 
   virtual double ComputeSpeedOfSound(const Vector &Uin, bool primitive = true) = 0;
 
@@ -302,7 +308,7 @@ class DryAir : public GasMixture {
   MFEM_HOST_DEVICE virtual void computeSpeciesEnthalpies(const double *state, double *speciesEnthalpies);
 
   virtual void GetPrimitivesFromConservatives(const Vector &conserv, Vector &primit);
-  MFEM_HOST_DEVICE virtual void GetPrimitivesFromConservatives(const Vector &conserv, Vector &primit);
+  MFEM_HOST_DEVICE virtual void GetPrimitivesFromConservatives(const double *conserv, double *primit);
   virtual void GetConservativesFromPrimitives(const Vector &primit, Vector &conserv);
 
   virtual double ComputeSpeedOfSound(const Vector &Uin, bool primitive = true);

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -249,7 +249,8 @@ void Fluxes::ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp
   }
 }
 
-MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const double *gradUp, double radius, double *flux) {
+MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const double *gradUp, double radius,
+                                                   double *flux) {
   for (int d = 0; d < dim; d++) {
     for (int eq = 0; eq < num_equation; eq++) {
       flux[eq + d * num_equation] = 0.;
@@ -289,8 +290,8 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
       double qeFlux = ke * gradUp[num_equation - 1 + d * num_equation];
       flux[1 + nvel + d * num_equation] += qeFlux;
       flux[num_equation - 1 + d * num_equation] += qeFlux;
-      flux[num_equation - 1 + d * num_equation] -= speciesEnthalpies[numSpecies - 2]
-                                                    * diffusionVelocity[numSpecies - 2 + d * numSpecies];
+      flux[num_equation - 1 + d * num_equation] -=
+          speciesEnthalpies[numSpecies - 2] * diffusionVelocity[numSpecies - 2 + d * numSpecies];
     }
   } else {
     k += ke;
@@ -309,7 +310,8 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
     }
     divV += gradUp[(1 + i) + i * num_equation];
   }
-  for (int i = 0; i < dim; i++) for (int j = 0; j < dim; j++) stress[i + j * dim] *= visc;
+  for (int i = 0; i < dim; i++)
+    for (int j = 0; j < dim; j++) stress[i + j * dim] *= visc;
 
   if (axisymmetric_ && radius > 0) {
     divV += ur / radius;
@@ -342,8 +344,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
   // stress.Mult(vel, vtmp);
   for (int i = 0; i < dim; i++) {
     vtmp[i] = 0.0;
-    for (int j = 0; j < dim; j++)
-      vtmp[i] += stress[i + j * dim] * vel[j];
+    for (int j = 0; j < dim; j++) vtmp[i] += stress[i + j * dim] * vel[j];
   }
 
   for (int d = 0; d < dim; d++) {
@@ -351,8 +352,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
     flux[(1 + nvel) + d * num_equation] += k * gradUp[(1 + nvel) + d * num_equation];
     // compute diffusive enthalpy flux.
     for (int sp = 0; sp < numSpecies; sp++) {
-      flux[(1 + nvel) + d * num_equation] -= speciesEnthalpies[sp]
-                                              * diffusionVelocity[sp + d * numSpecies];
+      flux[(1 + nvel) + d * num_equation] -= speciesEnthalpies[sp] * diffusionVelocity[sp + d * numSpecies];
     }
   }
 
@@ -370,8 +370,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
     // NOTE: diffusionVelocity is set to be (numSpecies,nvel)-matrix.
     // however only dim-components are used for flux.
     for (int d = 0; d < dim; d++)
-      flux[(nvel + 2 + sp) + d * num_equation] = -state[nvel + 2 + sp]
-                                                  * diffusionVelocity[sp + d * numSpecies];
+      flux[(nvel + 2 + sp) + d * num_equation] = -state[nvel + 2 + sp] * diffusionVelocity[sp + d * numSpecies];
   }
 }
 

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -592,9 +592,9 @@ void Fluxes::viscousFluxes_gpu(const Vector &x, ParGridFunction *gradUp, DenseTe
   // clang-format off
   MFEM_FORALL(n, dof,
   {
-    double Un[gpudata:MAXEQUATIONS]; // double Un[5];
-    double gradUpn[gpudata:MAXEQUATIONS * gpudata::MAXDIM]; // double gradUpn[5 * 3];
-    double vFlux[gpudata:MAXEQUATIONS * gpudata::MAXDIM]; // double vFlux[5 * 3];
+    double Un[gpudata::MAXEQUATIONS]; // double Un[5];
+    double gradUpn[gpudata::MAXEQUATIONS * gpudata::MAXDIM]; // double gradUpn[5 * 3];
+    double vFlux[gpudata::MAXEQUATIONS * gpudata::MAXDIM]; // double vFlux[5 * 3];
     double linVisc;
 
     // init. State

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -251,7 +251,7 @@ void Fluxes::ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp
 
 MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const double *gradUp, double radius, double *flux) {
   for (int d = 0; d < dim; d++) {
-    for (int eq = 0; eq < num_equations; eq++) {
+    for (int eq = 0; eq < num_equation; eq++) {
       flux[eq + d * num_equation] = 0.;
     }
   }

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -532,8 +532,8 @@ void Fluxes::convectiveFluxes_gpu(const Vector &x, DenseTensor &flux, const Equa
   double Sc = mixture->GetSchmidtNum();
 
   MFEM_FORALL(n, dof, {
-    double Un[20];
-    double KE[3];
+    double Un[gpudata::MAXEQUATIONS]; // double Un[20];
+    double KE[gpudata::MAXDIM]; // double KE[3];
     double p;
 
     for (int eq = 0; eq < num_equation; eq++) {
@@ -592,9 +592,9 @@ void Fluxes::viscousFluxes_gpu(const Vector &x, ParGridFunction *gradUp, DenseTe
   // clang-format off
   MFEM_FORALL(n, dof,
   {
-    double Un[5];
-    double gradUpn[5 * 3];
-    double vFlux[5 * 3];
+    double Un[gpudata:MAXEQUATIONS]; // double Un[5];
+    double gradUpn[gpudata:MAXEQUATIONS * gpudata::MAXDIM]; // double gradUpn[5 * 3];
+    double vFlux[gpudata:MAXEQUATIONS * gpudata::MAXDIM]; // double vFlux[5 * 3];
     double linVisc;
 
     // init. State

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -527,26 +527,26 @@ void Fluxes::convectiveFluxes_gpu(const Vector &x, DenseTensor &flux, const Equa
 #ifdef _GPU_
   auto dataIn = x.Read();
   auto d_flux = flux.Write();
-#endif // _GPU_
+// #endif // _GPU_
 
-#if defined(_CUDA_)
-  MFEM_FORALL(n, dof, {
-    double Un[gpudata::MAXEQUATIONS]; // double Un[20];
-    double fluxn[gpudata::MAXEQUATIONS * gpudata::MAXDIM];
-
-    for (int eq = 0; eq < num_equation; eq++) {
-      Un[eq] = dataIn[n + eq * dof];
-    }
-
-    ComputeConvectiveFluxes(Un, fluxn);
-
-    for (int eq = 0; eq < num_equation; eq++) {
-      for (int d = 0; d < dim; d++) {
-        d_flux[n + d * dof + eq * dof * dim] = fluxn[eq + d * num_equation];
-      }
-    }
-  });
-#elif defined(_HIP_)
+// #if defined(_CUDA_)
+//   MFEM_FORALL(n, dof, {
+//     double Un[gpudata::MAXEQUATIONS]; // double Un[20];
+//     double fluxn[gpudata::MAXEQUATIONS * gpudata::MAXDIM];
+//
+//     for (int eq = 0; eq < num_equation; eq++) {
+//       Un[eq] = dataIn[n + eq * dof];
+//     }
+//
+//     ComputeConvectiveFluxes(Un, fluxn);
+//
+//     for (int eq = 0; eq < num_equation; eq++) {
+//       for (int d = 0; d < dim; d++) {
+//         d_flux[n + d * dof + eq * dof * dim] = fluxn[eq + d * num_equation];
+//       }
+//     }
+//   });
+// #elif defined(_HIP_)
   double gamma = mixture->GetSpecificHeatRatio();
   double Sc = mixture->GetSchmidtNum();
 

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -414,12 +414,12 @@ void Fluxes::ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gra
   for (int sp = 0; sp < numSpecies; sp++) {
     // NOTE: diffusionVelocity is set to be (numSpecies,nvel)-matrix.
     // however only dim-components are used for flux.
-    for (int d = 0; d < dim; d++) normalPrimFlux(sp) += diffusionVelocity(sp, d) * bcFlux.normal(d);
+    for (int d = 0; d < dim; d++) normalPrimFlux(sp) += diffusionVelocity(sp, d) * bcFlux.normal[d];
   }
 
   // Replace with the prescribed boundary fluxes.
   for (int i = 0; i < numSpecies; i++) {
-    if (bcFlux.primFluxIdxs[i]) normalPrimFlux(i) = bcFlux.primFlux(i);
+    if (bcFlux.primFluxIdxs[i]) normalPrimFlux(i) = bcFlux.primFlux[i];
   }
 
   // Compute the stress.
@@ -440,7 +440,7 @@ void Fluxes::ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gra
   for (int i = 0; i < dim; i++) stress(i, i) += bulkViscosity * divV;
 
   for (int i = 0; i < dim; i++) {
-    for (int j = 0; j < dim; j++) normalPrimFlux(numSpecies + i) += stress(i, j) * bcFlux.normal(j);
+    for (int j = 0; j < dim; j++) normalPrimFlux(numSpecies + i) += stress(i, j) * bcFlux.normal[j];
   }
 
   double tau_tr = 0, tau_tz = 0;
@@ -453,22 +453,22 @@ void Fluxes::ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gra
 
     tau_tz = visc * ut_z;
 
-    normalPrimFlux(numSpecies + nvel - 1) += tau_tr * bcFlux.normal(0);
-    normalPrimFlux(numSpecies + nvel - 1) += tau_tz * bcFlux.normal(1);
+    normalPrimFlux(numSpecies + nvel - 1) += tau_tr * bcFlux.normal[0];
+    normalPrimFlux(numSpecies + nvel - 1) += tau_tz * bcFlux.normal[1];
   }
 
   // Compute the electron heat flux.
   if (twoTemperature) {
     // NOTE(kevin): followed the standard sign of heat flux.
     for (int d = 0; d < dim; d++)
-      normalPrimFlux(primFluxSize - 1) -= ke * gradUp(num_equation - 1, d) * bcFlux.normal(d);
+      normalPrimFlux(primFluxSize - 1) -= ke * gradUp(num_equation - 1, d) * bcFlux.normal[d];
     normalPrimFlux(primFluxSize - 1) += speciesEnthalpies(numSpecies - 2) * normalPrimFlux(numSpecies - 2);
   } else {
     k += ke;
   }
   // Compute the heavies heat flux.
   // NOTE(kevin): followed the standard sign of heat flux.
-  for (int d = 0; d < dim; d++) normalPrimFlux(numSpecies + nvel) -= k * gradUp(1 + nvel, d) * bcFlux.normal(d);
+  for (int d = 0; d < dim; d++) normalPrimFlux(numSpecies + nvel) -= k * gradUp(1 + nvel, d) * bcFlux.normal[d];
   for (int sp = 0; sp < numSpecies; sp++) {
     if (twoTemperature && (sp == numSpecies - 2)) continue;
     normalPrimFlux(numSpecies + nvel) += speciesEnthalpies(sp) * normalPrimFlux(sp);
@@ -476,7 +476,7 @@ void Fluxes::ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gra
 
   // Replace with the prescribed boundary fluxes.
   for (int i = numSpecies; i < primFluxSize; i++) {
-    if (bcFlux.primFluxIdxs[i]) normalPrimFlux(i) = bcFlux.primFlux(i);
+    if (bcFlux.primFluxIdxs[i]) normalPrimFlux(i) = bcFlux.primFlux[i];
   }
 
   Vector vel0(nvel);

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -522,7 +522,7 @@ void Fluxes::ComputeSplitFlux(const mfem::Vector &state, mfem::DenseMatrix &a_ma
   }
 }
 
-void Fluxes::convectiveFluxes_gpu(const Vector &x, DenseTensor &flux, const Equations &eqSystem, GasMixture *mixture,
+void Fluxes::convectiveFluxes_hip(const Vector &x, DenseTensor &flux, const Equations &eqSystem, GasMixture *mixture,
                                   const int &dof, const int &dim, const int &num_equation) {
 #ifdef _GPU_
   auto dataIn = x.Read();
@@ -565,7 +565,7 @@ void Fluxes::convectiveFluxes_gpu(const Vector &x, DenseTensor &flux, const Equa
 #endif // _GPU_
 }
 
-void Fluxes::viscousFluxes_gpu(const Vector &x, ParGridFunction *gradUp, DenseTensor &flux, const Equations &eqSystem,
+void Fluxes::viscousFluxes_hip(const Vector &x, ParGridFunction *gradUp, DenseTensor &flux, const Equations &eqSystem,
                                GasMixture *mixture, const ParGridFunction *spaceVaryViscMult,
                                const linearlyVaryingVisc &linViscData, const int &dof, const int &dim,
                                const int &num_equation) {

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -259,24 +259,24 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
     return;
   }
 
-  double vel[dim];
-  double vtmp[dim];
-  double stress[dim * dim];
+  double vel[gpudata::MAXDIM];
+  double vtmp[gpudata::MAXDIM];
+  double stress[gpudata::MAXDIM * gpudata::MAXDIM];
 
   // TODO(kevin): update E-field with EM coupling.
-  double Efield[nvel];
+  double Efield[gpudata::MAXDIM];
   for (int v = 0; v < nvel; v++) Efield[v] = 0.0;
 
   const int numSpecies = mixture->GetNumSpecies();
   const int numActiveSpecies = mixture->GetNumActiveSpecies();
   const bool twoTemperature = mixture->IsTwoTemperature();
 
-  double speciesEnthalpies[numSpecies];
+  double speciesEnthalpies[gpudata::MAXSPECIES];
   mixture->computeSpeciesEnthalpies(state, speciesEnthalpies);
 
   double transportBuffer[FluxTrns::NUM_FLUX_TRANS];
   // NOTE(kevin): in flux, only dim-components of diffusionVelocity will be used.
-  double diffusionVelocity[numSpecies * nvel];
+  double diffusionVelocity[gpudata::MAXSPECIES * gpudata::MAXDIM];
   transport->ComputeFluxTransportProperties(state, gradUp, Efield, transportBuffer, diffusionVelocity);
   const double visc = transportBuffer[FluxTrns::VISCOSITY];
   double bulkViscosity = transportBuffer[FluxTrns::BULK_VISCOSITY];
@@ -290,7 +290,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
       flux[1 + nvel + d * num_equation] += qeFlux;
       flux[num_equation - 1 + d * num_equation] += qeFlux;
       flux[num_equation - 1 + d * num_equation] -= speciesEnthalpies[numSpecies - 2]
-                                                    * diffusionVelocity[numSpecies - 2 + d * num_equation];
+                                                    * diffusionVelocity[numSpecies - 2 + d * gpudata::MAXSPECIES];
     }
   } else {
     k += ke;
@@ -305,20 +305,20 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
   double divV = 0.;
   for (int i = 0; i < dim; i++) {
     for (int j = 0; j < dim; j++) {
-      stress[i + j * dim] = gradUp[(1 + j) + i * num_equation] + gradUp[(1 + i) + j * num_equation];
+      stress[i + j * gpudata::MAXDIM] = gradUp[(1 + j) + i * num_equation] + gradUp[(1 + i) + j * num_equation];
     }
     divV += gradUp[(1 + i) + i * num_equation];
   }
-  for (int i = 0; i < dim; i++) for (int j = 0; j < dim; j++) stress[i + j * dim] *= visc;
+  for (int i = 0; i < dim; i++) for (int j = 0; j < dim; j++) stress[i + j * gpudata::MAXDIM] *= visc;
 
   if (axisymmetric_ && radius > 0) {
     divV += ur / radius;
   }
 
-  for (int i = 0; i < dim; i++) stress[i + i * dim] += bulkViscosity * divV;
+  for (int i = 0; i < dim; i++) stress[i + i * gpudata::MAXDIM] += bulkViscosity * divV;
 
   for (int i = 0; i < dim; i++)
-    for (int j = 0; j < dim; j++) flux[(1 + i) + j * num_equation] = stress[i + j * dim];
+    for (int j = 0; j < dim; j++) flux[(1 + i) + j * num_equation] = stress[i + j * gpudata::MAXDIM];
 
   double tau_tr = 0, tau_tz = 0;
   if (axisymmetric_) {
@@ -343,7 +343,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
   for (int i = 0; i < dim; i++) {
     vtmp[i] = 0.0;
     for (int j = 0; j < dim; j++)
-      vtmp[i] += stress[i + j * dim] * vel[j];
+      vtmp[i] += stress[i + j * gpudata::MAXDIM] * vel[j];
   }
 
   for (int d = 0; d < dim; d++) {
@@ -352,7 +352,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
     // compute diffusive enthalpy flux.
     for (int sp = 0; sp < numSpecies; sp++) {
       flux[(1 + nvel) + d * num_equation] -= speciesEnthalpies[sp]
-                                              * diffusionVelocity[sp + d * num_equation];
+                                              * diffusionVelocity[sp + d * gpudata::MAXSPECIES];
     }
   }
 
@@ -371,7 +371,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
     // however only dim-components are used for flux.
     for (int d = 0; d < dim; d++)
       flux[(nvel + 2 + sp) + d * num_equation] = -state[nvel + 2 + sp]
-                                                  * diffusionVelocity[sp + d * num_equation];
+                                                  * diffusionVelocity[sp + d * gpudata::MAXSPECIES];
   }
 }
 

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -527,7 +527,26 @@ void Fluxes::convectiveFluxes_gpu(const Vector &x, DenseTensor &flux, const Equa
 #ifdef _GPU_
   auto dataIn = x.Read();
   auto d_flux = flux.Write();
+#endif // _GPU_
 
+#if defined(_CUDA_)
+  MFEM_FORALL(n, dof, {
+    double Un[gpudata::MAXEQUATIONS]; // double Un[20];
+    double fluxn[gpudata::MAXEQUATIONS * gpudata::MAXDIM];
+
+    for (int eq = 0; eq < num_equation; eq++) {
+      Un[eq] = dataIn[n + eq * dof];
+    }
+
+    ComputeConvectiveFluxes(Un, fluxn);
+
+    for (int eq = 0; eq < num_equation; eq++) {
+      for (int d = 0; d < dim; d++) {
+        d_flux[n + d * dof + eq * dof * dim] = fluxn[eq + d * num_equation];
+      }
+    }
+  });
+#elif defined(_HIP_)
   double gamma = mixture->GetSpecificHeatRatio();
   double Sc = mixture->GetSchmidtNum();
 
@@ -562,8 +581,7 @@ void Fluxes::convectiveFluxes_gpu(const Vector &x, DenseTensor &flux, const Equa
       }
     }
   });
-
-#endif
+#endif // defined(_HIP_)
 }
 
 void Fluxes::viscousFluxes_gpu(const Vector &x, ParGridFunction *gradUp, DenseTensor &flux, const Equations &eqSystem,

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -527,26 +527,7 @@ void Fluxes::convectiveFluxes_gpu(const Vector &x, DenseTensor &flux, const Equa
 #ifdef _GPU_
   auto dataIn = x.Read();
   auto d_flux = flux.Write();
-// #endif // _GPU_
 
-// #if defined(_CUDA_)
-//   MFEM_FORALL(n, dof, {
-//     double Un[gpudata::MAXEQUATIONS]; // double Un[20];
-//     double fluxn[gpudata::MAXEQUATIONS * gpudata::MAXDIM];
-//
-//     for (int eq = 0; eq < num_equation; eq++) {
-//       Un[eq] = dataIn[n + eq * dof];
-//     }
-//
-//     ComputeConvectiveFluxes(Un, fluxn);
-//
-//     for (int eq = 0; eq < num_equation; eq++) {
-//       for (int d = 0; d < dim; d++) {
-//         d_flux[n + d * dof + eq * dof * dim] = fluxn[eq + d * num_equation];
-//       }
-//     }
-//   });
-// #elif defined(_HIP_)
   double gamma = mixture->GetSpecificHeatRatio();
   double Sc = mixture->GetSchmidtNum();
 
@@ -581,7 +562,7 @@ void Fluxes::convectiveFluxes_gpu(const Vector &x, DenseTensor &flux, const Equa
       }
     }
   });
-#endif // defined(_HIP_)
+#endif // _GPU_
 }
 
 void Fluxes::viscousFluxes_gpu(const Vector &x, ParGridFunction *gradUp, DenseTensor &flux, const Equations &eqSystem,

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -594,7 +594,8 @@ MFEM_HOST_DEVICE void Fluxes::ComputeBdrViscousFluxes(const double *state, const
   }
   // Compute the heavies heat flux.
   // NOTE(kevin): followed the standard sign of heat flux.
-  for (int d = 0; d < dim; d++) normalPrimFlux[numSpecies + nvel] -= k * gradUp[(1 + nvel) + d * num_equation] * bcFlux.normal[d];
+  for (int d = 0; d < dim; d++)
+    normalPrimFlux[numSpecies + nvel] -= k * gradUp[(1 + nvel) + d * num_equation] * bcFlux.normal[d];
   for (int sp = 0; sp < numSpecies; sp++) {
     if (twoTemperature && (sp == numSpecies - 2)) continue;
     normalPrimFlux[numSpecies + nvel] += speciesEnthalpies[sp] * normalPrimFlux[sp];
@@ -658,8 +659,8 @@ void Fluxes::convectiveFluxes_hip(const Vector &x, DenseTensor &flux, const Equa
   double Sc = mixture->GetSchmidtNum();
 
   MFEM_FORALL(n, dof, {
-    double Un[gpudata::MAXEQUATIONS]; // double Un[20];
-    double KE[gpudata::MAXDIM]; // double KE[3];
+    double Un[gpudata::MAXEQUATIONS];  // double Un[20];
+    double KE[gpudata::MAXDIM];        // double KE[3];
     double p;
 
     for (int eq = 0; eq < num_equation; eq++) {
@@ -688,7 +689,7 @@ void Fluxes::convectiveFluxes_hip(const Vector &x, DenseTensor &flux, const Equa
       }
     }
   });
-#endif // _GPU_
+#endif  // _GPU_
 }
 
 void Fluxes::viscousFluxes_hip(const Vector &x, ParGridFunction *gradUp, DenseTensor &flux, const Equations &eqSystem,

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -718,9 +718,9 @@ void Fluxes::viscousFluxes_hip(const Vector &x, ParGridFunction *gradUp, DenseTe
   // clang-format off
   MFEM_FORALL(n, dof,
   {
-    double Un[gpudata::MAXEQUATIONS]; // double Un[5];
-    double gradUpn[gpudata::MAXEQUATIONS * gpudata::MAXDIM]; // double gradUpn[5 * 3];
-    double vFlux[gpudata::MAXEQUATIONS * gpudata::MAXDIM]; // double vFlux[5 * 3];
+    double Un[gpudata::MAXEQUATIONS];  // double Un[5];
+    double gradUpn[gpudata::MAXEQUATIONS * gpudata::MAXDIM];  // double gradUpn[5 * 3];
+    double vFlux[gpudata::MAXEQUATIONS * gpudata::MAXDIM];  // double vFlux[5 * 3];
     double linVisc;
 
     // init. State

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -497,6 +497,132 @@ void Fluxes::ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gra
   }
 }
 
+MFEM_HOST_DEVICE void Fluxes::ComputeBdrViscousFluxes(const double *state, const double *gradUp, double radius,
+                                                      const BoundaryViscousFluxData &bcFlux, double *normalFlux) {
+  // normalFlux.SetSize(num_equation);
+  for (int eq = 0; eq < num_equation; eq++) normalFlux[eq] = 0.;
+  if (eqSystem == EULER) {
+    return;
+  }
+
+  double stress[gpudata::MAXDIM * gpudata::MAXDIM];
+
+  // TODO(kevin): update E-field with EM coupling.
+  double Efield[gpudata::MAXDIM];
+  for (int v = 0; v < nvel; v++) Efield[v] = 0.0;
+
+  const int numSpecies = mixture->GetNumSpecies();
+  const int numActiveSpecies = mixture->GetNumActiveSpecies();
+  const bool twoTemperature = mixture->IsTwoTemperature();
+
+  double speciesEnthalpies[gpudata::MAXSPECIES];
+  mixture->computeSpeciesEnthalpies(state, speciesEnthalpies);
+
+  double transportBuffer[FluxTrns::NUM_FLUX_TRANS];
+  // NOTE(kevin): in flux, only dim-components of diffusionVelocity will be used.
+  double diffusionVelocity[gpudata::MAXSPECIES * gpudata::MAXDIM];
+  transport->ComputeFluxTransportProperties(state, gradUp, Efield, transportBuffer, diffusionVelocity);
+  const double visc = transportBuffer[FluxTrns::VISCOSITY];
+  double bulkViscosity = transportBuffer[FluxTrns::BULK_VISCOSITY];
+  bulkViscosity -= 2. / 3. * visc;
+  double k = transportBuffer[FluxTrns::HEAVY_THERMAL_CONDUCTIVITY];
+  double ke = transportBuffer[FluxTrns::ELECTRON_THERMAL_CONDUCTIVITY];
+
+  // Primitive viscous fluxes.
+  const int primFluxSize = (twoTemperature) ? numSpecies + nvel + 2 : numSpecies + nvel + 1;
+  double normalPrimFlux[gpudata::MAXEQUATIONS];
+  for (int eq = 0; eq < primFluxSize; eq++) normalPrimFlux[eq] = 0.0;
+
+  // Compute the diffusion velocities.
+  for (int sp = 0; sp < numSpecies; sp++) {
+    // NOTE: diffusionVelocity is set to be (numSpecies,nvel)-matrix.
+    // however only dim-components are used for flux.
+    for (int d = 0; d < dim; d++) normalPrimFlux[sp] += diffusionVelocity[sp + d * numSpecies] * bcFlux.normal[d];
+  }
+
+  // Replace with the prescribed boundary fluxes.
+  for (int i = 0; i < numSpecies; i++) {
+    if (bcFlux.primFluxIdxs[i]) normalPrimFlux[i] = bcFlux.primFlux[i];
+  }
+
+  // Compute the stress.
+  const double ur = (axisymmetric_ ? state[1] / state[0] : 0);
+  const double ut = (axisymmetric_ ? state[3] / state[0] : 0);
+
+  double divV = 0.;
+  for (int i = 0; i < dim; i++) {
+    for (int j = 0; j < dim; j++) {
+      stress[i + j * dim] = gradUp[(1 + j) + i * num_equation] + gradUp[(1 + i) + j * num_equation];
+    }
+    divV += gradUp[(1 + i) + i * num_equation];
+  }
+  for (int i = 0; i < dim; i++)
+    for (int j = 0; j < dim; j++) stress[i + j * dim] *= visc;
+
+  if (axisymmetric_ && radius > 0) {
+    divV += ur / radius;
+  }
+
+  for (int i = 0; i < dim; i++) stress[i + i * dim] += bulkViscosity * divV;
+
+  for (int i = 0; i < dim; i++) {
+    for (int j = 0; j < dim; j++) normalPrimFlux[numSpecies + i] += stress[i + j * dim] * bcFlux.normal[j];
+  }
+
+  double tau_tr = 0, tau_tz = 0;
+  if (axisymmetric_) {
+    const double ut_r = gradUp[3 + 0 * num_equation];
+    const double ut_z = gradUp[3 + 1 * num_equation];
+    tau_tr = ut_r;
+    if (radius > 0) tau_tr -= ut / radius;
+    tau_tr *= visc;
+
+    tau_tz = visc * ut_z;
+
+    normalPrimFlux[numSpecies + nvel - 1] += tau_tr * bcFlux.normal[0];
+    normalPrimFlux[numSpecies + nvel - 1] += tau_tz * bcFlux.normal[1];
+  }
+
+  // Compute the electron heat flux.
+  if (twoTemperature) {
+    // NOTE(kevin): followed the standard sign of heat flux.
+    for (int d = 0; d < dim; d++)
+      normalPrimFlux[primFluxSize - 1] -= ke * gradUp[(num_equation - 1) + d * num_equation] * bcFlux.normal[d];
+    normalPrimFlux[primFluxSize - 1] += speciesEnthalpies[numSpecies - 2] * normalPrimFlux[numSpecies - 2];
+  } else {
+    k += ke;
+  }
+  // Compute the heavies heat flux.
+  // NOTE(kevin): followed the standard sign of heat flux.
+  for (int d = 0; d < dim; d++) normalPrimFlux[numSpecies + nvel] -= k * gradUp[(1 + nvel) + d * num_equation] * bcFlux.normal[d];
+  for (int sp = 0; sp < numSpecies; sp++) {
+    if (twoTemperature && (sp == numSpecies - 2)) continue;
+    normalPrimFlux[numSpecies + nvel] += speciesEnthalpies[sp] * normalPrimFlux[sp];
+  }
+
+  // Replace with the prescribed boundary fluxes.
+  for (int i = numSpecies; i < primFluxSize; i++) {
+    if (bcFlux.primFluxIdxs[i]) normalPrimFlux[i] = bcFlux.primFlux[i];
+  }
+
+  double vel0[gpudata::MAXDIM];
+  for (int d = 0; d < nvel; d++) vel0[d] = state[1 + d] / state[0];
+
+  // convert back to the conservative viscous flux.
+  // NOTE(kevin): negative sign comes in from the definition of numerical viscous flux.
+  // normalFlux(0) = 0.0;
+  for (int sp = 0; sp < numActiveSpecies; sp++) {
+    normalFlux[nvel + 2 + sp] = -state[nvel + 2 + sp] * normalPrimFlux[sp];
+  }
+  for (int d = 0; d < nvel; d++) normalFlux[d + 1] = normalPrimFlux[numSpecies + d];
+  for (int d = 0; d < nvel; d++) normalFlux[nvel + 1] += normalPrimFlux[numSpecies + d] * vel0[d];
+  normalFlux[nvel + 1] -= normalPrimFlux[numSpecies + nvel];
+  if (twoTemperature) {
+    normalFlux[nvel + 1] -= normalPrimFlux[primFluxSize - 1];
+    normalFlux[num_equation - 1] = -normalPrimFlux[primFluxSize - 1];
+  }
+}
+
 void Fluxes::ComputeSplitFlux(const mfem::Vector &state, mfem::DenseMatrix &a_mat, mfem::DenseMatrix &c_mat) {
   const int num_equation = state.Size();
   const int dim = num_equation - 2;

--- a/src/fluxes.hpp
+++ b/src/fluxes.hpp
@@ -83,6 +83,8 @@ class Fluxes {
   // Compute viscous flux with prescribed boundary flux.
   void ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gradUp, double radius,
                                const BoundaryViscousFluxData &bcFlux, Vector &normalFlux);
+  MFEM_HOST_DEVICE void ComputeBdrViscousFluxes(const double *state, const double *gradUp, double radius,
+                                                const BoundaryViscousFluxData &bcFlux, double *normalFlux);
 
   // Compute the split fersion of the flux for SBP operations
   // Output matrices a_mat, c_mat need not have the right size

--- a/src/fluxes.hpp
+++ b/src/fluxes.hpp
@@ -89,9 +89,9 @@ class Fluxes {
   void ComputeSplitFlux(const Vector &state, DenseMatrix &a_mat, DenseMatrix &c_mat);
 
   // GPU functions
-  static void convectiveFluxes_gpu(const Vector &x, DenseTensor &flux, const Equations &eqSystem, GasMixture *mixture,
+  static void convectiveFluxes_hip(const Vector &x, DenseTensor &flux, const Equations &eqSystem, GasMixture *mixture,
                                    const int &dof, const int &dim, const int &num_equation);
-  static void viscousFluxes_gpu(const Vector &x, ParGridFunction *gradUp, DenseTensor &flux, const Equations &eqSystem,
+  static void viscousFluxes_hip(const Vector &x, ParGridFunction *gradUp, DenseTensor &flux, const Equations &eqSystem,
                                 GasMixture *mixture, const ParGridFunction *spaceVaryViscMult,
                                 const linearlyVaryingVisc &linViscData, const int &dof, const int &dim,
                                 const int &num_equation);

--- a/src/fluxes.hpp
+++ b/src/fluxes.hpp
@@ -78,6 +78,7 @@ class Fluxes {
   MFEM_HOST_DEVICE void ComputeConvectiveFluxes(const double *state, double *flux) const;
 
   void ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp, double radius, DenseMatrix &flux);
+  MFEM_HOST_DEVICE void ComputeViscousFluxes(const double *state, const double *gradUp, double radius, double *flux);
 
   // Compute viscous flux with prescribed boundary flux.
   void ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gradUp, double radius,

--- a/src/forcing_terms.cpp
+++ b/src/forcing_terms.cpp
@@ -388,6 +388,7 @@ void AxisymmetricSource::updateTerms(Vector &in) {
   }
 }
 
+// TODO(kevin): implment gpu
 SpongeZone::SpongeZone(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                        Fluxes *_fluxClass, GasMixture *_mixture, IntegrationRules *_intRules,
                        ParFiniteElementSpace *_vfes, ParGridFunction *U, ParGridFunction *_Up, ParGridFunction *_gradUp,

--- a/src/forcing_terms.cpp
+++ b/src/forcing_terms.cpp
@@ -182,8 +182,9 @@ void ConstantPressureGradient::updateTerms_gpu(const int numElems, const int off
   // clang-format off
   MFEM_FORALL_2D(el, numElems, elDof, 1, 1, {
     MFEM_FOREACH_THREAD(i, x, elDof) {
-      MFEM_SHARED double Ui[216 * 5], gradUpi[216 * 5 * 3];
-      MFEM_SHARED double pGrad[3];
+      MFEM_SHARED double Ui[gpudata::MAXDOFS * gpudata::MAXEQUATIONS], // MFEM_SHARED double Ui[216 * 5],
+                         gradUpi[gpudata::MAXDOFS * gpudata::MAXEQUATIONS * gpudata::MAXDIM]; // gradUpi[216 * 5 * 3];
+      MFEM_SHARED double pGrad[gpudata::MAXDIM]; // MFEM_SHARED double pGrad[3];
 
       const int eli = el + offsetElems;
       const int offsetIDs    = d_posDofIds[2 * eli];
@@ -683,17 +684,11 @@ PassiveScalar::PassiveScalar(const int &_dim, const int &_num_equation, const in
     psData_[i]->nodes.DeleteAll();
   }
 
-  std::cout << "worked out so far. 2" << std::endl;
-
   // find nodes for each passive scalar location
   ParFiniteElementSpace dfes(vfes->GetParMesh(), vfes->FEColl(), dim,
                              Ordering::byNODES);  // Kevin: Had a seg fault from this line.
-  std::cout << "worked out so far. 2-1" << std::endl;
   ParGridFunction coordinates(&dfes);
-  std::cout << "worked out so far. 2-2" << std::endl;
   vfes->GetParMesh()->GetNodes(coordinates);
-
-  std::cout << "worked out so far. 3" << std::endl;
 
   int nnodes = vfes->GetNDofs();
 

--- a/src/forcing_terms.cpp
+++ b/src/forcing_terms.cpp
@@ -84,6 +84,7 @@ ForcingTerms::~ForcingTerms() {
 // #endif
 // }
 
+// TODO(kevin): gpu capability.
 ConstantPressureGradient::ConstantPressureGradient(const int &_dim, const int &_num_equation, const int &_order,
                                                    const int &_intRuleType, IntegrationRules *_intRules,
                                                    ParFiniteElementSpace *_vfes, ParGridFunction *U,
@@ -182,9 +183,11 @@ void ConstantPressureGradient::updateTerms_gpu(const int numElems, const int off
   // clang-format off
   MFEM_FORALL_2D(el, numElems, elDof, 1, 1, {
     MFEM_FOREACH_THREAD(i, x, elDof) {
-      MFEM_SHARED double Ui[gpudata::MAXDOFS * gpudata::MAXEQUATIONS], // MFEM_SHARED double Ui[216 * 5],
-                         gradUpi[gpudata::MAXDOFS * gpudata::MAXEQUATIONS * gpudata::MAXDIM]; // gradUpi[216 * 5 * 3];
-      MFEM_SHARED double pGrad[gpudata::MAXDIM]; // MFEM_SHARED double pGrad[3];
+      MFEM_SHARED double Ui[216 * 5], gradUpi[216 * 5 * 3];
+      MFEM_SHARED double pGrad[3];
+//      MFEM_SHARED double Ui[gpudata::MAXDOFS * gpudata::MAXEQUATIONS], // MFEM_SHARED double Ui[216 * 5],
+//                         gradUpi[gpudata::MAXDOFS * gpudata::MAXEQUATIONS * gpudata::MAXDIM]; // gradUpi[216 * 5 * 3];
+//      MFEM_SHARED double pGrad[gpudata::MAXDIM]; // MFEM_SHARED double pGrad[3];
 
       const int eli = el + offsetElems;
       const int offsetIDs    = d_posDofIds[2 * eli];

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -298,9 +298,9 @@ void Gradients::interpFaceData_gpu(const Vector &Up, int elType, int elemOffset,
   {
     // assuming max. num of equations = 20
     // and max elem dof is 216 (a p=5 hex)
-    double uk1[gpudata::MAXEQUATIONS]; // double uk1[20];
-    double shape[gpudata::MAXDOFS]; // double shape[216];
-    int indexes_i[gpudata::MAXDOFS]; // int indexes_i[216];
+    double uk1[gpudata::MAXEQUATIONS];  // double uk1[20];
+    double shape[gpudata::MAXDOFS];  // double shape[216];
+    int indexes_i[gpudata::MAXDOFS];  // int indexes_i[216];
 
     const int eli = elemOffset + el;
     const int offsetEl1 = d_posDofIds[2 * eli];

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -388,9 +388,9 @@ void Gradients::computeGradients_gpu(const int elType, const int offsetElems, co
 
     const int keoffset = d_Ke_pos[eli];
 
-    int index_i[gpudata::MAXDOFS]; // int index_i[216];
-    MFEM_SHARED double Ui[gpudata::MAXDOFS], // MFEM_SHARED double Ui[216],
-                       gradUpi[gpudata::MAXDOFS * gpudata::MAXDIM]; //  gradUpi[216 * 3];
+    int index_i[gpudata::MAXDOFS];                    // int index_i[216];
+    MFEM_SHARED double Ui[gpudata::MAXDOFS],          // MFEM_SHARED double Ui[216],
+        gradUpi[gpudata::MAXDOFS * gpudata::MAXDIM];  //  gradUpi[216 * 3];
 
     for (int i = 0; i < elDof; i++) {
       index_i[i] = d_nodesIDs[offsetIDs + i];
@@ -445,9 +445,8 @@ void Gradients::evalFaceIntegrand_gpu() {
   const int maxDofs = maxDofs_;
 
   MFEM_FORALL(iface, Nf, {
-    double u1[gpudata::MAXEQUATIONS],
-           u2[gpudata::MAXEQUATIONS],
-           nor[gpudata::MAXDIM]; // double u1[20], u2[20], nor[3];
+    double u1[gpudata::MAXEQUATIONS], u2[gpudata::MAXEQUATIONS],
+        nor[gpudata::MAXDIM];  // double u1[20], u2[20], nor[3];
 
     const int Q = d_elems12Q[3 * iface + 2];
     const int offsetShape1 = iface * maxIntPoints * (maxDofs + 1 + dim);
@@ -455,7 +454,7 @@ void Gradients::evalFaceIntegrand_gpu() {
     for (int k = 0; k < Q; k++) {
       const double weight = d_shapeWnor1[offsetShape1 + maxDofs + k * (maxDofs + 1 + dim)];
 
-      double du[gpudata::MAXEQUATIONS]; // double du[20];
+      double du[gpudata::MAXEQUATIONS];  // double du[20];
       for (int eq = 0; eq < num_equation; eq++) {
         u1[eq] = d_uk_el1[eq + k * num_equation + iface * maxIntPoints * num_equation];
         u2[eq] = d_uk_el2[eq + k * num_equation + iface * maxIntPoints * num_equation];
@@ -564,11 +563,10 @@ void Gradients::interpGradSharedFace_gpu() {
   const int Ndofs = vfes->GetNDofs();
 
   MFEM_FORALL_2D(el, maxNumElems, maxIntPoints, 1, 1, {
-    double l1[gpudata::MAXDOFS],
-           l2[gpudata::MAXDOFS],
-           nor[gpudata::MAXDIM]; // double l1[216], l2[216], nor[3];
+    double l1[gpudata::MAXDOFS], l2[gpudata::MAXDOFS],
+        nor[gpudata::MAXDIM];  // double l1[216], l2[216], nor[3];
     double u1, u2;
-    int index_i[gpudata::MAXDOFS]; // int index_i[216];
+    int index_i[gpudata::MAXDOFS];  // int index_i[216];
 
     const int el1 = d_sharedElemsFaces[0 + el * 7];
     const int numFaces = d_sharedElemsFaces[1 + el * 7];
@@ -695,7 +693,7 @@ void Gradients::multInverse_gpu(const int numElems, const int offsetElems, const
   const int num_equation = num_equation_;
 
   MFEM_FORALL_2D(el, numElems, elDof, 1, 1, {
-    MFEM_SHARED double gradUpi[gpudata::MAXDOFS * gpudata::MAXDIM]; // MFEM_SHARED double gradUpi[216 * 3];
+    MFEM_SHARED double gradUpi[gpudata::MAXDOFS * gpudata::MAXDIM];  // MFEM_SHARED double gradUpi[216 * 3];
 
     const int eli = el + offsetElems;
     const int offsetIDs = d_posDofIds[2 * eli];

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -35,9 +35,9 @@
 #include "riemann_solver.hpp"
 
 // TODO(kevin): non-reflecting bc for plasam.
-InletBC::InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rsolver, GasMixture *_mixture, GasMixture *d_mixture,
-                 ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, double &_dt, const int _dim,
-                 const int _num_equation, int _patchNumber, double _refLength, InletType _bcType,
+InletBC::InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rsolver, GasMixture *_mixture,
+                 GasMixture *d_mixture, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, double &_dt,
+                 const int _dim, const int _num_equation, int _patchNumber, double _refLength, InletType _bcType,
                  const Array<double> &_inputData, const int &_maxIntPoints, const int &_maxDofs, bool axisym)
     : BoundaryCondition(_rsolver, _mixture, _eqSystem, _vfes, _intRules, _dt, _dim, _num_equation, _patchNumber,
                         _refLength, axisym),
@@ -343,8 +343,8 @@ void InletBC::updateMean_gpu(ParGridFunction *Up, Vector &localMeanUp, const int
   MFEM_FORALL(el, numBdrElems, {
     const int elDof = d_bdrElemQ[2 * el];
     const int Q = d_bdrElemQ[2 * el + 1];
-    double elUp[gpudata::MAXEQUATIONS * gpudata::MAXDOFS]; // double elUp[20 * 216];
-    double shape[gpudata::MAXDOFS]; // double shape[216];
+    double elUp[gpudata::MAXEQUATIONS * gpudata::MAXDOFS];  // double elUp[20 * 216];
+    double shape[gpudata::MAXDOFS];                         // double shape[216];
     double sum;
 
     // retreive data
@@ -758,8 +758,8 @@ void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const Array<int> &
   const int maxDofs = maxDofs_;
 
   MFEM_FORALL_2D(n, numBdrElem, maxDofs, 1, 1, {
-    MFEM_SHARED double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS]; // MFEM_SHARED double Fcontrib[216 * 5];
-    double Rflux[gpudata::MAXEQUATIONS]; // double Rflux[5];
+    MFEM_SHARED double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS];  // MFEM_SHARED double Fcontrib[216 * 5];
+    double Rflux[gpudata::MAXEQUATIONS];                                    // double Rflux[5];
 
     const int el = d_listElems[n];
     const int Q = d_intPointsElIDBC[2 * el];
@@ -841,11 +841,9 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x, const Array<int> &nodesIDs,
 
   // MFEM_FORALL(n, numBdrElem, {
   MFEM_FORALL_2D(n, numBdrElem, maxIntPoints, 1, 1, {
-    double shape[gpudata::MAXDOFS]; // double shape[216];
-    double u1[gpudata::MAXEQUATIONS],
-           u2[gpudata::MAXEQUATIONS],
-           Rflux[gpudata::MAXEQUATIONS],
-           nor[gpudata::MAXDIM]; // double u1[5], u2[5], Rflux[5], nor[3];
+    double shape[gpudata::MAXDOFS];  // double shape[216];
+    double u1[gpudata::MAXEQUATIONS], u2[gpudata::MAXEQUATIONS], Rflux[gpudata::MAXEQUATIONS],
+        nor[gpudata::MAXDIM];  // double u1[5], u2[5], Rflux[5], nor[3];
 
     double p;
 
@@ -890,7 +888,7 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x, const Array<int> &nodesIDs,
           break;
       }
 
-      // compute flux
+        // compute flux
 #if defined(_CUDA_)
       d_rsolver->Eval_LF(u1, u2, nor, Rflux);
 #elif defined(_HIP_)

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -876,14 +876,7 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x, const Array<int> &nodesIDs,
         case InletType::SUB_DENS_VEL:
 #if defined(_CUDA_)
           p = d_mix->ComputePressure(u1);
-          u2[0] = d_inputState[0];
-          for (int v = 0; v < nvel; v++) u2[1 + v] = d_inputState[0] * d_inputState[1 + v];
-          if (numActiveSpecies > 0) {
-            for (int sp = 0; sp < numActiveSpecies; sp++)
-              // NOTE: inlet BC does not specify total energy. therefore skips one index.
-              // NOTE: regardless of dim_ension, inletBC save the first 4 elements for density and velocity.
-              u2[nvel + 2 + sp] = d_inputState[4 + sp];
-          }
+          pluginInputState(d_inputState, u2, nvel, numActiveSpecies);
           d_mix->modifyEnergyForPressure(u2, u2, p, true);
 #elif defined(_HIP_)
           computeSubDenseVel_gpu_serial(&u1[0], &u2[0], &nor[0], d_inputState, gamma, Rg, dim, num_equation, fluid);

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -338,10 +338,8 @@ void InletBC::updateMean_gpu(ParGridFunction *Up, Vector &localMeanUp, const int
   MFEM_FORALL(el, numBdrElems, {
     const int elDof = d_bdrElemQ[2 * el];
     const int Q = d_bdrElemQ[2 * el + 1];
-    //     double elUp[5*maxDofs];
-    //     double shape[maxDofs];
-    double elUp[20 * 216];
-    double shape[216];
+    double elUp[gpudata::MAXEQUATIONS * gpudata::MAXDOFS]; // double elUp[20 * 216];
+    double shape[gpudata::MAXDOFS]; // double shape[216];
     double sum;
 
     // retreive data
@@ -755,8 +753,8 @@ void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const Array<int> &
   const int maxDofs = maxDofs_;
 
   MFEM_FORALL_2D(n, numBdrElem, maxDofs, 1, 1, {
-    MFEM_SHARED double Fcontrib[216 * 5];
-    double Rflux[5];
+    MFEM_SHARED double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS]; // MFEM_SHARED double Fcontrib[216 * 5];
+    double Rflux[gpudata::MAXEQUATIONS]; // double Rflux[5];
 
     const int el = d_listElems[n];
     const int Q = d_intPointsElIDBC[2 * el];
@@ -828,8 +826,11 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x, const Array<int> &nodesIDs,
 
   // MFEM_FORALL(n, numBdrElem, {
   MFEM_FORALL_2D(n, numBdrElem, maxIntPoints, 1, 1, {
-    double shape[216];
-    double u1[5], u2[5], Rflux[5], nor[3];
+    double shape[gpudata::MAXDOFS]; // double shape[216];
+    double u1[gpudata::MAXEQUATIONS],
+           u2[gpudata::MAXEQUATIONS],
+           Rflux[gpudata::MAXEQUATIONS],
+           nor[gpudata::MAXDIM]; // double u1[5], u2[5], Rflux[5], nor[3];
 
     const int el = d_listElems[n];
     const int Q = d_intPointsElIDBC[2 * el];

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -47,6 +47,8 @@ class InletBC : public BoundaryCondition {
  private:
   MPI_Groups *groupsMPI;
 
+  GasMixture *d_mixture_; // used only in the device
+
   const InletType inletType_;
 
   // In/out conditions specified in the configuration file
@@ -88,7 +90,7 @@ class InletBC : public BoundaryCondition {
   virtual void updateMean(IntegrationRules *intRules, ParGridFunction *Up);
 
  public:
-  InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *rsolver_, GasMixture *_mixture,
+  InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *rsolver_, GasMixture *_mixture, GasMixture *d_mixture,
           ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, double &_dt, const int _dim,
           const int _num_equation, int _patchNumber, double _refLength, InletType _bcType,
           const Array<double> &_inputData, const int &_maxIntPoints, const int &maxDofs, bool axisym);

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -47,7 +47,7 @@ class InletBC : public BoundaryCondition {
  private:
   MPI_Groups *groupsMPI;
 
-  GasMixture *d_mixture_; // used only in the device
+  GasMixture *d_mixture_;  // used only in the device
 
   const InletType inletType_;
 
@@ -90,8 +90,8 @@ class InletBC : public BoundaryCondition {
   virtual void updateMean(IntegrationRules *intRules, ParGridFunction *Up);
 
  public:
-  InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *rsolver_, GasMixture *_mixture, GasMixture *d_mixture,
-          ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, double &_dt, const int _dim,
+  InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *rsolver_, GasMixture *_mixture,
+          GasMixture *d_mixture, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, double &_dt, const int _dim,
           const int _num_equation, int _patchNumber, double _refLength, InletType _bcType,
           const Array<double> &_inputData, const int &_maxIntPoints, const int &maxDofs, bool axisym);
   ~InletBC();
@@ -120,7 +120,8 @@ class InletBC : public BoundaryCondition {
                        Array<int> &offsetsBoundaryU);
 
 #ifdef _GPU_
-  MFEM_HOST_DEVICE void pluginInputState(const double *inputState, double *u2, const int nvel, const int numActiveSpecies) {
+  MFEM_HOST_DEVICE void pluginInputState(const double *inputState, double *u2, const int nvel,
+                                         const int numActiveSpecies) {
     u2[0] = inputState[0];
     for (int v = 0; v < nvel; v++) u2[1 + v] = inputState[0] * inputState[1 + v];
     if (numActiveSpecies > 0) {

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -120,6 +120,15 @@ class InletBC : public BoundaryCondition {
                        Array<int> &offsetsBoundaryU);
 
 #ifdef _GPU_
+  MFEM_HOST_DEVICE void pluginInputState(const double *inputState, double *u2, const int nvel, const int numActiveSpecies) {
+    u2[0] = inputState[0];
+    for (int v = 0; v < nvel; v++) u2[1 + v] = inputState[0] * inputState[1 + v];
+    if (numActiveSpecies > 0) {
+      for (int sp = 0; sp < numActiveSpecies; sp++) u2[nvel + 2 + sp] = inputState[4 + sp];
+    }
+    return;
+  }
+
   static MFEM_HOST_DEVICE void computeSubDenseVel(const double *u1, double *u2, const double *nor,
                                                   const double *inputState, const double &gamma, const double &Rg,
                                                   const int &dim, const int &num_equation, const WorkingFluid &fluid,

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -344,12 +344,8 @@ void OutletBC::updateMean_gpu(ParGridFunction *Up, Vector &localMeanUp, const in
   MFEM_FORALL(el, numBdrElems, {
     const int elDof = d_bdrElemQ[2 * el];
     const int Q = d_bdrElemQ[2 * el + 1];
-    //     double elUp[5*maxDofs];
-    //     double shape[maxDofs];
-    // compiler does not allow to have maxDofs.
-    // currently maxDofs = 64;
-    double elUp[20 * 216];
-    double shape[216];
+    double elUp[gpudata::MAXEQUATIONS * gpudata::MAXDOFS]; // double elUp[20 * 216];
+    double shape[gpudata::MAXDOFS]; // double shape[216];
     double sum;
 
     // retreive data
@@ -1043,8 +1039,8 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const Array<int>
   // clang-format off
   MFEM_FORALL_2D(n, numBdrElem, maxDofs, 1, 1,
   {
-    MFEM_SHARED double Fcontrib[216 * 20];
-    double Rflux[20];
+    MFEM_SHARED double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS]; // MFEM_SHARED double Fcontrib[216 * 20];
+    double Rflux[gpudata::MAXEQUATIONS]; // double Rflux[20];
 
     const int el = d_listElems[n];
 
@@ -1131,9 +1127,13 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const Array<int> &nodesID
   // MFEM_FORALL(n, numBdrElem, {
   MFEM_FORALL_2D(n, numBdrElem, maxIntPoints, 1, 1, {
     //
-    double shape[216];
-    double u1[5], u2[5], gradUp1[5 * 3], Rflux[5], nor[3];
-    int index_i[216];
+    double shape[gpudata::MAXDOFS]; // double shape[216];
+    double u1[gpudata::MAXEQUATIONS],
+           u2[gpudata::MAXEQUATIONS],
+           gradUp1[gpudata::MAXEQUATIONS * gpudata::MAXDIM],
+           Rflux[gpudata::MAXEQUATIONS],
+           nor[gpudata::MAXDIM]; // double u1[5], u2[5], gradUp1[5 * 3], Rflux[5], nor[3];
+    int index_i[gpudata::MAXDOFS]; // int index_i[216];
 
     const int el = d_listElems[n];
     const int offsetBdrU = d_offsetBoundaryU[n];

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -1044,8 +1044,8 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const Array<int>
   // clang-format off
   MFEM_FORALL_2D(n, numBdrElem, maxDofs, 1, 1,
   {
-    MFEM_SHARED double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS]; // MFEM_SHARED double Fcontrib[216 * 20];
-    double Rflux[gpudata::MAXEQUATIONS]; // double Rflux[20];
+    MFEM_SHARED double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS];  // MFEM_SHARED double Fcontrib[216 * 20];
+    double Rflux[gpudata::MAXEQUATIONS];  // double Rflux[20];
 
     const int el = d_listElems[n];
 

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -35,9 +35,9 @@
 #include "riemann_solver.hpp"
 
 // TODO(kevin): non-reflecting BC for plasma.
-OutletBC::OutletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rsolver, GasMixture *_mixture, GasMixture *d_mixture,
-                   ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, double &_dt, const int _dim,
-                   const int _num_equation, int _patchNumber, double _refLength, OutletType _bcType,
+OutletBC::OutletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rsolver, GasMixture *_mixture,
+                   GasMixture *d_mixture, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, double &_dt,
+                   const int _dim, const int _num_equation, int _patchNumber, double _refLength, OutletType _bcType,
                    const Array<double> &_inputData, const int &_maxIntPoints, const int &_maxDofs, bool axisym)
     : BoundaryCondition(_rsolver, _mixture, _eqSystem, _vfes, _intRules, _dt, _dim, _num_equation, _patchNumber,
                         _refLength, axisym),
@@ -349,8 +349,8 @@ void OutletBC::updateMean_gpu(ParGridFunction *Up, Vector &localMeanUp, const in
   MFEM_FORALL(el, numBdrElems, {
     const int elDof = d_bdrElemQ[2 * el];
     const int Q = d_bdrElemQ[2 * el + 1];
-    double elUp[gpudata::MAXEQUATIONS * gpudata::MAXDOFS]; // double elUp[20 * 216];
-    double shape[gpudata::MAXDOFS]; // double shape[216];
+    double elUp[gpudata::MAXEQUATIONS * gpudata::MAXDOFS];  // double elUp[20 * 216];
+    double shape[gpudata::MAXDOFS];                         // double shape[216];
     double sum;
 
     // retreive data
@@ -1140,13 +1140,11 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const Array<int> &nodesID
   // MFEM_FORALL(n, numBdrElem, {
   MFEM_FORALL_2D(n, numBdrElem, maxIntPoints, 1, 1, {
     //
-    double shape[gpudata::MAXDOFS]; // double shape[216];
-    double u1[gpudata::MAXEQUATIONS],
-           u2[gpudata::MAXEQUATIONS],
-           gradUp1[gpudata::MAXEQUATIONS * gpudata::MAXDIM],
-           Rflux[gpudata::MAXEQUATIONS],
-           nor[gpudata::MAXDIM]; // double u1[5], u2[5], gradUp1[5 * 3], Rflux[5], nor[3];
-    int index_i[gpudata::MAXDOFS]; // int index_i[216];
+    double shape[gpudata::MAXDOFS];  // double shape[216];
+    double u1[gpudata::MAXEQUATIONS], u2[gpudata::MAXEQUATIONS], gradUp1[gpudata::MAXEQUATIONS * gpudata::MAXDIM],
+        Rflux[gpudata::MAXEQUATIONS],
+        nor[gpudata::MAXDIM];       // double u1[5], u2[5], gradUp1[5 * 3], Rflux[5], nor[3];
+    int index_i[gpudata::MAXDOFS];  // int index_i[216];
 
     const int el = d_listElems[n];
     const int offsetBdrU = d_offsetBoundaryU[n];
@@ -1214,7 +1212,7 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const Array<int> &nodesID
           break;
       }
 
-      // compute flux
+        // compute flux
 #if defined(_CUDA_)
       d_rsolver->Eval_LF(u1, u2, nor, Rflux);
 #elif defined(_HIP_)

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -97,9 +97,9 @@ class OutletBC : public BoundaryCondition {
   void computeParallelArea();
 
  public:
-  OutletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *rsolver_, GasMixture *mixture, GasMixture *d_mixture,
-           ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, double &_dt, const int _dim,
-           const int _num_equation, int _patchNumber, double _refLength, OutletType _bcType,
+  OutletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *rsolver_, GasMixture *mixture,
+           GasMixture *d_mixture, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, double &_dt,
+           const int _dim, const int _num_equation, int _patchNumber, double _refLength, OutletType _bcType,
            const Array<double> &_inputData, const int &_maxIntPoints, const int &maxDofs, bool axisym);
   ~OutletBC();
 

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -51,7 +51,6 @@ class OutletBC : public BoundaryCondition {
 
   // In/out conditions specified in the configuration file
   const Array<double> inputState;
-  double d_inputState[gpudata::MAXEQUATIONS];
 
   // Mean boundary state
   Vector meanUp;
@@ -128,12 +127,6 @@ class OutletBC : public BoundaryCondition {
                         ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
                         Array<int> &listElems, Array<int> &offsetsBoundaryU);
 
-  MFEM_HOST_DEVICE void subsonicReflectingPressure(const double *normal, const double *stateIn, double *bdrFlux);
-  MFEM_HOST_DEVICE void modifyEnergyForPressure(const double *stateIn, double *state2, const double p) {
-printf("entered outlet modify.\n");
-    d_mixture_->modifyEnergyForPressure(stateIn, state2, p);
-    return;
-  }
 #ifdef _GPU_  // GPU functions
   static MFEM_HOST_DEVICE void computeSubPressure(const double *u1, double *u2, const double *nor, const double &press,
                                                   const double &gamma, const double &Rg, const int &dim,

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -553,9 +553,9 @@ void RHSoperator::updatePrimitives_gpu(Vector *Up, const Vector *x_in, const dou
   auto dataIn = x_in->Read();  // make sure data is available in GPU
 
   MFEM_FORALL(n, ndofs, {
-    double state[20];  // assuming 20 equations
+    double state[gpudata::MAXEQUATIONS]; // double state[20];
     // MFEM_SHARED double p;
-    double KE[3];
+    double KE[gpudata::MAXDIM]; // double KE[3];
 
     for (int eq = 0; eq < num_equation; eq++) {
       state[eq] = dataIn[n + eq * ndofs];  // loads data into shared memory
@@ -615,7 +615,7 @@ void RHSoperator::multiPlyInvers_gpu(Vector &y, Vector &z, const volumeFaceInteg
   const double *d_invM = invMArray.Read();
 
   MFEM_FORALL_2D(el, NE, dof, 1, 1, {
-    MFEM_SHARED double data[216 * 20];
+    MFEM_SHARED double data[gpudata::MAXDOFS * gpudata::MAXEQUATIONS]; // MFEM_SHARED double data[216 * 20];
 
     int eli = el + elemOffset;
     int offsetInv = d_posDofInvM[2 * eli];

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -453,12 +453,7 @@ void RHSoperator::copyDataForFluxIntegration_gpu(const Vector &z, DenseTensor &f
 void RHSoperator::GetFlux(const Vector &x, DenseTensor &flux) const {
 #ifdef _GPU_
 
-  // ComputeConvectiveFluxes
-  Fluxes::convectiveFluxes_gpu(x, flux, eqSystem, mixture, vfes->GetNDofs(), dim, num_equation);
-  if (eqSystem != EULER) {
-    Fluxes::viscousFluxes_gpu(x, gradUp, flux, eqSystem, mixture, spaceVaryViscMult, linViscData, vfes->GetNDofs(), dim,
-                              num_equation);
-  }
+  GetFlux_gpu(x, flux);
 #else
 
   DenseMatrix xmat(x.GetData(), vfes->GetNDofs(), num_equation);
@@ -526,6 +521,18 @@ void RHSoperator::GetFlux(const Vector &x, DenseTensor &flux) const {
 
   double partition_max_char = max_char_speed;
   MPI_Allreduce(&partition_max_char, &max_char_speed, 1, MPI_DOUBLE, MPI_MAX, mesh->GetComm());
+}
+
+void RHSoperator::GetFlux_gpu(const Vector &x, DenseTensor &flux) const {
+// #if defined(_CUDA_)
+// #elif defined(_HIP_)
+  // ComputeConvectiveFluxes
+  Fluxes::convectiveFluxes_gpu(x, flux, eqSystem, mixture, vfes->GetNDofs(), dim, num_equation);
+  if (eqSystem != EULER) {
+    Fluxes::viscousFluxes_gpu(x, gradUp, flux, eqSystem, mixture, spaceVaryViscMult, linViscData, vfes->GetNDofs(), dim,
+                              num_equation);
+  }
+// #endif
 }
 
 void RHSoperator::updatePrimitives(const Vector &x_in) const {

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -613,7 +613,7 @@ void RHSoperator::updatePrimitives(const Vector &x_in) const {
                                     vfes->GetNDofs(), dim_, num_equation_, eqSystem);
 #elif defined(_CUDA_)
   auto dataUp = Up->Write();   // make sure data is available in GPU
-  auto dataIn = x_in->Read();  // make sure data is available in GPU
+  auto dataIn = x_in.Read();  // make sure data is available in GPU
 
   const int ndofs = vfes->GetNDofs();
   const int num_equation = num_equation_;

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -532,6 +532,8 @@ void RHSoperator::GetFlux_gpu(const Vector &x, DenseTensor &flux) const {
   const int dim = dim_;
   const int num_equation = num_equation_;
 
+  Fluxes *d_fluxClass = fluxClass;
+
   MFEM_FORALL(n, dof, {
     double Un[gpudata::MAXEQUATIONS]; // double Un[20];
     double fluxn[gpudata::MAXEQUATIONS * gpudata::MAXDIM];
@@ -540,7 +542,7 @@ void RHSoperator::GetFlux_gpu(const Vector &x, DenseTensor &flux) const {
       Un[eq] = dataIn[n + eq * dof];
     }
 
-    fluxClass->ComputeConvectiveFluxes(Un, fluxn);
+    d_fluxClass->ComputeConvectiveFluxes(Un, fluxn);
 
     for (int eq = 0; eq < num_equation; eq++) {
       for (int d = 0; d < dim; d++) {

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -74,7 +74,7 @@ class RHSoperator : public TimeDependentOperator {
   const int intRuleType;
 
   Fluxes *fluxClass;
-  GasMixture *mixture;
+  GasMixture *mixture, *d_mixture_;
   TransportProperties *transport_;
 
   ParFiniteElementSpace *vfes;
@@ -168,7 +168,7 @@ class RHSoperator : public TimeDependentOperator {
   static void copyZk2Z_gpu(Vector &z, Vector &zk, const int eq, const int dof);
   static void copyDataForFluxIntegration_gpu(const Vector &z, DenseTensor &flux, Vector &fk, Vector &zk, const int eq,
                                              const int dof, const int dim);
-  static void updatePrimitives_gpu(Vector *Up, const Vector *x_in, const double gamma, const double Rgas,
+  static void updatePrimitives_hip(Vector *Up, const Vector *x_in, const double gamma, const double Rgas,
                                    const int ndofs, const int dim, const int num_equation, const Equations &eqSystem);
   static void multiPlyInvers_gpu(Vector &y, Vector &z, const volumeFaceIntegrationArrays &gpuArrays,
                                  const Vector &invMArray, const Array<int> &posDofInvM, const int num_equation,

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -137,7 +137,6 @@ class RHSoperator : public TimeDependentOperator {
 
   // void GetFlux(const DenseMatrix &state, DenseTensor &flux) const;
   void GetFlux(const Vector &state, DenseTensor &flux) const;
-  void GetFlux_gpu(const Vector &state, DenseTensor &flux) const;
 
   mutable Vector local_timeDerivatives;
   void computeMeanTimeDerivatives(Vector &y) const;
@@ -165,6 +164,7 @@ class RHSoperator : public TimeDependentOperator {
   static void waitAllDataTransfer(ParFiniteElementSpace *pfes, dataTransferArrays &dataTransfer);
 
   // GPU functions
+  void GetFlux_gpu(const Vector &state, DenseTensor &flux) const;
   static void copyZk2Z_gpu(Vector &z, Vector &zk, const int eq, const int dof);
   static void copyDataForFluxIntegration_gpu(const Vector &z, DenseTensor &flux, Vector &fk, Vector &zk, const int eq,
                                              const int dof, const int dim);

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -137,6 +137,7 @@ class RHSoperator : public TimeDependentOperator {
 
   // void GetFlux(const DenseMatrix &state, DenseTensor &flux) const;
   void GetFlux(const Vector &state, DenseTensor &flux) const;
+  void GetFlux_gpu(const Vector &state, DenseTensor &flux) const;
 
   mutable Vector local_timeDerivatives;
   void computeMeanTimeDerivatives(Vector &y) const;

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -144,12 +144,12 @@ class RHSoperator : public TimeDependentOperator {
  public:
   RHSoperator(int &_iter, const int _dim, const int &_num_equation, const int &_order, const Equations &_eqSystem,
               double &_max_char_speed, IntegrationRules *_intRules, int _intRuleType, Fluxes *_fluxClass,
-              GasMixture *_mixture, GasMixture *d_mixture, Chemistry *chemistry, TransportProperties *transport, ParFiniteElementSpace *_vfes,
-              const volumeFaceIntegrationArrays &gpuArrays, const int &_maxIntPoints, const int &_maxDofs,
-              DGNonLinearForm *_A, MixedBilinearForm *_Aflux, ParMesh *_mesh, ParGridFunction *_spaceVaryViscMult,
-              ParGridFunction *U, ParGridFunction *_Up, ParGridFunction *_gradUp, ParFiniteElementSpace *_gradUpfes,
-              GradNonLinearForm *_gradUp_A, BCintegrator *_bcIntegrator, bool &_isSBP, double &_alpha,
-              RunConfiguration &_config);
+              GasMixture *_mixture, GasMixture *d_mixture, Chemistry *chemistry, TransportProperties *transport,
+              ParFiniteElementSpace *_vfes, const volumeFaceIntegrationArrays &gpuArrays, const int &_maxIntPoints,
+              const int &_maxDofs, DGNonLinearForm *_A, MixedBilinearForm *_Aflux, ParMesh *_mesh,
+              ParGridFunction *_spaceVaryViscMult, ParGridFunction *U, ParGridFunction *_Up, ParGridFunction *_gradUp,
+              ParFiniteElementSpace *_gradUpfes, GradNonLinearForm *_gradUp_A, BCintegrator *_bcIntegrator,
+              bool &_isSBP, double &_alpha, RunConfiguration &_config);
 
   virtual void Mult(const Vector &x, Vector &y) const;
   void updatePrimitives(const Vector &x) const;

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -144,7 +144,7 @@ class RHSoperator : public TimeDependentOperator {
  public:
   RHSoperator(int &_iter, const int _dim, const int &_num_equation, const int &_order, const Equations &_eqSystem,
               double &_max_char_speed, IntegrationRules *_intRules, int _intRuleType, Fluxes *_fluxClass,
-              GasMixture *_mixture, Chemistry *chemistry, TransportProperties *transport, ParFiniteElementSpace *_vfes,
+              GasMixture *_mixture, GasMixture *d_mixture, Chemistry *chemistry, TransportProperties *transport, ParFiniteElementSpace *_vfes,
               const volumeFaceIntegrationArrays &gpuArrays, const int &_maxIntPoints, const int &_maxDofs,
               DGNonLinearForm *_A, MixedBilinearForm *_Aflux, ParMesh *_mesh, ParGridFunction *_spaceVaryViscMult,
               ParGridFunction *U, ParGridFunction *_Up, ParGridFunction *_gradUp, ParFiniteElementSpace *_gradUpfes,

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -62,13 +62,13 @@ class RHSoperator : public TimeDependentOperator {
 
   int &iter;
 
-  const int dim;
+  const int dim_;
   const int nvel;
 
   const Equations &eqSystem;
 
   double &max_char_speed;
-  const int &num_equation;
+  const int &num_equation_;
 
   IntegrationRules *intRules;
   const int intRuleType;

--- a/src/riemann_solver.cpp
+++ b/src/riemann_solver.cpp
@@ -108,7 +108,7 @@ void RiemannSolver::Eval(const Vector &state1, const Vector &state2, const Vecto
 MFEM_HOST_DEVICE void RiemannSolver::Eval(const double *state1, const double *state2, const double *nor, double *flux, bool LF) {
   if (useRoe && !LF) {
     // TODO(kevin): implement MFEM_HOST_DEVICE Eval_Roe.
-    mfem_error("Roe RiemannSolver is not implmented for gpu!");
+    printf("Roe RiemannSolver is not implmented for gpu!");
     //Eval_Roe(state1, state2, nor, flux);
   } else {
     Eval_LF(state1, state2, nor, flux);

--- a/src/riemann_solver.cpp
+++ b/src/riemann_solver.cpp
@@ -105,6 +105,15 @@ void RiemannSolver::Eval(const Vector &state1, const Vector &state2, const Vecto
   }
 }
 
+MFEM_HOST_DEVICE void RiemannSolver::Eval(const double *state1, const double *state2, const double *nor, double *flux, bool LF) {
+  if (useRoe && !LF) {
+    // TODO(kevin): implement MFEM_HOST_DEVICE Eval_Roe.
+    //Eval_Roe(state1, state2, nor, flux);
+  } else {
+    Eval_LF(state1, state2, nor, flux);
+  }
+}
+
 void RiemannSolver::Eval_LF(const Vector &state1, const Vector &state2, const Vector &nor, Vector &flux) {
   // NOTE: nor in general is not a unit normal
   const int dim = nor.Size();

--- a/src/riemann_solver.cpp
+++ b/src/riemann_solver.cpp
@@ -87,7 +87,7 @@ void RiemannSolver::ComputeFluxDotN(const Vector &state, const Vector &nor, Vect
 MFEM_HOST_DEVICE void RiemannSolver::ComputeFluxDotN(const double *state, const double *nor, double *fluxN) const {
   const int dim = mixture->GetDimension();
 
-  double fluxes[gpudata::MAXEQUATIONS * gpudata::MAXDIM]; // double fluxes[5 * 3];
+  double fluxes[gpudata::MAXEQUATIONS * gpudata::MAXDIM];  // double fluxes[5 * 3];
   fluxClass->ComputeConvectiveFluxes(state, fluxes);
   for (int eq = 0; eq < num_equation; eq++) {
     fluxN[eq] = 0;
@@ -105,11 +105,12 @@ void RiemannSolver::Eval(const Vector &state1, const Vector &state2, const Vecto
   }
 }
 
-MFEM_HOST_DEVICE void RiemannSolver::Eval(const double *state1, const double *state2, const double *nor, double *flux, bool LF) {
+MFEM_HOST_DEVICE void RiemannSolver::Eval(const double *state1, const double *state2, const double *nor, double *flux,
+                                          bool LF) {
   if (useRoe && !LF) {
     // TODO(kevin): implement MFEM_HOST_DEVICE Eval_Roe.
     printf("Roe RiemannSolver is not implmented for gpu!");
-    //Eval_Roe(state1, state2, nor, flux);
+    // Eval_Roe(state1, state2, nor, flux);
   } else {
     Eval_LF(state1, state2, nor, flux);
   }
@@ -156,8 +157,8 @@ MFEM_HOST_DEVICE void RiemannSolver::Eval_LF(const double *state1, const double 
   // const double maxE = max(maxE1, maxE2);
   const double maxE = fmax(maxE1, maxE2);
 
-  double flux1[gpudata::MAXEQUATIONS]; // double flux1[5];
-  double flux2[gpudata::MAXEQUATIONS]; // double flux2[5];
+  double flux1[gpudata::MAXEQUATIONS];  // double flux1[5];
+  double flux2[gpudata::MAXEQUATIONS];  // double flux2[5];
 
   ComputeFluxDotN(state1, nor, flux1);
   ComputeFluxDotN(state2, nor, flux2);

--- a/src/riemann_solver.cpp
+++ b/src/riemann_solver.cpp
@@ -108,6 +108,7 @@ void RiemannSolver::Eval(const Vector &state1, const Vector &state2, const Vecto
 MFEM_HOST_DEVICE void RiemannSolver::Eval(const double *state1, const double *state2, const double *nor, double *flux, bool LF) {
   if (useRoe && !LF) {
     // TODO(kevin): implement MFEM_HOST_DEVICE Eval_Roe.
+    mfem_error("Roe RiemannSolver is not implmented for gpu!");
     //Eval_Roe(state1, state2, nor, flux);
   } else {
     Eval_LF(state1, state2, nor, flux);

--- a/src/riemann_solver.cpp
+++ b/src/riemann_solver.cpp
@@ -87,8 +87,7 @@ void RiemannSolver::ComputeFluxDotN(const Vector &state, const Vector &nor, Vect
 MFEM_HOST_DEVICE void RiemannSolver::ComputeFluxDotN(const double *state, const double *nor, double *fluxN) const {
   const int dim = mixture->GetDimension();
 
-  // TODO(trevilo): replace 5 with a compile time constant for max number of eqns and 3 with compile time max dim
-  double fluxes[5 * 3];
+  double fluxes[gpudata::MAXEQUATIONS * gpudata::MAXDIM]; // double fluxes[5 * 3];
   fluxClass->ComputeConvectiveFluxes(state, fluxes);
   for (int eq = 0; eq < num_equation; eq++) {
     fluxN[eq] = 0;
@@ -147,9 +146,8 @@ MFEM_HOST_DEVICE void RiemannSolver::Eval_LF(const double *state1, const double 
   // const double maxE = max(maxE1, maxE2);
   const double maxE = fmax(maxE1, maxE2);
 
-  // TODO(trevilo): replace 5 with a compile time constant for max number of eqns
-  double flux1[5];
-  double flux2[5];
+  double flux1[gpudata::MAXEQUATIONS]; // double flux1[5];
+  double flux2[gpudata::MAXEQUATIONS]; // double flux2[5];
 
   ComputeFluxDotN(state1, nor, flux1);
   ComputeFluxDotN(state2, nor, flux2);

--- a/src/riemann_solver.hpp
+++ b/src/riemann_solver.hpp
@@ -66,7 +66,8 @@ class RiemannSolver {
                                  bool _useRoe, bool axisym);
 
   void Eval(const Vector &state1, const Vector &state2, const Vector &nor, Vector &flux, bool LF = false);
-  MFEM_HOST_DEVICE void Eval(const double *state1, const double *state2, const double *nor, double *flux, bool LF = false);
+  MFEM_HOST_DEVICE void Eval(const double *state1, const double *state2, const double *nor, double *flux,
+                             bool LF = false);
 
   void ComputeFluxDotN(const Vector &state, const Vector &nor, Vector &fluxN);
 

--- a/src/riemann_solver.hpp
+++ b/src/riemann_solver.hpp
@@ -66,6 +66,7 @@ class RiemannSolver {
                                  bool _useRoe, bool axisym);
 
   void Eval(const Vector &state1, const Vector &state2, const Vector &nor, Vector &flux, bool LF = false);
+  MFEM_HOST_DEVICE void Eval(const double *state1, const double *state2, const double *nor, double *flux, bool LF = false);
 
   void ComputeFluxDotN(const Vector &state, const Vector &nor, Vector &fluxN);
 

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -189,7 +189,7 @@ MFEM_HOST_DEVICE void DryAirTransport::ComputeFluxTransportProperties(const doub
   // diffusionVelocity.SetSize(numSpecies, nvel_);
   for (int v = 0; v < nvel_; v++) {
     for (int sp = 0; sp < numSpecies; sp++) {
-      diffusionVelocity[sp + v * numSpecies] = 0.0;
+      diffusionVelocity[sp + v * gpudata::MAXSPECIES] = 0.0;
     }
   }
   if (numActiveSpecies > 0) {
@@ -205,12 +205,12 @@ MFEM_HOST_DEVICE void DryAirTransport::ComputeFluxTransportProperties(const doub
           dY -= state[2 + nvel_ + sp] / state[0] * gradUp[0 + d * num_equation];
           dY /= state[0];
 
-          diffusionVelocity[sp + d * numSpecies] = diffusivity * dY / state[2 + nvel_ + sp];
+          diffusionVelocity[sp + d * gpudata::MAXSPECIES] = diffusivity * dY / state[2 + nvel_ + sp];
         }
       }
 
       for (int d = 0; d < nvel_; d++) {
-        assert(!isnan(diffusionVelocity[0 + d * num_equation]));
+        assert(!isnan(diffusionVelocity[0 + d * gpudata::MAXSPECIES]));
       }
     }
   }

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -32,8 +32,8 @@
 
 #include "transport_properties.hpp"
 
-MFEM_HOST_DEVICE TransportProperties::TransportProperties(GasMixture *_mixture) {
-  mixture = _mixture;
+MFEM_HOST_DEVICE TransportProperties::TransportProperties(GasMixture *_mixture)
+    : mixture(_mixture) {
   numSpecies = mixture->GetNumSpecies();
   dim = mixture->GetDimension();
   nvel_ = mixture->GetNumVels();
@@ -121,13 +121,17 @@ void TransportProperties::CurtissHirschfelder(const Vector &X_sp, const Vector &
 //////// Dry Air mixture
 //////////////////////////////////////////////////////
 
-DryAirTransport::DryAirTransport(GasMixture *_mixture, RunConfiguration &_runfile) : TransportProperties(_mixture) {
-  visc_mult = _runfile.GetViscMult();
-  bulk_visc_mult = _runfile.GetBulkViscMult();
+DryAirTransport::DryAirTransport(GasMixture *_mixture, RunConfiguration &_runfile)
+    : DryAirTransport(_mixture, _runfile.GetViscMult(), _runfile.GetBulkViscMult()) {}
+
+MFEM_HOST_DEVICE DryAirTransport::DryAirTransport(GasMixture *_mixture, const double viscosity_multiplier,
+                                                  const double bulk_viscosity) : TransportProperties(_mixture) {
+  visc_mult = viscosity_multiplier;
+  bulk_visc_mult = bulk_viscosity;
 
   Pr = 0.71;
   Sc = 0.71;
-  gas_constant = UNIVERSALGASCONSTANT / mixture->GetGasParams(0, GasParams::SPECIES_MW);
+  gas_constant = mixture->GetGasConstant();
   const double specific_heat_ratio = mixture->GetSpecificHeatRatio();
   cp_div_pr = specific_heat_ratio * gas_constant / (Pr * (specific_heat_ratio - 1.));
 }

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -189,7 +189,10 @@ MFEM_HOST_DEVICE void DryAirTransport::ComputeFluxTransportProperties(const doub
   // diffusionVelocity.SetSize(numSpecies, nvel_);
   for (int v = 0; v < nvel_; v++) {
     for (int sp = 0; sp < numSpecies; sp++) {
-      diffusionVelocity[sp + v * gpudata::MAXSPECIES] = 0.0;
+      // While the size of the array is set up to gpudata::MAXSPECIES,
+      // indexing does not have to follow the actual size,
+      // as long as it does not go beyond the size of array.
+      diffusionVelocity[sp + v * numSpecies] = 0.0;
     }
   }
   if (numActiveSpecies > 0) {
@@ -205,12 +208,12 @@ MFEM_HOST_DEVICE void DryAirTransport::ComputeFluxTransportProperties(const doub
           dY -= state[2 + nvel_ + sp] / state[0] * gradUp[0 + d * num_equation];
           dY /= state[0];
 
-          diffusionVelocity[sp + d * gpudata::MAXSPECIES] = diffusivity * dY / state[2 + nvel_ + sp];
+          diffusionVelocity[sp + d * numSpecies] = diffusivity * dY / state[2 + nvel_ + sp];
         }
       }
 
       for (int d = 0; d < nvel_; d++) {
-        assert(!isnan(diffusionVelocity[0 + d * gpudata::MAXSPECIES]));
+        assert(!isnan(diffusionVelocity[0 + d * numSpecies]));
       }
     }
   }

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -32,18 +32,8 @@
 
 #include "transport_properties.hpp"
 
-TransportProperties::TransportProperties(GasMixture *_mixture) : mixture(_mixture) {
-  numSpecies = mixture->GetNumSpecies();
-  dim = mixture->GetDimension();
-  nvel_ = mixture->GetNumVels();
-  numActiveSpecies = mixture->GetNumActiveSpecies();
-  ambipolar = mixture->IsAmbipolar();
-  twoTemperature_ = mixture->IsTwoTemperature();
-  num_equation = mixture->GetNumEquations();
-}
-
 MFEM_HOST_DEVICE TransportProperties::TransportProperties(GasMixture *_mixture) {
-  mixture = _mixture
+  mixture = _mixture;
   numSpecies = mixture->GetNumSpecies();
   dim = mixture->GetDimension();
   nvel_ = mixture->GetNumVels();

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -32,8 +32,7 @@
 
 #include "transport_properties.hpp"
 
-MFEM_HOST_DEVICE TransportProperties::TransportProperties(GasMixture *_mixture)
-    : mixture(_mixture) {
+MFEM_HOST_DEVICE TransportProperties::TransportProperties(GasMixture *_mixture) : mixture(_mixture) {
   numSpecies = mixture->GetNumSpecies();
   dim = mixture->GetDimension();
   nvel_ = mixture->GetNumVels();
@@ -125,7 +124,8 @@ DryAirTransport::DryAirTransport(GasMixture *_mixture, RunConfiguration &_runfil
     : DryAirTransport(_mixture, _runfile.GetViscMult(), _runfile.GetBulkViscMult()) {}
 
 MFEM_HOST_DEVICE DryAirTransport::DryAirTransport(GasMixture *_mixture, const double viscosity_multiplier,
-                                                  const double bulk_viscosity) : TransportProperties(_mixture) {
+                                                  const double bulk_viscosity)
+    : TransportProperties(_mixture) {
   visc_mult = viscosity_multiplier;
   bulk_visc_mult = bulk_viscosity;
 
@@ -203,8 +203,7 @@ MFEM_HOST_DEVICE void DryAirTransport::ComputeFluxTransportProperties(const doub
       for (int d = 0; d < dim; d++) {
         if (fabs(state[2 + nvel_ + sp]) > 1e-10) {
           // compute mass fraction gradient
-          double dY = UNIVERSALGASCONSTANT / mixture->GetGasConstant()
-                      * gradUp[2 + nvel_ + sp + d * num_equation];
+          double dY = UNIVERSALGASCONSTANT / mixture->GetGasConstant() * gradUp[2 + nvel_ + sp + d * num_equation];
           dY -= state[2 + nvel_ + sp] / state[0] * gradUp[0 + d * num_equation];
           dY /= state[0];
 

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -144,6 +144,8 @@ class DryAirTransport : public TransportProperties {
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
+                                              double *transportBuffer, double *diffusionVelocity);
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                                 const Vector &Efield, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -87,7 +87,8 @@ class TransportProperties {
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity) = 0;
-  // Vector &outputUp);
+  // virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
+  //                                             double *transportBuffer, double *diffusionVelocity) = 0;
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
@@ -136,6 +137,8 @@ class DryAirTransport : public TransportProperties {
 
  public:
   DryAirTransport(GasMixture *_mixture, RunConfiguration &_runfile);
+  MFEM_HOST_DEVICE DryAirTransport(GasMixture *_mixture, const double viscosity_multiplier,
+                                   const double bulk_viscosity);
 
   MFEM_HOST_DEVICE virtual ~DryAirTransport() {}
 

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -87,8 +87,9 @@ class TransportProperties {
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity) = 0;
-  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-                                              double *transportBuffer, double *diffusionVelocity) = 0;
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
+                                                               const double *Efield, double *transportBuffer,
+                                                               double *diffusionVelocity) = 0;
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
@@ -144,8 +145,9 @@ class DryAirTransport : public TransportProperties {
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
-  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-                                              double *transportBuffer, double *diffusionVelocity);
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
+                                                               const double *Efield, double *transportBuffer,
+                                                               double *diffusionVelocity);
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                                 const Vector &Efield, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
@@ -185,8 +187,12 @@ class ConstantTransport : public TransportProperties {
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
-  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-                                              double *transportBuffer, double *diffusionVelocity) { exit(-1); return; }
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
+                                                               const double *Efield, double *transportBuffer,
+                                                               double *diffusionVelocity) {
+    exit(-1);
+    return;
+  }
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                                 const Vector &Efield, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -68,10 +68,10 @@ class TransportProperties {
   const double Xeps_ = 1.0e-30;
 
  public:
-  TransportProperties(GasMixture *_mixture);
+  // TransportProperties(GasMixture *_mixture);
   MFEM_HOST_DEVICE TransportProperties(GasMixture *_mixture);
 
-  virtual ~TransportProperties() {}
+  // virtual ~TransportProperties() {}
   MFEM_HOST_DEVICE virtual ~TransportProperties() {}
 
   // Currently, diffusion velocity is evaluated together with transport properties,
@@ -137,7 +137,7 @@ class DryAirTransport : public TransportProperties {
  public:
   DryAirTransport(GasMixture *_mixture, RunConfiguration &_runfile);
 
-  virtual ~DryAirTransport() {}
+  MFEM_HOST_DEVICE virtual ~DryAirTransport() {}
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
@@ -176,7 +176,7 @@ class ConstantTransport : public TransportProperties {
  public:
   ConstantTransport(GasMixture *_mixture, RunConfiguration &_runfile);
 
-  virtual ~ConstantTransport() {}
+  MFEM_HOST_DEVICE virtual ~ConstantTransport() {}
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -87,8 +87,8 @@ class TransportProperties {
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity) = 0;
-  // virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-  //                                             double *transportBuffer, double *diffusionVelocity) = 0;
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
+                                              double *transportBuffer, double *diffusionVelocity) = 0;
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
@@ -185,6 +185,8 @@ class ConstantTransport : public TransportProperties {
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
+                                              double *transportBuffer, double *diffusionVelocity) { exit(-1); return; }
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                                 const Vector &Efield, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -516,8 +516,8 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, 
   const int num_equation = num_equation_;
   const int maxIntPoints = maxIntPoints_;
 
-  const RiemannSolver *d_rsolver = rsolver_;
-  Fluxes *d_fluxclass = fluxes;
+  const RiemannSolver *d_rsolver = rsolver;
+  Fluxes *d_fluxclass = fluxClass;
 
   // clang-format on
   // el_wall is index within wall boundary elements?
@@ -588,7 +588,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, 
 #if defined(_CUDA_)
         d_rsolver->Eval_LF(u1, u2, nor, Rflux);
         d_fluxclass->ComputeViscousFluxes(u1, gradUp1, 0.0, vF1);
-        d_fluxclass->ComputeViscousFluxes(u2, gradUp2, 0.0, vF2);
+        d_fluxclass->ComputeViscousFluxes(u2, gradUp1, 0.0, vF2);
 #elif defined(_HIP_)
         RiemannSolver::riemannLF_serial_gpu(&u1[0], &u2[0], &Rflux[0], &nor[0], gamma, Rg, dim, num_equation);
         Fluxes::viscousFlux_serial_gpu(&vF1[0], &u1[0], &gradUp1[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -586,6 +586,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, 
 
         // evaluate flux
 #if defined(_CUDA_)
+        // TODO(kevin): implement radius.
         d_rsolver->Eval_LF(u1, u2, nor, Rflux);
         d_fluxclass->ComputeViscousFluxes(u1, gradUp1, 0.0, vF1);
         d_fluxclass->ComputeViscousFluxes(u2, gradUp1, 0.0, vF2);

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -615,12 +615,12 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, 
                                        num_equation);
         Fluxes::viscousFlux_serial_gpu(&vF2[0], &u2[0], &gradUp1[0], gamma, Rg, viscMult, bulkViscMult, Pr, dim,
                                        num_equation);
+#endif
 
         // add visc flux contribution
         for (int eq = 0; eq < num_equation; eq++)
           for (int d = 0; d < dim; d++)
             Rflux[eq] -= 0.5 * (vF2[eq + d * num_equation] + vF1[eq + d * num_equation]) * nor[d];
-#endif
 
         // store flux (TODO: change variable name)
         for (int eq = 0; eq < num_equation; eq++) {

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -33,9 +33,9 @@
 
 #include "riemann_solver.hpp"
 
-WallBC::WallBC(RiemannSolver *_rsolver, GasMixture *_mixture, GasMixture *d_mixture, Equations _eqSystem, Fluxes *_fluxClass,
-               ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, double &_dt, const int _dim,
-               const int _num_equation, int _patchNumber, WallType _bcType, const WallData _inputData,
+WallBC::WallBC(RiemannSolver *_rsolver, GasMixture *_mixture, GasMixture *d_mixture, Equations _eqSystem,
+               Fluxes *_fluxClass, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, double &_dt,
+               const int _dim, const int _num_equation, int _patchNumber, WallType _bcType, const WallData _inputData,
                const Array<int> &_intPointsElIDBC, const int &_maxIntPoints, bool axisym)
     : BoundaryCondition(_rsolver, _mixture, _eqSystem, _vfes, _intRules, _dt, _dim, _num_equation, _patchNumber, 1,
                         axisym),  // so far walls do not require ref. length. Left at 1
@@ -424,8 +424,8 @@ void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const Array<int> &no
     // double shape[216];
     // double Rflux[20], u1[20], u2[20], nor[3], gradUpi[20 * 3];
     // double vF1[20 * 3], vF2[20 * 3];
-    MFEM_SHARED double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS]; // MFEM_SHARED double Fcontrib[216 * 5];
-    double Rflux[gpudata::MAXEQUATIONS]; // double Rflux[5];
+    MFEM_SHARED double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS];  // MFEM_SHARED double Fcontrib[216 * 5];
+    double Rflux[gpudata::MAXEQUATIONS];                                    // double Rflux[5];
 
     const int numFaces = d_wallElems[0 + el_wall * 7];
     bool elemDataRecovered = false;
@@ -531,7 +531,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, 
     double u1[gpudata::MAXEQUATIONS], u2[gpudata::MAXEQUATIONS], nor[gpudata::MAXDIM], Rflux[gpudata::MAXEQUATIONS];
     double vF1[gpudata::MAXEQUATIONS * gpudata::MAXDIM],
 #if defined(_CUDA_)
-           vF2[gpudata::MAXEQUATIONS];
+        vF2[gpudata::MAXEQUATIONS];
 #elif defined(_HIP_)
            vF2[gpudata::MAXEQUATIONS * gpudata::MAXDIM];
 #endif
@@ -615,8 +615,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, 
         // add visc flux contribution
         for (int eq = 0; eq < num_equation; eq++) {
           Rflux[eq] -= 0.5 * vF2[eq];
-          for (int d = 0; d < dim; d++)
-            Rflux[eq] -= 0.5 * vF1[eq + d * num_equation] * nor[d];
+          for (int d = 0; d < dim; d++) Rflux[eq] -= 0.5 * vF1[eq + d * num_equation] * nor[d];
         }
 #elif defined(_HIP_)
         // compute mirror state

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -584,7 +584,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, 
             break;
         }
 
-        // evaluate flux
+          // evaluate flux
 #if defined(_CUDA_)
         // TODO(kevin): implement radius.
         d_rsolver->Eval_LF(u1, u2, nor, Rflux);

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -516,9 +516,8 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, 
   const int dim = dim_;
   const int num_equation = num_equation_;
   const int maxIntPoints = maxIntPoints_;
-
-  const BoundaryPrimitiveData *d_bcState = &bcState_;
-  const BoundaryViscousFluxData *d_bcFlux = &bcFlux_;
+  const BoundaryPrimitiveData d_bcState = bcState_;
+  const BoundaryViscousFluxData d_bcFlux = bcFlux_;
 
   const RiemannSolver *d_rsolver = rsolver;
   GasMixture *d_mix = d_mixture_;
@@ -581,22 +580,11 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, 
         }
 
         // fill out the boundary data.
-        for (int eq = 0; eq < gpudata::MAXEQUATIONS; eq++) {
-          bcState.primIdxs[eq] = (*d_bcState).primIdxs[eq];
-          bcState.prim[eq] = (*d_bcState).prim[eq];
-
-          bcFlux.primFluxIdxs[eq] = (*d_bcFlux).primFluxIdxs[eq];
-          bcFlux.primFlux[eq] = (*d_bcFlux).primFlux[eq];
-        }
+        bcState = d_bcState;
+        bcFlux = d_bcFlux;
         for (int d = 0; d < dim; d++) {
           bcFlux.normal[d] = nor[d];
         }
-        printf("bcState: %f (%s) %f (%s) %f (%s) %f (%s) %f (%s)\n",
-               bcState.prim[0], bcState.primIdxs[0],
-               bcState.prim[1], bcState.primIdxs[1],
-               bcState.prim[2], bcState.primIdxs[2],
-               bcState.prim[3], bcState.primIdxs[3],
-               bcState.prim[4], bcState.primIdxs[4],);
 
 // only implemented general wall flux, as it can supersede all the other types.
 // TODO(kevin): implement radius.

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -580,6 +580,24 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, 
           }
         }
 
+        // fill out the boundary data.
+        for (int eq = 0; eq < gpudata::MAXEQUATIONS; eq++) {
+          bcState.primIdxs[eq] = (*d_bcState).primIdxs[eq];
+          bcState.prim[eq] = (*d_bcState).prim[eq];
+
+          bcFlux.primFluxIdxs[eq] = (*d_bcFlux).primFluxIdxs[eq];
+          bcFlux.primFlux[eq] = (*d_bcFlux).primFlux[eq];
+        }
+        for (int d = 0; d < dim; d++) {
+          bcFlux.normal[d] = nor[d];
+        }
+        printf("bcState: %f (%s) %f (%s) %f (%s) %f (%s) %f (%s)\n",
+               bcState.prim[0], bcState.primIdxs[0],
+               bcState.prim[1], bcState.primIdxs[1],
+               bcState.prim[2], bcState.primIdxs[2],
+               bcState.prim[3], bcState.primIdxs[3],
+               bcState.prim[4], bcState.primIdxs[4],);
+
 // only implemented general wall flux, as it can supersede all the other types.
 // TODO(kevin): implement radius.
         // compute mirror state

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -423,8 +423,8 @@ void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const Array<int> &no
     // double shape[216];
     // double Rflux[20], u1[20], u2[20], nor[3], gradUpi[20 * 3];
     // double vF1[20 * 3], vF2[20 * 3];
-    MFEM_SHARED double Fcontrib[216 * 5];
-    double Rflux[5];
+    MFEM_SHARED double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS]; // MFEM_SHARED double Fcontrib[216 * 5];
+    double Rflux[gpudata::MAXEQUATIONS]; // double Rflux[5];
 
     const int numFaces = d_wallElems[0 + el_wall * 7];
     bool elemDataRecovered = false;

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -47,6 +47,7 @@ class WallBC : public BoundaryCondition {
   const WallType wallType_;
   const WallData wallData_;
 
+  GasMixture *d_mixture_;  // only used in the device.
   Fluxes *fluxClass;
 
   // TODO(kevin): eventually replace this with wallPrim.
@@ -70,7 +71,7 @@ class WallBC : public BoundaryCondition {
   void computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector &bdrFlux);
 
  public:
-  WallBC(RiemannSolver *rsolver_, GasMixture *_mixture, Equations _eqSystem, Fluxes *_fluxClass,
+  WallBC(RiemannSolver *rsolver_, GasMixture *_mixture, GasMixture *d_mixture, Equations _eqSystem, Fluxes *_fluxClass,
          ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, double &_dt, const int _dim,
          const int _num_equation, int _patchNumber, WallType _bcType, const WallData _inputData,
          const Array<int> &intPointsElIDBC, const int &maxIntPoints, bool axisym);

--- a/test/cyl3d.gpu.test
+++ b/test/cyl3d.gpu.test
@@ -26,7 +26,7 @@ setup() {
 
 @test "[$TEST] run tps with input -> $RUNFILE" {
     rm -f $SOLN_FILE
-    ../src/tps --runFile $RUNFILE
+    ../src/tps --runFile $RUNFILE &> run.log
 
     test -s $SOLN_FILE
 }

--- a/test/test_boundary_flux.cpp
+++ b/test/test_boundary_flux.cpp
@@ -133,10 +133,10 @@ bool testComputeBdrViscousFlux(RunConfiguration &srcConfig, const int dim) {
 
   grvy_printf(GRVY_INFO, "\n ComputeBdrViscousFluxes. \n");
   BoundaryViscousFluxData bcFlux;
-  bcFlux.normal = dir;
-  bcFlux.primFlux.SetSize(primFluxSize);
-  bcFlux.primFluxIdxs.SetSize(primFluxSize);
-  bcFlux.primFlux = 0.0;
+  for (int d = 0; d < dim; d++) bcFlux.normal[d] = dir[d];
+  // bcFlux.primFlux.SetSize(primFluxSize);
+  // bcFlux.primFluxIdxs.SetSize(primFluxSize);
+  for (int i = 0; i < primFluxSize; i++) bcFlux.primFlux[i] = 0.0;
   for (int i = 0; i < primFluxSize; i++) bcFlux.primFluxIdxs[i] = false;
 
   Vector wallViscF(num_equation);


### PR DESCRIPTION
This PR comes after PR #146 .

- `_CUDA_` path is now gas-agnostic, not depending on `DryAir`.
- All the existing gpu routines on `_CUDA_` path now use device `GasMixture`, `TransportProperties`, `Fluxes` and `RiemannSolver`.
- All derived classes of `BoundaryCondition` remain in the host, not being instantiated in the device. In order to minimize the instantiation in the device and corresponding development time, their functions are duplicated in their own `interp***_gpu` functions, instead of a `MFEM_HOST_DEVICE` counterpart.
- For `WallBC`, only `computeGeneralWallFlux` is translated into gpu path, as it can replace all the other wall types.
- Any arrays defined in the device are now defined with the compile-time constant integer, stored in the namespace `gpudata` in `src/dataStructures.hpp`.

Known limitations
- Due to the issue #145 , `_HIP_` path remains unsupported for plasma.
- In some places for `ComputeViscousFluxes` and `ComputeBdrViscousFluxes`, `radius` is not implemented and thus axisymmetric case is not yet supported in gpu. These places are marked with the comment `// TODO(kevin): implement radius.`.
- This PR does not extend gpu capability for plasma `GasMixture` and `TransportProperties`, such as:
  - `PerfectMixture`
  - `ConstantTransport`
  - `ArgonMinimalTransport` and `ArgonMixtureTransport`
- This PR refactored the existing gpu routines only. The components that require a new gpu routine are:
  - `ConstantPressureGradient`
  - `AxisymmetricSource`
  - `SourceTerm`
  - `MASA_forcings`?
and all the associated classes.
- `InletBC` and `OutletBC` have a limited gpu capability, only for `subsonicReflectingDensityVelocity` and `subsonicReflectingPressure`, respectively. Other BC types are not yet supported (in fact both for cpu and gpu).