### PR TITLE
`MFEM_HOST_DEVICE` ArgonMixtureTransport

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -307,7 +307,14 @@ void M2ulPhyS::initVariables() {
       }
       switch (config.GetTranportModel()) {
         case ARGON_MINIMAL:
+#if defined(_CUDA_)
+          gpu::instantiateDeviceArgonMinimalTransport<<<1, 1>>>(d_mixture, config.argonTransportInput, d_transport_tmp);
+          cudaMemcpy(&transportPtr, d_transport_tmp, sizeof(TransportProperties *), cudaMemcpyDeviceToHost);
+#elif defined(_HIP_)
+          mfem_error("ArgonMinimalTransport is not supported for HIP!");
+#else
           transportPtr = new ArgonMinimalTransport(mixture, config);
+#endif
           break;
         case ARGON_MIXTURE:
           transportPtr = new ArgonMixtureTransport(mixture, config);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -2270,6 +2270,8 @@ void M2ulPhyS::parseTransportInputs() {
           grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'E' !\n");
           exit(ERROR);
         }
+
+        config.argonTransportInput.thirdOrderkElectron = config.thirdOrderkElectron;
       }
     } break;
     case ARGON_MIXTURE: {
@@ -2284,6 +2286,8 @@ void M2ulPhyS::parseTransportInputs() {
           grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'E' !\n");
           exit(ERROR);
         }
+
+        config.argonTransportInput.thirdOrderkElectron = config.thirdOrderkElectron;
       }
     } break;
     case CONSTANT: {

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -317,7 +317,14 @@ void M2ulPhyS::initVariables() {
 #endif
           break;
         case ARGON_MIXTURE:
+#if defined(_CUDA_)
+          gpu::instantiateDeviceArgonMixtureTransport<<<1, 1>>>(d_mixture, config.argonTransportInput, d_transport_tmp);
+          cudaMemcpy(&transportPtr, d_transport_tmp, sizeof(TransportProperties *), cudaMemcpyDeviceToHost);
+#elif defined(_HIP_)
+          mfem_error("ArgonMixtureTransport is not supported for HIP!");
+#else
           transportPtr = new ArgonMixtureTransport(mixture, config);
+#endif
           break;
         case CONSTANT:
 #if defined(_CUDA_)

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -2814,7 +2814,7 @@ void M2ulPhyS::packUpGasMixtureInput() {
 void M2ulPhyS::identifySpeciesType(Array<ArgonSpcs> &speciesType) {
   speciesType.SetSize(config.numSpecies);
 
-  for (int sp = 0; sp < numSpecies; sp++) {
+  for (int sp = 0; sp < config.numSpecies; sp++) {
     speciesType[sp] = NONE_ARGSPCS;
 
     Vector spComp(config.numAtoms);
@@ -2890,8 +2890,8 @@ void M2ulPhyS::identifyCollisionType(const Array<ArgonSpcs> &speciesType, ArgonC
       // If not initialized, will raise an error.
       collisionIndex[spI + spJ * config.numSpecies] = NONE_ARGCOLL;
 
-      const double pairType = mixture->GetGasParams(spI, GasParams::SPECIES_CHARGES) *
-                              mixture->GetGasParams(spJ, GasParams::SPECIES_CHARGES);
+      const double pairType = config.gasParams(spI, GasParams::SPECIES_CHARGES) *
+                              config.gasParams(spJ, GasParams::SPECIES_CHARGES);
       if (pairType > 0.0) {  // Repulsive screened Coulomb potential
         collisionIndex[spI + spJ * config.numSpecies] = CLMB_REP;
       } else if (pairType < 0.0) {  // Attractive screened Coulomb potential

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -2890,8 +2890,8 @@ void M2ulPhyS::identifyCollisionType(const Array<ArgonSpcs> &speciesType, ArgonC
       // If not initialized, will raise an error.
       collisionIndex[spI + spJ * config.numSpecies] = NONE_ARGCOLL;
 
-      const double pairType = config.gasParams(spI, GasParams::SPECIES_CHARGES) *
-                              config.gasParams(spJ, GasParams::SPECIES_CHARGES);
+      const double pairType =
+          config.gasParams(spI, GasParams::SPECIES_CHARGES) * config.gasParams(spJ, GasParams::SPECIES_CHARGES);
       if (pairType > 0.0) {  // Repulsive screened Coulomb potential
         collisionIndex[spI + spJ * config.numSpecies] = CLMB_REP;
       } else if (pairType < 0.0) {  // Attractive screened Coulomb potential

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -360,6 +360,8 @@ class M2ulPhyS : public TPS::Solver {
   void parseSpongeZoneInputs();
 
   void packUpGasMixtureInput();
+  void identifySpeciesType(Array<ArgonSpcs> &speciesType);
+  void identifyCollisionType(const Array<ArgonSpcs> &speciesType, ArgonColl *collisionIndex);
 
   void checkSolverOptions() const;
   void projectInitialSolution();

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -839,9 +839,9 @@ ArgonMixtureTransport::ArgonMixtureTransport(GasMixture *_mixture, RunConfigurat
 
 MFEM_HOST_DEVICE ArgonMixtureTransport::ArgonMixtureTransport(GasMixture *_mixture, const ArgonTransportInput &inputs)
     : ArgonMinimalTransport(_mixture) {
-      // numAtoms_(_runfile.numAtoms),
-      // atomMap_(_runfile.atomMap),
-      // speciesNames_(_runfile.speciesNames) {
+  // numAtoms_(_runfile.numAtoms),
+  // atomMap_(_runfile.atomMap),
+  // speciesNames_(_runfile.speciesNames) {
   // std::map<std::string, int> *speciesMapping = mixture->getSpeciesMapping();
   // if (speciesMapping->count("E")) {
   //   electronIndex_ = (*speciesMapping)["E"];
@@ -887,8 +887,8 @@ MFEM_HOST_DEVICE ArgonMixtureTransport::ArgonMixtureTransport(GasMixture *_mixtu
       collisionIndex_[spI + spJ * numSpecies] = inputs.collisionIndex[spI + spJ * numSpecies];
 }
 
-MFEM_HOST_DEVICE double ArgonMixtureTransport::collisionIntegral(const int _spI, const int _spJ, const int l, const int r,
-                                                                 const collisionInputs collInputs) {
+MFEM_HOST_DEVICE double ArgonMixtureTransport::collisionIntegral(const int _spI, const int _spJ, const int l,
+                                                                 const int r, const collisionInputs collInputs) {
   const int spI = (_spI > _spJ) ? _spJ : _spI;
   const int spJ = (_spI > _spJ) ? _spI : _spJ;
 
@@ -920,8 +920,10 @@ MFEM_HOST_DEVICE double ArgonMixtureTransport::collisionIntegral(const int _spI,
             return collInputs.debyeCircle * collision::charged::att15(temp);
             break;
           default:
-            printf("(%d, %d)-collision integral for attractive Coulomb potential is not supported in "
-                   "ArgonMixtureTransport! \n", l, r);
+            printf(
+                "(%d, %d)-collision integral for attractive Coulomb potential is not supported in "
+                "ArgonMixtureTransport! \n",
+                l, r);
             assert(false);
             break;
         }
@@ -937,8 +939,10 @@ MFEM_HOST_DEVICE double ArgonMixtureTransport::collisionIntegral(const int _spI,
             return collInputs.debyeCircle * collision::charged::att24(temp);
             break;
           default:
-            printf("(%d, %d)-collision integral for attractive Coulomb potential is not supported in "
-                   "ArgonMixtureTransport! \n", l, r);
+            printf(
+                "(%d, %d)-collision integral for attractive Coulomb potential is not supported in "
+                "ArgonMixtureTransport! \n",
+                l, r);
             assert(false);
             break;
         }
@@ -963,8 +967,10 @@ MFEM_HOST_DEVICE double ArgonMixtureTransport::collisionIntegral(const int _spI,
             return collInputs.debyeCircle * collision::charged::rep15(temp);
             break;
           default:
-            printf("(%d, %d)-collision integral for repulsive Coulomb potential is not supported in "
-                   "ArgonMixtureTransport! \n", l, r);
+            printf(
+                "(%d, %d)-collision integral for repulsive Coulomb potential is not supported in "
+                "ArgonMixtureTransport! \n",
+                l, r);
             assert(false);
             break;
         }
@@ -980,8 +986,10 @@ MFEM_HOST_DEVICE double ArgonMixtureTransport::collisionIntegral(const int _spI,
             return collInputs.debyeCircle * collision::charged::rep24(temp);
             break;
           default:
-            printf("(%d, %d)-collision integral for repulsive Coulomb potential is not supported in "
-                   "ArgonMixtureTransport! \n", l, r);
+            printf(
+                "(%d, %d)-collision integral for repulsive Coulomb potential is not supported in "
+                "ArgonMixtureTransport! \n",
+                l, r);
             assert(false);
             break;
         }
@@ -1014,8 +1022,10 @@ MFEM_HOST_DEVICE double ArgonMixtureTransport::collisionIntegral(const int _spI,
             return collision::argon::eAr15(temp);
             break;
           default:
-            printf("(%d, %d)-collision integral for repulsive Coulomb potential is not supported in "
-                   "ArgonMixtureTransport! \n", l, r);
+            printf(
+                "(%d, %d)-collision integral for repulsive Coulomb potential is not supported in "
+                "ArgonMixtureTransport! \n",
+                l, r);
             assert(false);
             break;
         }
@@ -1088,7 +1098,8 @@ void ArgonMixtureTransport::ComputeFluxTransportProperties(const Vector &state, 
   //   for (int spJ = spI + 1; spJ < numSpecies; spJ++) {
   //     double temp = ((spI == electronIndex_) || (spJ == electronIndex_)) ? collInputs.Te : collInputs.Th;
   //     binaryDiff(spI, spJ) =
-  //         diffusivityFactor_ * sqrt(temp / getMuw(spI, spJ)) / nTotal / collisionIntegral(spI, spJ, 1, 1, collInputs);
+  //         diffusivityFactor_ * sqrt(temp / getMuw(spI, spJ)) / nTotal / collisionIntegral(spI, spJ, 1, 1,
+  //         collInputs);
   //     binaryDiff(spJ, spI) = binaryDiff(spI, spJ);
   //   }
   // }
@@ -1135,7 +1146,8 @@ void ArgonMixtureTransport::ComputeFluxTransportProperties(const Vector &state, 
 }
 
 MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                                            const double *Efield, double *transportBuffer,
+                                                                            const double *Efield,
+                                                                            double *transportBuffer,
                                                                             double *diffusionVelocity) {
   for (int p = 0; p < FluxTrns::NUM_FLUX_TRANS; p++) transportBuffer[p] = 0.0;
 
@@ -1219,7 +1231,8 @@ MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeFluxTransportProperties(cons
   for (int sp = 0; sp < numActiveSpecies; sp++) {
     double speciesSpeed = 0.0;
     // azimuthal component does not participate in flux.
-    for (int d = 0; d < dim; d++) speciesSpeed += diffusionVelocity[sp + d * numSpecies] * diffusionVelocity[sp + d * numSpecies];
+    for (int d = 0; d < dim; d++)
+      speciesSpeed += diffusionVelocity[sp + d * numSpecies] * diffusionVelocity[sp + d * numSpecies];
     speciesSpeed = sqrt(speciesSpeed);
     if (speciesSpeed > charSpeed) charSpeed = speciesSpeed;
     // charSpeed = max(charSpeed, speciesSpeed);
@@ -1227,8 +1240,8 @@ MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeFluxTransportProperties(cons
   // std::cout << "max diff. vel: " << charSpeed << std::endl;
 }
 
-MFEM_HOST_DEVICE double ArgonMixtureTransport::computeThirdOrderElectronThermalConductivity(const double *X_sp,
-                                                                                            const collisionInputs &collInputs) {
+MFEM_HOST_DEVICE double ArgonMixtureTransport::computeThirdOrderElectronThermalConductivity(
+    const double *X_sp, const collisionInputs &collInputs) {
   double Q2[3];
   for (int r = 0; r < 3; r++) Q2[r] = collisionIntegral(electronIndex_, electronIndex_, 2, r + 2, collInputs);
 
@@ -1256,7 +1269,8 @@ void ArgonMixtureTransport::ComputeSourceTransportProperties(const Vector &state
   speciesTransport.SetSize(numSpecies, SpeciesTrns::NUM_SPECIES_COEFFS);
   diffusionVelocity.SetSize(numSpecies, nvel_);
   n_sp.SetSize(numSpecies);
-  ComputeSourceTransportProperties(&state[0], &Up[0], gradUp.Read(), &Efield[0], &globalTransport[0], speciesTransport.Write(), diffusionVelocity.Write(), &n_sp[0]);
+  ComputeSourceTransportProperties(&state[0], &Up[0], gradUp.Read(), &Efield[0], &globalTransport[0],
+                                   speciesTransport.Write(), diffusionVelocity.Write(), &n_sp[0]);
   // globalTransport = 0.0;
   // speciesTransport.SetSize(numSpecies, SpeciesTrns::NUM_SPECIES_COEFFS);
   // speciesTransport = 0.0;
@@ -1276,7 +1290,8 @@ void ArgonMixtureTransport::ComputeSourceTransportProperties(const Vector &state
   //     double temp = ((spI == electronIndex_) || (spJ == electronIndex_)) ? collInputs.Te : collInputs.Th;
   //
   //     binaryDiff(spI, spJ) =
-  //         diffusivityFactor_ * sqrt(temp / getMuw(spI, spJ)) / nTotal / collisionIntegral(spI, spJ, 1, 1, collInputs);
+  //         diffusivityFactor_ * sqrt(temp / getMuw(spI, spJ)) / nTotal / collisionIntegral(spI, spJ, 1, 1,
+  //         collInputs);
   //     binaryDiff(spJ, spI) = binaryDiff(spI, spJ);
   //   }
   // }
@@ -1332,10 +1347,9 @@ void ArgonMixtureTransport::ComputeSourceTransportProperties(const Vector &state
   // // std::cout << "max diff. vel: " << charSpeed << std::endl;
 }
 
-MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeSourceTransportProperties(const double *state, const double *Up,
-                                                                              const double *gradUp, const double *Efield,
-                                                                              double *globalTransport, double *speciesTransport,
-                                                                              double *diffusionVelocity, double *n_sp) {
+MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeSourceTransportProperties(
+    const double *state, const double *Up, const double *gradUp, const double *Efield, double *globalTransport,
+    double *speciesTransport, double *diffusionVelocity, double *n_sp) {
   for (int p = 0; p < SrcTrns::NUM_SRC_TRANS; p++) globalTransport[p] = 0.0;
   for (int p = 0; p < SpeciesTrns::NUM_SPECIES_COEFFS; p++)
     for (int sp = 0; sp < numSpecies; sp++) speciesTransport[sp + p * numSpecies] = 0.0;
@@ -1393,16 +1407,17 @@ MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeSourceTransportProperties(co
   // NOTE(kevin): collision integrals could be reused from diffusivities.. but not done that way at this point.
   for (int sp = 0; sp < numSpecies; sp++) {
     if (sp == electronIndex_) continue;
-    speciesTransport[sp + SpeciesTrns::MF_FREQUENCY * numSpecies] = mfFreqFactor_ * sqrt(collInputs.Te / mw_[electronIndex_]) *
-                                                      n_sp[sp] *
-                                                      collisionIntegral(sp, electronIndex_, 1, 1, collInputs);
+    speciesTransport[sp + SpeciesTrns::MF_FREQUENCY * numSpecies] =
+        mfFreqFactor_ * sqrt(collInputs.Te / mw_[electronIndex_]) * n_sp[sp] *
+        collisionIntegral(sp, electronIndex_, 1, 1, collInputs);
   }
 
   double charSpeed = 0.0;
   for (int sp = 0; sp < numActiveSpecies; sp++) {
     double speciesSpeed = 0.0;
     // azimuthal component does not participate in flux.
-    for (int d = 0; d < dim; d++) speciesSpeed += diffusionVelocity[sp + d * numSpecies] * diffusionVelocity[sp + d * numSpecies];
+    for (int d = 0; d < dim; d++)
+      speciesSpeed += diffusionVelocity[sp + d * numSpecies] * diffusionVelocity[sp + d * numSpecies];
     speciesSpeed = sqrt(speciesSpeed);
     if (speciesSpeed > charSpeed) charSpeed = speciesSpeed;
     // charSpeed = max(charSpeed, speciesSpeed);
@@ -1435,8 +1450,8 @@ void ArgonMixtureTransport::GetViscosities(const Vector &conserved, const Vector
   return;
 }
 
-MFEM_HOST_DEVICE void ArgonMixtureTransport::GetViscosities(const double *conserved, const double *primitive, double &visc,
-                                                            double &bulkVisc) {
+MFEM_HOST_DEVICE void ArgonMixtureTransport::GetViscosities(const double *conserved, const double *primitive,
+                                                            double &visc, double &bulkVisc) {
   double n_sp[gpudata::MAXSPECIES], X_sp[gpudata::MAXSPECIES], Y_sp[gpudata::MAXSPECIES];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
   double nTotal = 0.0;

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -90,7 +90,7 @@ ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixture, RunConfigurat
   mw_[ionIndex_] = mixture->GetGasParams(ionIndex_, GasParams::SPECIES_MW);
   // assumes input mass is consistent with this.
   assert(abs(mw_[neutralIndex_] - mw_[electronIndex_] - mw_[ionIndex_]) < 1.0e-15);
-  mw_ /= AVOGADRONUMBER;
+  for (int sp = 0; sp < numSpecies; sp++) mw_[sp] /= AVOGADRONUMBER;
   // mA_ /= AVOGADRONUMBER;
   // mI_ /= AVOGADRONUMBER;
 
@@ -489,7 +489,7 @@ ArgonMixtureTransport::ArgonMixtureTransport(GasMixture *_mixture, RunConfigurat
   // multiplying/dividing big numbers are risky of losing precision.
   // mw_.SetSize(numSpecies);
   for (int sp = 0; sp < numSpecies; sp++) mw_[sp] = mixture->GetGasParams(sp, GasParams::SPECIES_MW);
-  mw_ /= AVOGADRONUMBER;
+  for (int sp = 0; sp < numSpecies; sp++) mw_[sp] /= AVOGADRONUMBER;
 
   // muw_.SetSize(numSpecies);
   computeEffectiveMass(mw_, muw_);

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -837,7 +837,7 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::GetViscosities(const double *conser
 ArgonMixtureTransport::ArgonMixtureTransport(GasMixture *_mixture, RunConfiguration &_runfile)
     : ArgonMixtureTransport(_mixture, _runfile.argonTransportInput) {}
 
-ArgonMixtureTransport::ArgonMixtureTransport(GasMixture *_mixture, const ArgonTransportInput &inputs)
+MFEM_HOST_DEVICE ArgonMixtureTransport::ArgonMixtureTransport(GasMixture *_mixture, const ArgonTransportInput &inputs)
     : ArgonMinimalTransport(_mixture) {
       // numAtoms_(_runfile.numAtoms),
       // atomMap_(_runfile.atomMap),
@@ -851,8 +851,10 @@ ArgonMixtureTransport::ArgonMixtureTransport(GasMixture *_mixture, const ArgonTr
   // }
   electronIndex_ = inputs.electronIndex;
   if (electronIndex_ < 0) {
-    grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'E' !\n");
-    exit(ERROR);
+    // grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'E' !\n");
+    // exit(ERROR);
+    printf("\nArgon ternary transport requires the species 'E' !\n");
+    assert(false);
   }
 
   // composition_.SetSize(numSpecies, numAtoms_);

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -660,27 +660,58 @@ void ArgonMinimalTransport::ComputeSourceTransportProperties(const Vector &state
 
 void ArgonMinimalTransport::GetViscosities(const Vector &conserved, const Vector &primitive, double &visc,
                                            double &bulkVisc) {
-  Vector n_sp(3), X_sp(3), Y_sp(3);
+  GetViscosities(&conserved[0], &primitive[0], visc, bulkVisc);
+  // Vector n_sp(3), X_sp(3), Y_sp(3);
+  // mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
+  // double nTotal = 0.0;
+  // for (int sp = 0; sp < numSpecies; sp++) nTotal += n_sp(sp);
+  //
+  // double Te = (twoTemperature_) ? primitive[num_equation - 1] : primitive[nvel_ + 1];
+  // double Th = primitive[nvel_ + 1];
+  //
+  // // Add Xeps to avoid zero number density case.
+  // double nOverT = (n_sp(electronIndex_) + Xeps_) / Te + (n_sp(ionIndex_) + Xeps_) / Th;
+  // double debyeLength = sqrt(debyeFactor_ / AVOGADRONUMBER / nOverT);
+  // double debyeCircle = PI_ * debyeLength * debyeLength;
+  //
+  // // double nondimTe = debyeLength * 4.0 * PI_ * debyeFactor_ * Te;
+  // double nondimTh = debyeLength * 4.0 * PI_ * debyeFactor_ * Th;
+  //
+  // Vector speciesViscosity(3);
+  // speciesViscosity(ionIndex_) =
+  //     viscosityFactor_ * sqrt(mw_[ionIndex_] * Th) / (collision::charged::rep22(nondimTh) * debyeCircle);
+  // speciesViscosity(neutralIndex_) = viscosityFactor_ * sqrt(mw_[neutralIndex_] * Th) / collision::argon::ArAr22(Th);
+  // speciesViscosity(electronIndex_) = 0.0;
+  //
+  // visc = linearAverage(X_sp, speciesViscosity);
+  // bulkVisc = 0.0;
+
+  return;
+}
+
+MFEM_HOST_DEVICE void ArgonMinimalTransport::GetViscosities(const double *conserved, const double *primitive, double &visc,
+                                                            double &bulkVisc) {
+  double n_sp[3], X_sp[3], Y_sp[3];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
   double nTotal = 0.0;
-  for (int sp = 0; sp < numSpecies; sp++) nTotal += n_sp(sp);
+  for (int sp = 0; sp < numSpecies; sp++) nTotal += n_sp[sp];
 
   double Te = (twoTemperature_) ? primitive[num_equation - 1] : primitive[nvel_ + 1];
   double Th = primitive[nvel_ + 1];
 
   // Add Xeps to avoid zero number density case.
-  double nOverT = (n_sp(electronIndex_) + Xeps_) / Te + (n_sp(ionIndex_) + Xeps_) / Th;
+  double nOverT = (n_sp[electronIndex_] + Xeps_) / Te + (n_sp[ionIndex_] + Xeps_) / Th;
   double debyeLength = sqrt(debyeFactor_ / AVOGADRONUMBER / nOverT);
   double debyeCircle = PI_ * debyeLength * debyeLength;
 
   // double nondimTe = debyeLength * 4.0 * PI_ * debyeFactor_ * Te;
   double nondimTh = debyeLength * 4.0 * PI_ * debyeFactor_ * Th;
 
-  Vector speciesViscosity(3);
-  speciesViscosity(ionIndex_) =
+  double speciesViscosity[3];
+  speciesViscosity[ionIndex_] =
       viscosityFactor_ * sqrt(mw_[ionIndex_] * Th) / (collision::charged::rep22(nondimTh) * debyeCircle);
-  speciesViscosity(neutralIndex_) = viscosityFactor_ * sqrt(mw_[neutralIndex_] * Th) / collision::argon::ArAr22(Th);
-  speciesViscosity(electronIndex_) = 0.0;
+  speciesViscosity[neutralIndex_] = viscosityFactor_ * sqrt(mw_[neutralIndex_] * Th) / collision::argon::ArAr22(Th);
+  speciesViscosity[electronIndex_] = 0.0;
 
   visc = linearAverage(X_sp, speciesViscosity);
   bulkVisc = 0.0;

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -887,8 +887,8 @@ MFEM_HOST_DEVICE ArgonMixtureTransport::ArgonMixtureTransport(GasMixture *_mixtu
       collisionIndex_[spI + spJ * numSpecies] = inputs.collisionIndex[spI + spJ * numSpecies];
 }
 
-double ArgonMixtureTransport::collisionIntegral(const int _spI, const int _spJ, const int l, const int r,
-                                                const collisionInputs collInputs) {
+MFEM_HOST_DEVICE double ArgonMixtureTransport::collisionIntegral(const int _spI, const int _spJ, const int l, const int r,
+                                                                 const collisionInputs collInputs) {
   const int spI = (_spI > _spJ) ? _spJ : _spI;
   const int spJ = (_spI > _spJ) ? _spI : _spJ;
 
@@ -920,11 +920,9 @@ double ArgonMixtureTransport::collisionIntegral(const int _spI, const int _spJ, 
             return collInputs.debyeCircle * collision::charged::att15(temp);
             break;
           default:
-            grvy_printf(GRVY_ERROR,
-                        "(%d, %d)-collision integral for attractive Coulomb potential is not supported in "
-                        "ArgonMixtureTransport! \n",
-                        l, r);
-            exit(-1);
+            printf("(%d, %d)-collision integral for attractive Coulomb potential is not supported in "
+                   "ArgonMixtureTransport! \n", l, r);
+            assert(false);
             break;
         }
       } else if (l == 2) {
@@ -939,11 +937,9 @@ double ArgonMixtureTransport::collisionIntegral(const int _spI, const int _spJ, 
             return collInputs.debyeCircle * collision::charged::att24(temp);
             break;
           default:
-            grvy_printf(GRVY_ERROR,
-                        "(%d, %d)-collision integral for attractive Coulomb potential is not supported in "
-                        "ArgonMixtureTransport! \n",
-                        l, r);
-            exit(-1);
+            printf("(%d, %d)-collision integral for attractive Coulomb potential is not supported in "
+                   "ArgonMixtureTransport! \n", l, r);
+            assert(false);
             break;
         }
       }
@@ -967,11 +963,9 @@ double ArgonMixtureTransport::collisionIntegral(const int _spI, const int _spJ, 
             return collInputs.debyeCircle * collision::charged::rep15(temp);
             break;
           default:
-            grvy_printf(GRVY_ERROR,
-                        "(%d, %d)-collision integral for repulsive Coulomb potential is not supported in "
-                        "ArgonMixtureTransport! \n",
-                        l, r);
-            exit(-1);
+            printf("(%d, %d)-collision integral for repulsive Coulomb potential is not supported in "
+                   "ArgonMixtureTransport! \n", l, r);
+            assert(false);
             break;
         }
       } else if (l == 2) {
@@ -986,11 +980,9 @@ double ArgonMixtureTransport::collisionIntegral(const int _spI, const int _spJ, 
             return collInputs.debyeCircle * collision::charged::rep24(temp);
             break;
           default:
-            grvy_printf(GRVY_ERROR,
-                        "(%d, %d)-collision integral for repulsive Coulomb potential is not supported in "
-                        "ArgonMixtureTransport! \n",
-                        l, r);
-            exit(-1);
+            printf("(%d, %d)-collision integral for repulsive Coulomb potential is not supported in "
+                   "ArgonMixtureTransport! \n", l, r);
+            assert(false);
             break;
         }
       }
@@ -999,10 +991,8 @@ double ArgonMixtureTransport::collisionIntegral(const int _spI, const int _spJ, 
       if ((l == 1) && (r == 1)) {
         return collision::argon::ArAr1P11(temp);
       } else {
-        grvy_printf(GRVY_ERROR,
-                    "(%d, %d)-collision integral for Ar-Ar.1+ pair is not supported in ArgonMixtureTransport! \n", l,
-                    r);
-        exit(-1);
+        printf("(%d, %d)-collision integral for Ar-Ar.1+ pair is not supported in ArgonMixtureTransport! \n", l, r);
+        assert(false);
       }
     } break;
     case AR_E: {
@@ -1024,17 +1014,14 @@ double ArgonMixtureTransport::collisionIntegral(const int _spI, const int _spJ, 
             return collision::argon::eAr15(temp);
             break;
           default:
-            grvy_printf(GRVY_ERROR,
-                        "(%d, %d)-collision integral for repulsive Coulomb potential is not supported in "
-                        "ArgonMixtureTransport! \n",
-                        l, r);
-            exit(-1);
+            printf("(%d, %d)-collision integral for repulsive Coulomb potential is not supported in "
+                   "ArgonMixtureTransport! \n", l, r);
+            assert(false);
             break;
         }
       } else {
-        grvy_printf(GRVY_ERROR,
-                    "(%d, %d)-collision integral for Ar-E pair is not supported in ArgonMixtureTransport! \n", l, r);
-        exit(-1);
+        printf("(%d, %d)-collision integral for Ar-E pair is not supported in ArgonMixtureTransport! \n", l, r);
+        assert(false);
       }
     } break;
     case AR_AR: {
@@ -1043,9 +1030,8 @@ double ArgonMixtureTransport::collisionIntegral(const int _spI, const int _spJ, 
       } else if ((l == 2) && (r == 2)) {
         return collision::argon::ArAr22(temp);
       } else {
-        grvy_printf(GRVY_ERROR,
-                    "(%d, %d)-collision integral for Ar-Ar pair is not supported in ArgonMixtureTransport! \n", l, r);
-        exit(-1);
+        printf("(%d, %d)-collision integral for Ar-Ar pair is not supported in ArgonMixtureTransport! \n", l, r);
+        assert(false);
       }
     } break;
     default:

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -1366,7 +1366,7 @@ MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeSourceTransportProperties(co
     double temp = (sp == electronIndex_) ? collInputs.Te : collInputs.Th;
     mobility[sp] = qeOverkB_ * mixture->GetGasParams(sp, GasParams::SPECIES_CHARGES) / temp * diffusivity[sp];
   }
-  globalTransport(SrcTrns::ELECTRIC_CONDUCTIVITY) =
+  globalTransport[SrcTrns::ELECTRIC_CONDUCTIVITY] =
       computeMixtureElectricConductivity(mobility, n_sp) * MOLARELECTRONCHARGE;
 
   double gradX[gpudata::MAXSPECIES * gpudata::MAXDIM];

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -975,16 +975,16 @@ double ArgonMixtureTransport::computeThirdOrderElectronThermalConductivity(const
   Vector Q2(3);
   for (int r = 0; r < 3; r++) Q2(r) = collisionIntegral(electronIndex_, electronIndex_, 2, r + 2, collInputs);
 
-  double L11 = sqrt(2.0) * X_sp(electronIndex_) * L11ee(Q2);
-  double L12 = sqrt(2.0) * X_sp(electronIndex_) * L12ee(Q2);
-  double L22 = sqrt(2.0) * X_sp(electronIndex_) * L22ee(Q2);
+  double L11 = sqrt(2.0) * X_sp(electronIndex_) * L11ee(&Q2[0]);
+  double L12 = sqrt(2.0) * X_sp(electronIndex_) * L12ee(&Q2[0]);
+  double L22 = sqrt(2.0) * X_sp(electronIndex_) * L22ee(&Q2[0]);
   for (int sp = 0; sp < numSpecies; sp++) {
     if (sp == electronIndex_) continue;
     Vector Q1(5);
     for (int r = 0; r < 5; r++) Q1(r) = collisionIntegral(sp, electronIndex_, 1, r + 1, collInputs);
-    L11 += X_sp(sp) * L11ea(Q1);
-    L12 += X_sp(sp) * L12ea(Q1);
-    L22 += X_sp(sp) * L22ea(Q1);
+    L11 += X_sp(sp) * L11ea(&Q1[0]);
+    L12 += X_sp(sp) * L12ea(&Q1[0]);
+    L22 += X_sp(sp) * L22ea(&Q1[0]);
   }
 
   return viscosityFactor_ * kOverEtaFactor_ * sqrt(2.0 * collInputs.Te / mw_[electronIndex_]) * X_sp(electronIndex_) /

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -1132,9 +1132,9 @@ void ArgonMixtureTransport::ComputeFluxTransportProperties(const Vector &state, 
   // std::cout << "max diff. vel: " << charSpeed << std::endl;
 }
 
-MFEM_HOST_DEVICE virtual void ArgonMixtureTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                                                    const double *Efield, double *transportBuffer,
-                                                                                    double *diffusionVelocity) {
+MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
+                                                                            const double *Efield, double *transportBuffer,
+                                                                            double *diffusionVelocity) {
   for (int p = 0; p < FluxTrns::NUM_FLUX_TRANS; p++) transportBuffer[p] = 0.0;
 
   double primitiveState[gpudata::MAXEQUATIONS];
@@ -1172,7 +1172,7 @@ MFEM_HOST_DEVICE virtual void ArgonMixtureTransport::ComputeFluxTransportPropert
   }
 
   double binaryDiff[gpudata::MAXSPECIES * gpudata::MAXSPECIES];
-  binaryDiff = 0.0;
+  // binaryDiff = 0.0;
   for (int spI = 0; spI < numSpecies - 1; spI++) {
     for (int spJ = spI + 1; spJ < numSpecies; spJ++) {
       double temp = ((spI == electronIndex_) || (spJ == electronIndex_)) ? collInputs.Te : collInputs.Th;

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -169,7 +169,7 @@ MFEM_HOST_DEVICE ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixtu
   thirdOrderkElectron_ = inputs.thirdOrderkElectron;
 }
 
-ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixture) : TransportProperties(_mixture) {}
+MFEM_HOST_DEVICE ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixture) : TransportProperties(_mixture) {}
 
 // void ArgonMinimalTransport::computeEffectiveMass(const Vector &mw, DenseSymmetricMatrix &muw) {
 MFEM_HOST_DEVICE void ArgonMinimalTransport::computeEffectiveMass(const double *mw, double *muw) {

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -37,14 +37,81 @@
 //////////////////////////////////////////////////////
 
 ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixture, RunConfiguration &_runfile)
+    : ArgonMinimalTransport(_mixture, _runfile.argonTransportInput) {}
+//     : TransportProperties(_mixture) {
+//   // if (!ambipolar) {
+//   //   grvy_printf(GRVY_ERROR, "\nArgon ternary transport currently supports ambipolar condition only. Set
+//   //   plasma_models/ambipolar = true.\n"); exit(ERROR);
+//   // }
+//   if (numSpecies != 3) {
+//     grvy_printf(GRVY_ERROR, "\nArgon ternary transport only supports ternary mixture of Ar, Ar.+1, and E !\n");
+//     exit(ERROR);
+//   }
+//
+//   // std::map<std::string, int> *speciesMapping = mixture->getSpeciesMapping();
+//   // if (speciesMapping->count("Ar")) {
+//   //   neutralIndex_ = (*speciesMapping)["Ar"];
+//   // } else {
+//   //   grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'Ar' !\n");
+//   //   exit(ERROR);
+//   // }
+//   // if (speciesMapping->count("Ar.+1")) {
+//   //   ionIndex_ = (*speciesMapping)["Ar.+1"];
+//   // } else {
+//   //   grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'Ar.+1' !\n");
+//   //   exit(ERROR);
+//   // }
+//   // if (speciesMapping->count("E")) {
+//   //   electronIndex_ = (*speciesMapping)["E"];
+//   // } else {
+//   //   grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'E' !\n");
+//   //   exit(ERROR);
+//   // }
+//   neutralIndex_ = _runfile.argonTransportInput.neutralIndex;
+//   if (neutralIndex_ < 0) {
+//     grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'Ar' !\n");
+//     exit(ERROR);
+//   }
+//   ionIndex_ = _runfile.argonTransportInput.ionIndex;
+//   if (ionIndex_ < 0) {
+//     grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'Ar.+1' !\n");
+//     exit(ERROR);
+//   }
+//   electronIndex_ = _runfile.argonTransportInput.electronIndex;
+//   if (electronIndex_ < 0) {
+//     grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'E' !\n");
+//     exit(ERROR);
+//   }
+//
+//   // TODO(kevin): need to factor out avogadro numbers throughout all transport property.
+//   // multiplying/dividing big numbers are risky of losing precision.
+//   // mw_.SetSize(3);
+//   mw_[electronIndex_] = mixture->GetGasParams(electronIndex_, GasParams::SPECIES_MW);
+//   mw_[neutralIndex_] = mixture->GetGasParams(neutralIndex_, GasParams::SPECIES_MW);
+//   mw_[ionIndex_] = mixture->GetGasParams(ionIndex_, GasParams::SPECIES_MW);
+//   // assumes input mass is consistent with this.
+//   assert(abs(mw_[neutralIndex_] - mw_[electronIndex_] - mw_[ionIndex_]) < 1.0e-15);
+//   mw_ /= AVOGADRONUMBER;
+//   // mA_ /= AVOGADRONUMBER;
+//   // mI_ /= AVOGADRONUMBER;
+//
+//   // muw_.SetSize(3);
+//   computeEffectiveMass(mw_, muw_);
+//
+//   thirdOrderkElectron_ = _runfile.thirdOrderkElectron;
+// }
+
+MFEM_HOST_DEVICE ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixture, const ArgonTransportInput &inputs)
     : TransportProperties(_mixture) {
   // if (!ambipolar) {
   //   grvy_printf(GRVY_ERROR, "\nArgon ternary transport currently supports ambipolar condition only. Set
   //   plasma_models/ambipolar = true.\n"); exit(ERROR);
   // }
   if (numSpecies != 3) {
-    grvy_printf(GRVY_ERROR, "\nArgon ternary transport only supports ternary mixture of Ar, Ar.+1, and E !\n");
-    exit(ERROR);
+    // grvy_printf(GRVY_ERROR, "\nArgon ternary transport only supports ternary mixture of Ar, Ar.+1, and E !\n");
+    // exit(ERROR);
+    printf( "\nArgon ternary transport only supports ternary mixture of Ar, Ar.+1, and E !\n");
+    assert(false);
   }
 
   // std::map<std::string, int> *speciesMapping = mixture->getSpeciesMapping();
@@ -66,20 +133,22 @@ ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixture, RunConfigurat
   //   grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'E' !\n");
   //   exit(ERROR);
   // }
-  neutralIndex_ = _runfile.argonTransportInput.neutralIndex;
+  neutralIndex_ = inputs.neutralIndex;
   if (neutralIndex_ < 0) {
-    grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'Ar' !\n");
-    exit(ERROR);
+    // grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'Ar' !\n");
+    // exit(ERROR);
+    printf("\nArgon ternary transport requires the species 'Ar' !\n");
+    assert(false);
   }
-  ionIndex_ = _runfile.argonTransportInput.ionIndex;
+  ionIndex_ = inputs.ionIndex;
   if (ionIndex_ < 0) {
-    grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'Ar.+1' !\n");
-    exit(ERROR);
+    printf("\nArgon ternary transport requires the species 'Ar.+1' !\n");
+    assert(false);
   }
-  electronIndex_ = _runfile.argonTransportInput.electronIndex;
+  electronIndex_ = inputs.electronIndex;
   if (electronIndex_ < 0) {
-    grvy_printf(GRVY_ERROR, "\nArgon ternary transport requires the species 'E' !\n");
-    exit(ERROR);
+    printf("\nArgon ternary transport requires the species 'E' !\n");
+    assert(false);
   }
 
   // TODO(kevin): need to factor out avogadro numbers throughout all transport property.
@@ -97,7 +166,7 @@ ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixture, RunConfigurat
   // muw_.SetSize(3);
   computeEffectiveMass(mw_, muw_);
 
-  thirdOrderkElectron_ = _runfile.thirdOrderkElectron;
+  thirdOrderkElectron_ = inputs.thirdOrderkElectron;
 }
 
 ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixture) : TransportProperties(_mixture) {}

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -284,8 +284,8 @@ void ArgonMinimalTransport::ComputeFluxTransportProperties(const Vector &state, 
   //       computeThirdOrderElectronThermalConductivity(&X_sp[0], debyeLength, Te, nondimTe);
   // } else {
   //   transportBuffer[FluxTrns::ELECTRON_THERMAL_CONDUCTIVITY] = viscosityFactor_ * kOverEtaFactor_ *
-  //                                                              sqrt(Te / mw_[electronIndex_]) * X_sp(electronIndex_) /
-  //                                                              (collision::charged::rep22(nondimTe) * debyeCircle);
+  //                                                              sqrt(Te / mw_[electronIndex_]) * X_sp(electronIndex_)
+  //                                                              / (collision::charged::rep22(nondimTe) * debyeCircle);
   // }
   //
   // DenseMatrix binaryDiff(3);
@@ -296,7 +296,8 @@ void ArgonMinimalTransport::ComputeFluxTransportProperties(const Vector &state, 
   // binaryDiff(neutralIndex_, ionIndex_) =
   //     diffusivityFactor_ * sqrt(Th / getMuw(neutralIndex_, ionIndex_)) / nTotal / collision::argon::ArAr1P11(Th);
   // binaryDiff(ionIndex_, neutralIndex_) = binaryDiff(neutralIndex_, ionIndex_);
-  // binaryDiff(electronIndex_, ionIndex_) = diffusivityFactor_ * sqrt(Te / getMuw(ionIndex_, electronIndex_)) / nTotal /
+  // binaryDiff(electronIndex_, ionIndex_) = diffusivityFactor_ * sqrt(Te / getMuw(ionIndex_, electronIndex_)) / nTotal
+  // /
   //                                         (collision::charged::att11(nondimTe) * debyeCircle);
   // binaryDiff(ionIndex_, electronIndex_) = binaryDiff(electronIndex_, ionIndex_);
   //

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -668,7 +668,6 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeSourceTransportProperties(co
                                                                               double *globalTransport, double *speciesTransport,
                                                                               double *diffusionVelocity, double *n_sp) {
   for (int p = 0; p < SrcTrns::NUM_SRC_TRANS; p++) globalTransport[p] = 0.0;
-  speciesTransport.SetSize(numSpecies, SpeciesTrns::NUM_SPECIES_COEFFS);
   for (int p = 0; p < SpeciesTrns::NUM_SPECIES_COEFFS; p++)
     for (int sp = 0; sp < numSpecies; sp++) speciesTransport[sp + p * numSpecies] = 0.0;
 

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -278,7 +278,7 @@ void ArgonMinimalTransport::ComputeFluxTransportProperties(const Vector &state, 
 
   if (thirdOrderkElectron_) {
     transportBuffer[FluxTrns::ELECTRON_THERMAL_CONDUCTIVITY] =
-        computeThirdOrderElectronThermalConductivity(X_sp, debyeLength, Te, nondimTe);
+        computeThirdOrderElectronThermalConductivity(&X_sp[0], debyeLength, Te, nondimTe);
   } else {
     transportBuffer[FluxTrns::ELECTRON_THERMAL_CONDUCTIVITY] = viscosityFactor_ * kOverEtaFactor_ *
                                                                sqrt(Te / mw_[electronIndex_]) * X_sp(electronIndex_) /
@@ -338,50 +338,50 @@ void ArgonMinimalTransport::ComputeFluxTransportProperties(const Vector &state, 
   // std::cout << "max diff. vel: " << charSpeed << std::endl;
 }
 
-double ArgonMinimalTransport::computeThirdOrderElectronThermalConductivity(const Vector &X_sp, const double debyeLength,
-                                                                           const double Te, const double nondimTe) {
+MFEM_HOST_DEVICE double ArgonMinimalTransport::computeThirdOrderElectronThermalConductivity(const double *X_sp, const double debyeLength,
+                                                                                            const double Te, const double nondimTe) {
   double debyeCircle = PI_ * debyeLength * debyeLength;
   // std::cout << "LD: " << debyeLength << std::endl;
-  Vector Q2(3);
-  Q2(0) = debyeCircle * collision::charged::rep22(nondimTe);
-  Q2(1) = debyeCircle * collision::charged::rep23(nondimTe);
-  Q2(2) = debyeCircle * collision::charged::rep24(nondimTe);
+  double Q2[3];
+  Q2[0] = debyeCircle * collision::charged::rep22(nondimTe);
+  Q2[1] = debyeCircle * collision::charged::rep23(nondimTe);
+  Q2[2] = debyeCircle * collision::charged::rep24(nondimTe);
   // std::cout << "Q2r: " << Q2(0) << ",\t" << Q2(1) << ",\t" << Q2(2) << std::endl;
 
-  Vector Q1Ion(5);
-  Q1Ion(0) = debyeCircle * collision::charged::att11(nondimTe);
-  Q1Ion(1) = debyeCircle * collision::charged::att12(nondimTe);
-  Q1Ion(2) = debyeCircle * collision::charged::att13(nondimTe);
-  Q1Ion(3) = debyeCircle * collision::charged::att14(nondimTe);
-  Q1Ion(4) = debyeCircle * collision::charged::att15(nondimTe);
+  double Q1Ion[5];
+  Q1Ion[0] = debyeCircle * collision::charged::att11(nondimTe);
+  Q1Ion[1] = debyeCircle * collision::charged::att12(nondimTe);
+  Q1Ion[2] = debyeCircle * collision::charged::att13(nondimTe);
+  Q1Ion[3] = debyeCircle * collision::charged::att14(nondimTe);
+  Q1Ion[4] = debyeCircle * collision::charged::att15(nondimTe);
   //   std::cout << "Q1i: ";
   // for (int i = 0; i < 5; i++) std::cout << Q1Ion(i) << ",\t";
   // std::cout << std::endl;
 
-  Vector Q1Neutral(5);
-  Q1Neutral(0) = collision::argon::eAr11(Te);
-  Q1Neutral(1) = collision::argon::eAr12(Te);
-  Q1Neutral(2) = collision::argon::eAr13(Te);
-  Q1Neutral(3) = collision::argon::eAr14(Te);
-  Q1Neutral(4) = collision::argon::eAr15(Te);
+  double Q1Neutral[5];
+  Q1Neutral[0] = collision::argon::eAr11(Te);
+  Q1Neutral[1] = collision::argon::eAr12(Te);
+  Q1Neutral[2] = collision::argon::eAr13(Te);
+  Q1Neutral[3] = collision::argon::eAr14(Te);
+  Q1Neutral[4] = collision::argon::eAr15(Te);
   //   std::cout << "Q1A: ";
   // for (int i = 0; i < 5; i++) std::cout << Q1Neutral(i) << ",\t";
   // std::cout << std::endl;
 
-  double L11 = sqrt(2.0) * X_sp(electronIndex_) * L11ee(Q2);
-  L11 += X_sp(ionIndex_) * L11ea(Q1Ion);
-  L11 += X_sp(neutralIndex_) * L11ea(Q1Neutral);
-  double L12 = sqrt(2.0) * X_sp(electronIndex_) * L12ee(Q2);
-  L12 += X_sp(ionIndex_) * L12ea(Q1Ion);
-  L12 += X_sp(neutralIndex_) * L12ea(Q1Neutral);
-  double L22 = sqrt(2.0) * X_sp(electronIndex_) * L22ee(Q2);
-  L22 += X_sp(ionIndex_) * L22ea(Q1Ion);
-  L22 += X_sp(neutralIndex_) * L22ea(Q1Neutral);
+  double L11 = sqrt(2.0) * X_sp[electronIndex_] * L11ee(Q2);
+  L11 += X_sp[ionIndex_] * L11ea(Q1Ion);
+  L11 += X_sp[neutralIndex_] * L11ea(Q1Neutral);
+  double L12 = sqrt(2.0) * X_sp[electronIndex_] * L12ee(Q2);
+  L12 += X_sp[ionIndex_] * L12ea(Q1Ion);
+  L12 += X_sp[neutralIndex_] * L12ea(Q1Neutral);
+  double L22 = sqrt(2.0) * X_sp[electronIndex_] * L22ee(Q2);
+  L22 += X_sp[ionIndex_] * L22ea(Q1Ion);
+  L22 += X_sp[neutralIndex_] * L22ea(Q1Neutral);
   // std::cout << "L11: " << L11 << std::endl;
   // std::cout << "L12: " << L12 << std::endl;
   // std::cout << "L22: " << L22 << std::endl;
 
-  return viscosityFactor_ * kOverEtaFactor_ * sqrt(2.0 * Te / mw_[electronIndex_]) * X_sp(electronIndex_) /
+  return viscosityFactor_ * kOverEtaFactor_ * sqrt(2.0 * Te / mw_[electronIndex_]) * X_sp[electronIndex_] /
          (L11 - L12 * L12 / L22);
 }
 

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -110,7 +110,7 @@ MFEM_HOST_DEVICE ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixtu
   if (numSpecies != 3) {
     // grvy_printf(GRVY_ERROR, "\nArgon ternary transport only supports ternary mixture of Ar, Ar.+1, and E !\n");
     // exit(ERROR);
-    printf( "\nArgon ternary transport only supports ternary mixture of Ar, Ar.+1, and E !\n");
+    printf("\nArgon ternary transport only supports ternary mixture of Ar, Ar.+1, and E !\n");
     assert(false);
   }
 
@@ -205,7 +205,8 @@ collisionInputs ArgonMinimalTransport::computeCollisionInputs(const Vector &prim
   // return collInputs;
 }
 
-MFEM_HOST_DEVICE collisionInputs ArgonMinimalTransport::computeCollisionInputs(const double *primitive, const double *n_sp) {
+MFEM_HOST_DEVICE collisionInputs ArgonMinimalTransport::computeCollisionInputs(const double *primitive,
+                                                                               const double *n_sp) {
   collisionInputs collInputs;
   collInputs.Te = (twoTemperature_) ? primitive[num_equation - 1] : primitive[nvel_ + 1];
   collInputs.Th = primitive[nvel_ + 1];
@@ -339,7 +340,8 @@ void ArgonMinimalTransport::ComputeFluxTransportProperties(const Vector &state, 
 }
 
 MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                                            const double *Efield, double *transportBuffer,
+                                                                            const double *Efield,
+                                                                            double *transportBuffer,
                                                                             double *diffusionVelocity) {
   // transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   for (int p = 0; p < FluxTrns::NUM_FLUX_TRANS; p++) transportBuffer[p] = 0.0;
@@ -395,8 +397,9 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeFluxTransportProperties(cons
   binaryDiff[neutralIndex_ + ionIndex_ * numSpecies] =
       diffusivityFactor_ * sqrt(Th / getMuw(neutralIndex_, ionIndex_)) / nTotal / collision::argon::ArAr1P11(Th);
   binaryDiff[ionIndex_ + neutralIndex_ * numSpecies] = binaryDiff[neutralIndex_ + ionIndex_ * numSpecies];
-  binaryDiff[electronIndex_ + ionIndex_ * numSpecies] = diffusivityFactor_ * sqrt(Te / getMuw(ionIndex_, electronIndex_)) / nTotal /
-                                          (collision::charged::att11(nondimTe) * debyeCircle);
+  binaryDiff[electronIndex_ + ionIndex_ * numSpecies] = diffusivityFactor_ *
+                                                        sqrt(Te / getMuw(ionIndex_, electronIndex_)) / nTotal /
+                                                        (collision::charged::att11(nondimTe) * debyeCircle);
   binaryDiff[ionIndex_ + electronIndex_ * numSpecies] = binaryDiff[electronIndex_ + ionIndex_ * numSpecies];
 
   double diffusivity[3], mobility[3];
@@ -434,7 +437,8 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeFluxTransportProperties(cons
   for (int sp = 0; sp < numActiveSpecies; sp++) {
     double speciesSpeed = 0.0;
     // azimuthal component does not participate in flux.
-    for (int d = 0; d < dim; d++) speciesSpeed += diffusionVelocity[sp + d * numSpecies] * diffusionVelocity[sp + d * numSpecies];
+    for (int d = 0; d < dim; d++)
+      speciesSpeed += diffusionVelocity[sp + d * numSpecies] * diffusionVelocity[sp + d * numSpecies];
     speciesSpeed = sqrt(speciesSpeed);
     if (speciesSpeed > charSpeed) charSpeed = speciesSpeed;
     // charSpeed = max(charSpeed, speciesSpeed);
@@ -442,8 +446,10 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeFluxTransportProperties(cons
   // std::cout << "max diff. vel: " << charSpeed << std::endl;
 }
 
-MFEM_HOST_DEVICE double ArgonMinimalTransport::computeThirdOrderElectronThermalConductivity(const double *X_sp, const double debyeLength,
-                                                                                            const double Te, const double nondimTe) {
+MFEM_HOST_DEVICE double ArgonMinimalTransport::computeThirdOrderElectronThermalConductivity(const double *X_sp,
+                                                                                            const double debyeLength,
+                                                                                            const double Te,
+                                                                                            const double nondimTe) {
   double debyeCircle = PI_ * debyeLength * debyeLength;
   // std::cout << "LD: " << debyeLength << std::endl;
   double Q2[3];
@@ -520,7 +526,8 @@ void ArgonMinimalTransport::computeMixtureAverageDiffusivity(const Vector &state
   // binaryDiff(ionIndex_, neutralIndex_) =
   //     diffusivityFactor_ * sqrt(Th / getMuw(neutralIndex_, ionIndex_)) / nTotal / collision::argon::ArAr1P11(Th);
   // binaryDiff(neutralIndex_, ionIndex_) = binaryDiff(ionIndex_, neutralIndex_);
-  // binaryDiff(electronIndex_, ionIndex_) = diffusivityFactor_ * sqrt(Te / getMuw(ionIndex_, electronIndex_)) / nTotal /
+  // binaryDiff(electronIndex_, ionIndex_) = diffusivityFactor_ * sqrt(Te / getMuw(ionIndex_, electronIndex_)) / nTotal
+  // /
   //                                         (collision::charged::att11(nondimTe) * debyeCircle);
   // binaryDiff(ionIndex_, electronIndex_) = binaryDiff(electronIndex_, ionIndex_);
   //
@@ -529,7 +536,8 @@ void ArgonMinimalTransport::computeMixtureAverageDiffusivity(const Vector &state
   // CurtissHirschfelder(X_sp, Y_sp, binaryDiff, diffusivity);
 }
 
-MFEM_HOST_DEVICE void ArgonMinimalTransport::computeMixtureAverageDiffusivity(const double *state, double *diffusivity) {
+MFEM_HOST_DEVICE void ArgonMinimalTransport::computeMixtureAverageDiffusivity(const double *state,
+                                                                              double *diffusivity) {
   double primitiveState[gpudata::MAXEQUATIONS];
   mixture->GetPrimitivesFromConservatives(state, primitiveState);
 
@@ -557,8 +565,9 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::computeMixtureAverageDiffusivity(co
   binaryDiff[neutralIndex_ + ionIndex_ * numSpecies] =
       diffusivityFactor_ * sqrt(Th / getMuw(neutralIndex_, ionIndex_)) / nTotal / collision::argon::ArAr1P11(Th);
   binaryDiff[ionIndex_ + neutralIndex_ * numSpecies] = binaryDiff[neutralIndex_ + ionIndex_ * numSpecies];
-  binaryDiff[electronIndex_ + ionIndex_ * numSpecies] = diffusivityFactor_ * sqrt(Te / getMuw(ionIndex_, electronIndex_)) / nTotal /
-                                          (collision::charged::att11(nondimTe) * debyeCircle);
+  binaryDiff[electronIndex_ + ionIndex_ * numSpecies] = diffusivityFactor_ *
+                                                        sqrt(Te / getMuw(ionIndex_, electronIndex_)) / nTotal /
+                                                        (collision::charged::att11(nondimTe) * debyeCircle);
   binaryDiff[ionIndex_ + electronIndex_ * numSpecies] = binaryDiff[electronIndex_ + ionIndex_ * numSpecies];
 
   // diffusivity.SetSize(3);
@@ -606,9 +615,9 @@ void ArgonMinimalTransport::ComputeSourceTransportProperties(const Vector &state
   // binaryDiff(electronIndex_, neutralIndex_) =
   //     diffusivityFactor_ * sqrt(Te / getMuw(electronIndex_, neutralIndex_)) / nTotal / Qea;
   // binaryDiff(neutralIndex_, electronIndex_) = binaryDiff(electronIndex_, neutralIndex_);
-  // binaryDiff(neutralIndex_, ionIndex_) = diffusivityFactor_ * sqrt(Th / getMuw(neutralIndex_, ionIndex_)) / nTotal / Qai;
-  // binaryDiff(ionIndex_, neutralIndex_) = binaryDiff(neutralIndex_, ionIndex_);
-  // binaryDiff(electronIndex_, ionIndex_) =
+  // binaryDiff(neutralIndex_, ionIndex_) = diffusivityFactor_ * sqrt(Th / getMuw(neutralIndex_, ionIndex_)) / nTotal /
+  // Qai; binaryDiff(ionIndex_, neutralIndex_) = binaryDiff(neutralIndex_, ionIndex_); binaryDiff(electronIndex_,
+  // ionIndex_) =
   //     diffusivityFactor_ * sqrt(Te / getMuw(ionIndex_, electronIndex_)) / nTotal / Qie;
   // binaryDiff(ionIndex_, electronIndex_) = binaryDiff(electronIndex_, ionIndex_);
   //
@@ -649,7 +658,8 @@ void ArgonMinimalTransport::ComputeSourceTransportProperties(const Vector &state
   //     mfFreqFactor_ * sqrt(Te / mw_[electronIndex_]) * n_sp(neutralIndex_) * Qea;
   // // // relative electron collision speed
   // // double ge = sqrt(8.0 * kB_ * Te / PI_ / mw_(electronIndex_));
-  // // speciesTransport(ionIndex_, SpeciesTrns::MF_FREQUENCY) = 4.0 / 3.0 * AVOGADRONUMBER * n_sp(ionIndex_) * ge * Qie;
+  // // speciesTransport(ionIndex_, SpeciesTrns::MF_FREQUENCY) = 4.0 / 3.0 * AVOGADRONUMBER * n_sp(ionIndex_) * ge *
+  // Qie;
   //
   // double charSpeed = 0.0;
   // for (int sp = 0; sp < numActiveSpecies; sp++) {
@@ -663,10 +673,9 @@ void ArgonMinimalTransport::ComputeSourceTransportProperties(const Vector &state
   // // std::cout << "max diff. vel: " << charSpeed << std::endl;
 }
 
-MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeSourceTransportProperties(const double *state, const double *Up,
-                                                                              const double *gradUp, const double *Efield,
-                                                                              double *globalTransport, double *speciesTransport,
-                                                                              double *diffusionVelocity, double *n_sp) {
+MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeSourceTransportProperties(
+    const double *state, const double *Up, const double *gradUp, const double *Efield, double *globalTransport,
+    double *speciesTransport, double *diffusionVelocity, double *n_sp) {
   for (int p = 0; p < SrcTrns::NUM_SRC_TRANS; p++) globalTransport[p] = 0.0;
   for (int p = 0; p < SpeciesTrns::NUM_SPECIES_COEFFS; p++)
     for (int sp = 0; sp < numSpecies; sp++) speciesTransport[sp + p * numSpecies] = 0.0;
@@ -700,8 +709,9 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeSourceTransportProperties(co
   binaryDiff[neutralIndex_ + ionIndex_ * numSpecies] =
       diffusivityFactor_ * sqrt(Th / getMuw(neutralIndex_, ionIndex_)) / nTotal / collision::argon::ArAr1P11(Th);
   binaryDiff[ionIndex_ + neutralIndex_ * numSpecies] = binaryDiff[neutralIndex_ + ionIndex_ * numSpecies];
-  binaryDiff[electronIndex_ + ionIndex_ * numSpecies] = diffusivityFactor_ * sqrt(Te / getMuw(ionIndex_, electronIndex_)) / nTotal /
-                                          (collision::charged::att11(nondimTe) * debyeCircle);
+  binaryDiff[electronIndex_ + ionIndex_ * numSpecies] = diffusivityFactor_ *
+                                                        sqrt(Te / getMuw(ionIndex_, electronIndex_)) / nTotal /
+                                                        (collision::charged::att11(nondimTe) * debyeCircle);
   binaryDiff[ionIndex_ + electronIndex_ * numSpecies] = binaryDiff[electronIndex_ + ionIndex_ * numSpecies];
 
   double diffusivity[3], mobility[3];
@@ -747,7 +757,8 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeSourceTransportProperties(co
   for (int sp = 0; sp < numActiveSpecies; sp++) {
     double speciesSpeed = 0.0;
     // azimuthal component does not participate in flux.
-    for (int d = 0; d < dim; d++) speciesSpeed += diffusionVelocity[sp + d * numSpecies] * diffusionVelocity[sp + d * numSpecies];
+    for (int d = 0; d < dim; d++)
+      speciesSpeed += diffusionVelocity[sp + d * numSpecies] * diffusionVelocity[sp + d * numSpecies];
     speciesSpeed = sqrt(speciesSpeed);
     if (speciesSpeed > charSpeed) charSpeed = speciesSpeed;
     // charSpeed = max(charSpeed, speciesSpeed);
@@ -786,8 +797,8 @@ void ArgonMinimalTransport::GetViscosities(const Vector &conserved, const Vector
   return;
 }
 
-MFEM_HOST_DEVICE void ArgonMinimalTransport::GetViscosities(const double *conserved, const double *primitive, double &visc,
-                                                            double &bulkVisc) {
+MFEM_HOST_DEVICE void ArgonMinimalTransport::GetViscosities(const double *conserved, const double *primitive,
+                                                            double &visc, double &bulkVisc) {
   double n_sp[3], X_sp[3], Y_sp[3];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
   double nTotal = 0.0;

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -185,6 +185,27 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::computeEffectiveMass(const double *
 }
 
 collisionInputs ArgonMinimalTransport::computeCollisionInputs(const Vector &primitive, const Vector &n_sp) {
+  return computeCollisionInputs(&primitive[0], &n_sp[0]);
+  // collisionInputs collInputs;
+  // collInputs.Te = (twoTemperature_) ? primitive[num_equation - 1] : primitive[nvel_ + 1];
+  // collInputs.Th = primitive[nvel_ + 1];
+  //
+  // // Add Xeps to avoid zero number density case.
+  // double nOverT = 0.0;
+  // for (int sp = 0; sp < numSpecies; sp++) {
+  //   nOverT += (n_sp(sp) + Xeps_) / collInputs.Te * mixture->GetGasParams(sp, GasParams::SPECIES_CHARGES) *
+  //             mixture->GetGasParams(sp, GasParams::SPECIES_CHARGES);
+  // }
+  // double debyeLength = sqrt(debyeFactor_ / AVOGADRONUMBER / nOverT);
+  // collInputs.debyeCircle = PI_ * debyeLength * debyeLength;
+  //
+  // collInputs.ndimTe = debyeLength * 4.0 * PI_ * debyeFactor_ * collInputs.Te;
+  // collInputs.ndimTh = debyeLength * 4.0 * PI_ * debyeFactor_ * collInputs.Th;
+  //
+  // return collInputs;
+}
+
+MFEM_HOST_DEVICE collisionInputs ArgonMinimalTransport::computeCollisionInputs(const double *primitive, const double *n_sp) {
   collisionInputs collInputs;
   collInputs.Te = (twoTemperature_) ? primitive[num_equation - 1] : primitive[nvel_ + 1];
   collInputs.Th = primitive[nvel_ + 1];
@@ -192,7 +213,7 @@ collisionInputs ArgonMinimalTransport::computeCollisionInputs(const Vector &prim
   // Add Xeps to avoid zero number density case.
   double nOverT = 0.0;
   for (int sp = 0; sp < numSpecies; sp++) {
-    nOverT += (n_sp(sp) + Xeps_) / collInputs.Te * mixture->GetGasParams(sp, GasParams::SPECIES_CHARGES) *
+    nOverT += (n_sp[sp] + Xeps_) / collInputs.Te * mixture->GetGasParams(sp, GasParams::SPECIES_CHARGES) *
               mixture->GetGasParams(sp, GasParams::SPECIES_CHARGES);
   }
   double debyeLength = sqrt(debyeFactor_ / AVOGADRONUMBER / nOverT);

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -118,6 +118,10 @@ class ArgonMinimalTransport : public TransportProperties {
                                                 const Vector &Efield, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp);
+  MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up, const double *gradUp,
+                                                                 const double *Efield, double *globalTransport,
+                                                                 double *speciesTransport, double *diffusionVelocity,
+                                                                 double *n_sp);
 
   // NOTE(kevin): only for AxisymmetricSource
   virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -109,10 +109,7 @@ class ArgonMinimalTransport : public TransportProperties {
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
                                                                const double *Efield, double *transportBuffer,
-                                                               double *diffusionVelocity) {
-    exit(-1);
-    return;
-  }
+                                                               double *diffusionVelocity);
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -69,7 +69,8 @@ class ArgonMinimalTransport : public TransportProperties {
   const double qe_ = ELECTRONCHARGE;
   const double R_ = UNIVERSALGASCONSTANT;
   const double debyeFactor_ = kB_ * eps0_ / qe_ / qe_;
-  const double PI_ = 4.0 * atan(1.0);
+  // const double PI_ = 4.0 * atan(1.0);
+  const double PI_ = PI;
   const double qeOverkB_ = qe_ / kB_;
 
   // standard Chapman-Enskog coefficients
@@ -78,8 +79,9 @@ class ArgonMinimalTransport : public TransportProperties {
   const double diffusivityFactor_ = 3. / 16. * sqrt(2.0 * PI_ * kB_) / AVOGADRONUMBER;
   const double mfFreqFactor_ = 4. / 3. * AVOGADRONUMBER * sqrt(8. * kB_ / PI_);
 
-  Vector mw_;
-  DenseSymmetricMatrix muw_;  // effective mass
+  // molecular mass per each particle. [kg^-1]
+  double mw_[gpudata::MAXSPECIES];
+  double muw_[gpudata::MAXSPECIES * gpudata::MAXSPECIES];  // effective mass
 
   bool thirdOrderkElectron_;
 
@@ -88,6 +90,8 @@ class ArgonMinimalTransport : public TransportProperties {
   ArgonMinimalTransport(GasMixture *_mixture);
 
   MFEM_HOST_DEVICE virtual ~ArgonMinimalTransport() {}
+
+  MFEM_HOST_DEVICE double getMuw(const int &spI, const int &spJ) { return muw_[spI + spJ * numSpecies]; }
 
   int getIonIndex() { return ionIndex_; }
 
@@ -134,7 +138,7 @@ class ArgonMinimalTransport : public TransportProperties {
     return 19.140625 * Q1(0) - 91.875 * Q1(1) + 199.5 * Q1(2) - 210. * Q1(3) + 90. * Q1(4);
   }
 
-  void computeEffectiveMass(const Vector &mw, DenseSymmetricMatrix &muw);
+  MFEM_HOST_DEVICE void computeEffectiveMass(const double *mw, double *muw);
 };
 
 //////////////////////////////////////////////////////

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -206,6 +206,7 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
 
   // NOTE(kevin): only for AxisymmetricSource
   virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double &visc, double &bulkVisc);
 
   MFEM_HOST_DEVICE virtual double computeThirdOrderElectronThermalConductivity(const double *X_sp, const collisionInputs &collInputs);
   //

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -118,18 +118,20 @@ class ArgonMinimalTransport : public TransportProperties {
                                                 const Vector &Efield, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp);
-  MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up, const double *gradUp,
-                                                                 const double *Efield, double *globalTransport,
-                                                                 double *speciesTransport, double *diffusionVelocity,
-                                                                 double *n_sp);
+  MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
+                                                                 const double *gradUp, const double *Efield,
+                                                                 double *globalTransport, double *speciesTransport,
+                                                                 double *diffusionVelocity, double *n_sp);
 
   // NOTE(kevin): only for AxisymmetricSource
   virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double &visc, double &bulkVisc);
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double &visc,
+                                       double &bulkVisc);
 
   // virtual double computeThirdOrderElectronThermalConductivity(const Vector &X_sp, const double debyeLength,
   //                                                             const double Te, const double nondimTe);
-  MFEM_HOST_DEVICE virtual double computeThirdOrderElectronThermalConductivity(const double *X_sp, const double debyeLength,
+  MFEM_HOST_DEVICE virtual double computeThirdOrderElectronThermalConductivity(const double *X_sp,
+                                                                               const double debyeLength,
                                                                                const double Te, const double nondimTe);
 
   virtual void computeMixtureAverageDiffusivity(const Vector &state, Vector &diffusivity);
@@ -139,7 +141,9 @@ class ArgonMinimalTransport : public TransportProperties {
   MFEM_HOST_DEVICE double L11ee(const double *Q2) { return Q2[0]; }
   MFEM_HOST_DEVICE double L11ea(const double *Q1) { return 6.25 * Q1[0] - 15. * Q1[1] + 12. * Q1[2]; }
   MFEM_HOST_DEVICE double L12ee(const double *Q2) { return 1.75 * Q2[0] - 2.0 * Q2[1]; }
-  MFEM_HOST_DEVICE double L12ea(const double *Q1) { return 10.9375 * Q1[0] - 39.375 * Q1[1] + 57. * Q1[2] - 30. * Q1[3]; }
+  MFEM_HOST_DEVICE double L12ea(const double *Q1) {
+    return 10.9375 * Q1[0] - 39.375 * Q1[1] + 57. * Q1[2] - 30. * Q1[3];
+  }
   MFEM_HOST_DEVICE double L22ee(const double *Q2) { return 4.8125 * Q2[0] - 7.0 * Q2[1] + 5. * Q2[2]; }
   MFEM_HOST_DEVICE double L22ea(const double *Q1) {
     return 19.140625 * Q1[0] - 91.875 * Q1[1] + 199.5 * Q1[2] - 210. * Q1[3] + 90. * Q1[4];

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -87,6 +87,7 @@ class ArgonMinimalTransport : public TransportProperties {
 
  public:
   ArgonMinimalTransport(GasMixture *_mixture, RunConfiguration &_runfile);
+  MFEM_HOST_DEVICE ArgonMinimalTransport(GasMixture *_mixture, const ArgonTransportInput &inputs);
   ArgonMinimalTransport(GasMixture *_mixture);
 
   MFEM_HOST_DEVICE virtual ~ArgonMinimalTransport() {}

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -178,7 +178,8 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
 
   MFEM_HOST_DEVICE virtual ~ArgonMixtureTransport() {}
 
-  MFEM_HOST_DEVICE double collisionIntegral(const int _spI, const int _spJ, const int l, const int r, const collisionInputs collInputs);
+  MFEM_HOST_DEVICE double collisionIntegral(const int _spI, const int _spJ, const int l, const int r,
+                                            const collisionInputs collInputs);
 
   // Currently, transport properties are evaluated in flux and source term separately.
   // Flux does not take primitive variables as input, rather evaluate them whenever needed.
@@ -206,9 +207,11 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
 
   // NOTE(kevin): only for AxisymmetricSource
   virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double &visc, double &bulkVisc);
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double &visc,
+                                       double &bulkVisc);
 
-  MFEM_HOST_DEVICE virtual double computeThirdOrderElectronThermalConductivity(const double *X_sp, const collisionInputs &collInputs);
+  MFEM_HOST_DEVICE virtual double computeThirdOrderElectronThermalConductivity(const double *X_sp,
+                                                                               const collisionInputs &collInputs);
   //
   // virtual void computeMixtureAverageDiffusivity(const Vector &state, Vector &diffusivity);
 };

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -88,7 +88,7 @@ class ArgonMinimalTransport : public TransportProperties {
  public:
   ArgonMinimalTransport(GasMixture *_mixture, RunConfiguration &_runfile);
   MFEM_HOST_DEVICE ArgonMinimalTransport(GasMixture *_mixture, const ArgonTransportInput &inputs);
-  ArgonMinimalTransport(GasMixture *_mixture);
+  MFEM_HOST_DEVICE ArgonMinimalTransport(GasMixture *_mixture);
 
   MFEM_HOST_DEVICE virtual ~ArgonMinimalTransport() {}
 

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -190,10 +190,7 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
                                                                const double *Efield, double *transportBuffer,
-                                                               double *diffusionVelocity) {
-    exit(-1);
-    return;
-  }
+                                                               double *diffusionVelocity);
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -97,6 +97,7 @@ class ArgonMinimalTransport : public TransportProperties {
   int getIonIndex() { return ionIndex_; }
 
   virtual collisionInputs computeCollisionInputs(const Vector &primitive, const Vector &n_sp);
+  MFEM_HOST_DEVICE collisionInputs computeCollisionInputs(const double *primitive, const double *n_sp);
 
   // Currently, transport properties are evaluated in flux and source term separately.
   // Flux does not take primitive variables as input, rather evaluate them whenever needed.

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -206,7 +206,7 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
   // NOTE(kevin): only for AxisymmetricSource
   virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);
 
-  virtual double computeThirdOrderElectronThermalConductivity(const Vector &X_sp, const collisionInputs &collInputs);
+  MFEM_HOST_DEVICE virtual double computeThirdOrderElectronThermalConductivity(const double *X_sp, const collisionInputs &collInputs);
   //
   // virtual void computeMixtureAverageDiffusivity(const Vector &state, Vector &diffusivity);
 };

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -125,19 +125,21 @@ class ArgonMinimalTransport : public TransportProperties {
   // NOTE(kevin): only for AxisymmetricSource
   virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);
 
-  virtual double computeThirdOrderElectronThermalConductivity(const Vector &X_sp, const double debyeLength,
-                                                              const double Te, const double nondimTe);
+  // virtual double computeThirdOrderElectronThermalConductivity(const Vector &X_sp, const double debyeLength,
+  //                                                             const double Te, const double nondimTe);
+  MFEM_HOST_DEVICE virtual double computeThirdOrderElectronThermalConductivity(const double *X_sp, const double debyeLength,
+                                                                               const double Te, const double nondimTe);
 
   virtual void computeMixtureAverageDiffusivity(const Vector &state, Vector &diffusivity);
 
   // These are used to compute third-order electron thermal conductivity based on standard Chapman--Enskog method.
-  double L11ee(const Vector &Q2) { return Q2(0); }
-  double L11ea(const Vector &Q1) { return 6.25 * Q1(0) - 15. * Q1(1) + 12. * Q1(2); }
-  double L12ee(const Vector &Q2) { return 1.75 * Q2(0) - 2.0 * Q2(1); }
-  double L12ea(const Vector &Q1) { return 10.9375 * Q1(0) - 39.375 * Q1(1) + 57. * Q1(2) - 30. * Q1(3); }
-  double L22ee(const Vector &Q2) { return 4.8125 * Q2(0) - 7.0 * Q2(1) + 5. * Q2(2); }
-  double L22ea(const Vector &Q1) {
-    return 19.140625 * Q1(0) - 91.875 * Q1(1) + 199.5 * Q1(2) - 210. * Q1(3) + 90. * Q1(4);
+  MFEM_HOST_DEVICE double L11ee(const double *Q2) { return Q2[0]; }
+  MFEM_HOST_DEVICE double L11ea(const double *Q1) { return 6.25 * Q1[0] - 15. * Q1[1] + 12. * Q1[2]; }
+  MFEM_HOST_DEVICE double L12ee(const double *Q2) { return 1.75 * Q2[0] - 2.0 * Q2[1]; }
+  MFEM_HOST_DEVICE double L12ea(const double *Q1) { return 10.9375 * Q1[0] - 39.375 * Q1[1] + 57. * Q1[2] - 30. * Q1[3]; }
+  MFEM_HOST_DEVICE double L22ee(const double *Q2) { return 4.8125 * Q2[0] - 7.0 * Q2[1] + 5. * Q2[2]; }
+  MFEM_HOST_DEVICE double L22ea(const double *Q1) {
+    return 19.140625 * Q1[0] - 91.875 * Q1[1] + 199.5 * Q1[2] - 210. * Q1[3] + 90. * Q1[4];
   }
 
   MFEM_HOST_DEVICE void computeEffectiveMass(const double *mw, double *muw);

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -121,6 +121,7 @@ class ArgonMinimalTransport : public TransportProperties {
 
   // NOTE(kevin): only for AxisymmetricSource
   virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double &visc, double &bulkVisc);
 
   // virtual double computeThirdOrderElectronThermalConductivity(const Vector &X_sp, const double debyeLength,
   //                                                             const double Te, const double nondimTe);

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -199,6 +199,10 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
                                                 const Vector &Efield, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp);
+  MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
+                                                                 const double *gradUp, const double *Efield,
+                                                                 double *globalTransport, double *speciesTransport,
+                                                                 double *diffusionVelocity, double *n_sp);
 
   // NOTE(kevin): only for AxisymmetricSource
   virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -174,7 +174,7 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
 
  public:
   ArgonMixtureTransport(GasMixture *_mixture, RunConfiguration &_runfile);
-  ArgonMixtureTransport(GasMixture *_mixture, const ArgonTransportInput &inputs);
+  MFEM_HOST_DEVICE ArgonMixtureTransport(GasMixture *_mixture, const ArgonTransportInput &inputs);
 
   MFEM_HOST_DEVICE virtual ~ArgonMixtureTransport() {}
 

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -158,21 +158,23 @@ class ArgonMinimalTransport : public TransportProperties {
 
 class ArgonMixtureTransport : public ArgonMinimalTransport {
  private:
-  int numAtoms_;
-  DenseMatrix composition_;
-  std::map<std::string, int> atomMap_;
-  Array<ArgonSpcs> speciesType_;
-  std::vector<std::string> speciesNames_;
+  // int numAtoms_;
+  // DenseMatrix composition_;
+  // std::map<std::string, int> atomMap_;
+  // Array<ArgonSpcs> speciesType_;
+  // std::vector<std::string> speciesNames_;
   // std::map<int, int> *mixtureToInputMap_;
 
   // integer matrix. only upper triangular part will be used.
-  std::vector<std::vector<ArgonColl>> collisionIndex_;
+  // std::vector<std::vector<ArgonColl>> collisionIndex_;
+  ArgonColl collisionIndex_[gpudata::MAXSPECIES * gpudata::MAXSPECIES];
 
-  void identifySpeciesType();
-  void identifyCollisionType();
+  // void identifySpeciesType();
+  // void identifyCollisionType();
 
  public:
   ArgonMixtureTransport(GasMixture *_mixture, RunConfiguration &_runfile);
+  ArgonMixtureTransport(GasMixture *_mixture, const ArgonTransportInput &inputs);
 
   MFEM_HOST_DEVICE virtual ~ArgonMixtureTransport() {}
 

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -128,6 +128,7 @@ class ArgonMinimalTransport : public TransportProperties {
                                                                                const double Te, const double nondimTe);
 
   virtual void computeMixtureAverageDiffusivity(const Vector &state, Vector &diffusivity);
+  MFEM_HOST_DEVICE void computeMixtureAverageDiffusivity(const double *state, double *diffusivity);
 
   // These are used to compute third-order electron thermal conductivity based on standard Chapman--Enskog method.
   MFEM_HOST_DEVICE double L11ee(const double *Q2) { return Q2[0]; }

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -178,7 +178,7 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
 
   MFEM_HOST_DEVICE virtual ~ArgonMixtureTransport() {}
 
-  double collisionIntegral(const int _spI, const int _spJ, const int l, const int r, const collisionInputs collInputs);
+  MFEM_HOST_DEVICE double collisionIntegral(const int _spI, const int _spJ, const int l, const int r, const collisionInputs collInputs);
 
   // Currently, transport properties are evaluated in flux and source term separately.
   // Flux does not take primitive variables as input, rather evaluate them whenever needed.

--- a/src/collision_integrals.cpp
+++ b/src/collision_integrals.cpp
@@ -50,37 +50,37 @@ namespace charged {
   laser-plasma interactions. Journal of Computational Physics, 406, 109190. https://doi.org/10.1016/j.jcp.2019.109190
 */
 
-double att11(const double Tp) { return 0.2150 * pow(log(1.0 + 5.2194 * pow(Tp, 1.0472)), 1.2435) / Tp / Tp; }
+MFEM_HOST_DEVICE double att11(const double &Tp) { return 0.2150 * pow(log(1.0 + 5.2194 * pow(Tp, 1.0472)), 1.2435) / Tp / Tp; }
 
-double att12(const double Tp) { return 0.0991 * pow(log(1.0 + 7.4684 * pow(Tp, 1.0155)), 1.1536) / Tp / Tp; }
+MFEM_HOST_DEVICE double att12(const double &Tp) { return 0.0991 * pow(log(1.0 + 7.4684 * pow(Tp, 1.0155)), 1.1536) / Tp / Tp; }
 
-double att13(const double Tp) { return 0.0616 * pow(log(1.0 + 7.8271 * pow(Tp, 0.9452)), 1.1105) / Tp / Tp; }
+MFEM_HOST_DEVICE double att13(const double &Tp) { return 0.0616 * pow(log(1.0 + 7.8271 * pow(Tp, 0.9452)), 1.1105) / Tp / Tp; }
 
-double att14(const double Tp) { return 0.0308 * pow(log(1.0 + 13.9567 * pow(Tp, 0.9511)), 1.1803) / Tp / Tp; }
+MFEM_HOST_DEVICE double att14(const double &Tp) { return 0.0308 * pow(log(1.0 + 13.9567 * pow(Tp, 0.9511)), 1.1803) / Tp / Tp; }
 
-double att15(const double Tp) { return 0.0232 * pow(log(1.0 + 13.7888 * pow(Tp, 0.9148)), 1.1532) / Tp / Tp; }
+MFEM_HOST_DEVICE double att15(const double &Tp) { return 0.0232 * pow(log(1.0 + 13.7888 * pow(Tp, 0.9148)), 1.1532) / Tp / Tp; }
 
-double att22(const double Tp) { return 0.2423 * pow(log(1.0 + 4.6796 * pow(Tp, 1.3290)), 1.1279) / Tp / Tp; }
+MFEM_HOST_DEVICE double att22(const double &Tp) { return 0.2423 * pow(log(1.0 + 4.6796 * pow(Tp, 1.3290)), 1.1279) / Tp / Tp; }
 
-double att23(const double Tp) { return 0.1221 * pow(log(1.0 + 8.7542 * pow(Tp, 1.3875)), 1.1110) / Tp / Tp; }
+MFEM_HOST_DEVICE double att23(const double &Tp) { return 0.1221 * pow(log(1.0 + 8.7542 * pow(Tp, 1.3875)), 1.1110) / Tp / Tp; }
 
-double att24(const double Tp) { return 0.0619 * pow(log(1.0 + 18.2538 * pow(Tp, 1.4341)), 1.1618) / Tp / Tp; }
+MFEM_HOST_DEVICE double att24(const double &Tp) { return 0.0619 * pow(log(1.0 + 18.2538 * pow(Tp, 1.4341)), 1.1618) / Tp / Tp; }
 
-double rep11(const double Tp) { return 0.3904 * pow(log(1.0 + 0.9100 * pow(Tp, 1.1025)), 1.0544) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep11(const double &Tp) { return 0.3904 * pow(log(1.0 + 0.9100 * pow(Tp, 1.1025)), 1.0544) / Tp / Tp; }
 
-double rep12(const double Tp) { return 0.1547 * pow(log(1.0 + 1.6597 * pow(Tp, 1.1725)), 0.9792) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep12(const double &Tp) { return 0.1547 * pow(log(1.0 + 1.6597 * pow(Tp, 1.1725)), 0.9792) / Tp / Tp; }
 
-double rep13(const double Tp) { return 0.0814 * pow(log(1.0 + 2.5815 * pow(Tp, 1.1948)), 0.9570) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep13(const double &Tp) { return 0.0814 * pow(log(1.0 + 2.5815 * pow(Tp, 1.1948)), 0.9570) / Tp / Tp; }
 
-double rep14(const double Tp) { return 0.0683 * pow(log(1.0 + 1.9774 * pow(Tp, 1.2033)), 0.8264) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep14(const double &Tp) { return 0.0683 * pow(log(1.0 + 1.9774 * pow(Tp, 1.2033)), 0.8264) / Tp / Tp; }
 
-double rep15(const double Tp) { return 0.0346 * pow(log(1.0 + 4.5177 * pow(Tp, 1.2132)), 0.9294) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep15(const double &Tp) { return 0.0346 * pow(log(1.0 + 4.5177 * pow(Tp, 1.2132)), 0.9294) / Tp / Tp; }
 
-double rep22(const double Tp) { return 0.4128 * pow(log(1.0 + 1.2436 * pow(Tp, 1.1830)), 1.0123) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep22(const double &Tp) { return 0.4128 * pow(log(1.0 + 1.2436 * pow(Tp, 1.1830)), 1.0123) / Tp / Tp; }
 
-double rep23(const double Tp) { return 0.2203 * pow(log(1.0 + 1.8832 * pow(Tp, 1.2059)), 0.9851) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep23(const double &Tp) { return 0.2203 * pow(log(1.0 + 1.8832 * pow(Tp, 1.2059)), 0.9851) / Tp / Tp; }
 
-double rep24(const double Tp) { return 0.1323 * pow(log(1.0 + 2.7248 * pow(Tp, 1.2129)), 0.9847) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep24(const double &Tp) { return 0.1323 * pow(log(1.0 + 2.7248 * pow(Tp, 1.2129)), 0.9847) / Tp / Tp; }
 
 }  // namespace charged
 
@@ -89,13 +89,13 @@ double rep24(const double Tp) { return 0.1323 * pow(log(1.0 + 2.7248 * pow(Tp, 1
 // Takes T in Kelvin, returns in unit of m^2.
 namespace argon {
 
-double ArAr11(const double T) {
+MFEM_HOST_DEVICE double ArAr11(const double &T) {
   // Reference : fitted from tabulated data of Amdur, I., & Mason, E. A. (1958). Properties of gases at very high
   // temperatures. Physics of Fluids, 1(5), 370–383. https://doi.org/10.1063/1.1724353
   return 2.2910e-18 * pow(T, -0.3032);
 }
 
-double ArAr22(const double T) {
+MFEM_HOST_DEVICE double ArAr22(const double &T) {
   // Reference : Liu, W. S., Whitten, B. T., & Glass, I. I. (1978). Ionizing argon boundary layers. Part 1. Quasi-steady
   // flat-plate laminar boundary-layer flows. Journal of Fluid Mechanics, 87(4), 609–640.
   // https://doi.org/10.1017/S0022112078001792
@@ -103,7 +103,7 @@ double ArAr22(const double T) {
 }
 
 // argon neutral (Ar) - argon positive ion (Ar1P)
-double ArAr1P11(const double T) {
+MFEM_HOST_DEVICE double ArAr1P11(const double &T) {
   // Reference: fitted from tabulated data of Devoto, R. S. (1973). Transport coefficients of ionized argon. Physics of
   // Fluids, 16(5), 616–623. https://doi.org/10.1063/1.1694396
   return 4.574321e-18 * pow(T, -0.1805);
@@ -114,7 +114,7 @@ double ArAr1P11(const double T) {
   Q_{e,Ar}^(1), elastic momentum transfer cross section, is determined by a 7-parameter shifted MERT model,
   fitted over BSR LXCat dataset.
 */
-double eAr11(const double T) {
+MFEM_HOST_DEVICE double eAr11(const double &T) {
   const double logT = log(T);
   if (T < 1.2e4) {
     return 5.8664e-22 * logT * logT * logT - 6.3417e-21 * logT * logT + 3.2083e-21 * logT + 9.0686e-20;
@@ -124,7 +124,7 @@ double eAr11(const double T) {
   }
 }
 
-double eAr12(const double T) {
+MFEM_HOST_DEVICE double eAr12(const double &T) {
   const double logT = log(T);
   if (T < 1.0e4) {
     return 5.0435e-22 * logT * logT * logT - 4.0041e-21 * logT * logT - 1.3234e-20 * logT + 1.1966e-19;
@@ -134,7 +134,7 @@ double eAr12(const double T) {
   }
 }
 
-double eAr13(const double T) {
+MFEM_HOST_DEVICE double eAr13(const double &T) {
   const double logT = log(T);
   if (T < 8.2e3) {
     return 4.3150e-22 * logT * logT * logT - 2.1312e-21 * logT * logT - 2.5311e-20 * logT + 1.3866e-19;
@@ -144,7 +144,7 @@ double eAr13(const double T) {
   }
 }
 
-double eAr14(const double T) {
+MFEM_HOST_DEVICE double eAr14(const double &T) {
   const double logT = log(T);
   if (T < 7.1e3) {
     return 3.9545e-22 * logT * logT * logT - 1.1198e-21 * logT * logT - 3.1302e-20 * logT + 1.4507e-19;
@@ -154,7 +154,7 @@ double eAr14(const double T) {
   }
 }
 
-double eAr15(const double T) {
+MFEM_HOST_DEVICE double eAr15(const double &T) {
   const double logT = log(T);
   if (T < 6.0e3) {
     return 2.8521e-22 * logT * logT * logT + 9.9567e-22 * logT * logT - 4.2614e-20 * logT + 1.6026e-19;

--- a/src/collision_integrals.cpp
+++ b/src/collision_integrals.cpp
@@ -50,37 +50,69 @@ namespace charged {
   laser-plasma interactions. Journal of Computational Physics, 406, 109190. https://doi.org/10.1016/j.jcp.2019.109190
 */
 
-MFEM_HOST_DEVICE double att11(const double &Tp) { return 0.2150 * pow(log(1.0 + 5.2194 * pow(Tp, 1.0472)), 1.2435) / Tp / Tp; }
+MFEM_HOST_DEVICE double att11(const double &Tp) {
+  return 0.2150 * pow(log(1.0 + 5.2194 * pow(Tp, 1.0472)), 1.2435) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double att12(const double &Tp) { return 0.0991 * pow(log(1.0 + 7.4684 * pow(Tp, 1.0155)), 1.1536) / Tp / Tp; }
+MFEM_HOST_DEVICE double att12(const double &Tp) {
+  return 0.0991 * pow(log(1.0 + 7.4684 * pow(Tp, 1.0155)), 1.1536) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double att13(const double &Tp) { return 0.0616 * pow(log(1.0 + 7.8271 * pow(Tp, 0.9452)), 1.1105) / Tp / Tp; }
+MFEM_HOST_DEVICE double att13(const double &Tp) {
+  return 0.0616 * pow(log(1.0 + 7.8271 * pow(Tp, 0.9452)), 1.1105) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double att14(const double &Tp) { return 0.0308 * pow(log(1.0 + 13.9567 * pow(Tp, 0.9511)), 1.1803) / Tp / Tp; }
+MFEM_HOST_DEVICE double att14(const double &Tp) {
+  return 0.0308 * pow(log(1.0 + 13.9567 * pow(Tp, 0.9511)), 1.1803) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double att15(const double &Tp) { return 0.0232 * pow(log(1.0 + 13.7888 * pow(Tp, 0.9148)), 1.1532) / Tp / Tp; }
+MFEM_HOST_DEVICE double att15(const double &Tp) {
+  return 0.0232 * pow(log(1.0 + 13.7888 * pow(Tp, 0.9148)), 1.1532) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double att22(const double &Tp) { return 0.2423 * pow(log(1.0 + 4.6796 * pow(Tp, 1.3290)), 1.1279) / Tp / Tp; }
+MFEM_HOST_DEVICE double att22(const double &Tp) {
+  return 0.2423 * pow(log(1.0 + 4.6796 * pow(Tp, 1.3290)), 1.1279) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double att23(const double &Tp) { return 0.1221 * pow(log(1.0 + 8.7542 * pow(Tp, 1.3875)), 1.1110) / Tp / Tp; }
+MFEM_HOST_DEVICE double att23(const double &Tp) {
+  return 0.1221 * pow(log(1.0 + 8.7542 * pow(Tp, 1.3875)), 1.1110) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double att24(const double &Tp) { return 0.0619 * pow(log(1.0 + 18.2538 * pow(Tp, 1.4341)), 1.1618) / Tp / Tp; }
+MFEM_HOST_DEVICE double att24(const double &Tp) {
+  return 0.0619 * pow(log(1.0 + 18.2538 * pow(Tp, 1.4341)), 1.1618) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double rep11(const double &Tp) { return 0.3904 * pow(log(1.0 + 0.9100 * pow(Tp, 1.1025)), 1.0544) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep11(const double &Tp) {
+  return 0.3904 * pow(log(1.0 + 0.9100 * pow(Tp, 1.1025)), 1.0544) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double rep12(const double &Tp) { return 0.1547 * pow(log(1.0 + 1.6597 * pow(Tp, 1.1725)), 0.9792) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep12(const double &Tp) {
+  return 0.1547 * pow(log(1.0 + 1.6597 * pow(Tp, 1.1725)), 0.9792) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double rep13(const double &Tp) { return 0.0814 * pow(log(1.0 + 2.5815 * pow(Tp, 1.1948)), 0.9570) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep13(const double &Tp) {
+  return 0.0814 * pow(log(1.0 + 2.5815 * pow(Tp, 1.1948)), 0.9570) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double rep14(const double &Tp) { return 0.0683 * pow(log(1.0 + 1.9774 * pow(Tp, 1.2033)), 0.8264) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep14(const double &Tp) {
+  return 0.0683 * pow(log(1.0 + 1.9774 * pow(Tp, 1.2033)), 0.8264) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double rep15(const double &Tp) { return 0.0346 * pow(log(1.0 + 4.5177 * pow(Tp, 1.2132)), 0.9294) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep15(const double &Tp) {
+  return 0.0346 * pow(log(1.0 + 4.5177 * pow(Tp, 1.2132)), 0.9294) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double rep22(const double &Tp) { return 0.4128 * pow(log(1.0 + 1.2436 * pow(Tp, 1.1830)), 1.0123) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep22(const double &Tp) {
+  return 0.4128 * pow(log(1.0 + 1.2436 * pow(Tp, 1.1830)), 1.0123) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double rep23(const double &Tp) { return 0.2203 * pow(log(1.0 + 1.8832 * pow(Tp, 1.2059)), 0.9851) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep23(const double &Tp) {
+  return 0.2203 * pow(log(1.0 + 1.8832 * pow(Tp, 1.2059)), 0.9851) / Tp / Tp;
+}
 
-MFEM_HOST_DEVICE double rep24(const double &Tp) { return 0.1323 * pow(log(1.0 + 2.7248 * pow(Tp, 1.2129)), 0.9847) / Tp / Tp; }
+MFEM_HOST_DEVICE double rep24(const double &Tp) {
+  return 0.1323 * pow(log(1.0 + 2.7248 * pow(Tp, 1.2129)), 0.9847) / Tp / Tp;
+}
 
 }  // namespace charged
 

--- a/src/collision_integrals.hpp
+++ b/src/collision_integrals.hpp
@@ -33,6 +33,7 @@
 #define COLLISION_INTEGRALS_HPP_
 
 #include <math.h>
+
 #include <mfem/general/forall.hpp>
 
 using namespace std;

--- a/src/collision_integrals.hpp
+++ b/src/collision_integrals.hpp
@@ -33,6 +33,7 @@
 #define COLLISION_INTEGRALS_HPP_
 
 #include <math.h>
+#include <mfem/general/forall.hpp>
 
 using namespace std;
 

--- a/src/collision_integrals.hpp
+++ b/src/collision_integrals.hpp
@@ -54,25 +54,25 @@ namespace charged {
   laser-plasma interactions. Journal of Computational Physics, 406, 109190. https://doi.org/10.1016/j.jcp.2019.109190
 */
 
-double att11(const double Tp);
-double att12(const double Tp);
-double att13(const double Tp);
-double att14(const double Tp);
-double att15(const double Tp);
+MFEM_HOST_DEVICE double att11(const double &Tp);
+MFEM_HOST_DEVICE double att12(const double &Tp);
+MFEM_HOST_DEVICE double att13(const double &Tp);
+MFEM_HOST_DEVICE double att14(const double &Tp);
+MFEM_HOST_DEVICE double att15(const double &Tp);
 
-double att22(const double Tp);
-double att23(const double Tp);
-double att24(const double Tp);
+MFEM_HOST_DEVICE double att22(const double &Tp);
+MFEM_HOST_DEVICE double att23(const double &Tp);
+MFEM_HOST_DEVICE double att24(const double &Tp);
 
-double rep11(const double Tp);
-double rep12(const double Tp);
-double rep13(const double Tp);
-double rep14(const double Tp);
-double rep15(const double Tp);
+MFEM_HOST_DEVICE double rep11(const double &Tp);
+MFEM_HOST_DEVICE double rep12(const double &Tp);
+MFEM_HOST_DEVICE double rep13(const double &Tp);
+MFEM_HOST_DEVICE double rep14(const double &Tp);
+MFEM_HOST_DEVICE double rep15(const double &Tp);
 
-double rep22(const double Tp);
-double rep23(const double Tp);
-double rep24(const double Tp);
+MFEM_HOST_DEVICE double rep22(const double &Tp);
+MFEM_HOST_DEVICE double rep23(const double &Tp);
+MFEM_HOST_DEVICE double rep24(const double &Tp);
 
 }  // namespace charged
 
@@ -81,23 +81,23 @@ double rep24(const double Tp);
 // Takes T in Kelvin, returns in unit of m^2.
 namespace argon {
 
-double ArAr11(const double T);
+MFEM_HOST_DEVICE double ArAr11(const double &T);
 
-double ArAr22(const double T);
+MFEM_HOST_DEVICE double ArAr22(const double &T);
 
 // argon neutral (Ar) - argon positive ion (Ar1P)
-double ArAr1P11(const double T);
+MFEM_HOST_DEVICE double ArAr1P11(const double &T);
 
 /*
   e-Ar (l,r) are fitted over numerical quadrature of definitions.
   Q_{e,Ar}^(1), elastic momentum transfer cross section, is determined by a 7-parameter shifted MERT model,
   fitted over BSR LXCat dataset.
 */
-double eAr11(const double T);
-double eAr12(const double T);
-double eAr13(const double T);
-double eAr14(const double T);
-double eAr15(const double T);
+MFEM_HOST_DEVICE double eAr11(const double &T);
+MFEM_HOST_DEVICE double eAr12(const double &T);
+MFEM_HOST_DEVICE double eAr13(const double &T);
+MFEM_HOST_DEVICE double eAr14(const double &T);
+MFEM_HOST_DEVICE double eAr15(const double &T);
 
 }  // namespace argon
 

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -349,6 +349,9 @@ struct ArgonTransportInput {
   int electronIndex;
 
   bool thirdOrderkElectron;
+
+  // ArgonMixtureTransport
+  ArgonColl collisionIndex[gpudata::MAXSPECIES * gpudata::MAXSPECIES];
 };
 
 struct ChemistryInput {

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -347,6 +347,8 @@ struct ArgonTransportInput {
   int neutralIndex;
   int ionIndex;
   int electronIndex;
+
+  bool thirdOrderkElectron;
 };
 
 struct ChemistryInput {

--- a/src/gpu_constructor.cpp
+++ b/src/gpu_constructor.cpp
@@ -62,6 +62,11 @@ __global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const co
   *trans = new ConstantTransport(mixture, inputs);
 }
 
+__global__ void instantiateDeviceArgonMinimalTransport(GasMixture *mixture, const ArgonTransportInput inputs,
+                                                       TransportProperties **trans) {
+  *trans = new ArgonMinimalTransport(mixture, inputs);
+}
+
 __global__ void instantiateDeviceFluxes(GasMixture *_mixture, Equations _eqSystem, TransportProperties *_transport,
                                         const int _num_equation, const int _dim, bool axisym, Fluxes **f) {
   *f = new Fluxes(_mixture, _eqSystem, _transport, _num_equation, _dim, axisym);

--- a/src/gpu_constructor.cpp
+++ b/src/gpu_constructor.cpp
@@ -67,6 +67,11 @@ __global__ void instantiateDeviceArgonMinimalTransport(GasMixture *mixture, cons
   *trans = new ArgonMinimalTransport(mixture, inputs);
 }
 
+__global__ void instantiateDeviceArgonMixtureTransport(GasMixture *mixture, const ArgonTransportInput inputs,
+                                                       TransportProperties **trans) {
+  *trans = new ArgonMixtureTransport(mixture, inputs);
+}
+
 __global__ void instantiateDeviceFluxes(GasMixture *_mixture, Equations _eqSystem, TransportProperties *_transport,
                                         const int _num_equation, const int _dim, bool axisym, Fluxes **f) {
   *f = new Fluxes(_mixture, _eqSystem, _transport, _num_equation, _dim, axisym);

--- a/src/gpu_constructor.hpp
+++ b/src/gpu_constructor.hpp
@@ -79,6 +79,8 @@ __global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const co
                                                    TransportProperties **trans);
 __global__ void instantiateDeviceArgonMinimalTransport(GasMixture *mixture, const ArgonTransportInput inputs,
                                                        TransportProperties **trans);
+__global__ void instantiateDeviceArgonMixtureTransport(GasMixture *mixture, const ArgonTransportInput inputs,
+                                                       TransportProperties **trans);
 __global__ void instantiateDeviceFluxes(GasMixture *_mixture, Equations _eqSystem, TransportProperties *_transport,
                                         const int _num_equation, const int _dim, bool axisym, Fluxes **f);
 __global__ void instantiateDeviceRiemann(int _num_equation, GasMixture *_mixture, Equations _eqSystem,

--- a/src/gpu_constructor.hpp
+++ b/src/gpu_constructor.hpp
@@ -77,6 +77,8 @@ __global__ void instantiateDeviceDryAirTransport(GasMixture *mixture, const doub
 __global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel, GasMixture **mix);
 __global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const constantTransportData inputs,
                                                    TransportProperties **trans);
+__global__ void instantiateDeviceArgonMinimalTransport(GasMixture *mixture, const ArgonTransportInput inputs,
+                                                       TransportProperties **trans);
 __global__ void instantiateDeviceFluxes(GasMixture *_mixture, Equations _eqSystem, TransportProperties *_transport,
                                         const int _num_equation, const int _dim, bool axisym, Fluxes **f);
 __global__ void instantiateDeviceRiemann(int _num_equation, GasMixture *_mixture, Equations _eqSystem,

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -45,16 +45,7 @@ TESTS += cyl3d.gpu.python.test
 endif
 
 else
-TESTS += cyl3d.test \
-	 cyl3d.mflow.test \
-	 cyl3d.dtconst.test \
-	 averages.test \
-	 wedge.test \
-	 qms.rings.test \
-	 sponge_zone.test \
-	 annulus.test \
-	 pipe.test \
-	 perfect_gas.test \
+TESTS += perfect_gas.test \
 	 collision_integrals.test \
 	 argon_minimal.test \
 	 argon_minimal.binary.test \
@@ -89,8 +80,7 @@ TESTS           += cuda-memcheck.test
 endif
 
 if MASA_ENABLED
-TESTS += mms.euler.test \
-	 mms.ternary_2d.test \
+TESTS += mms.ternary_2d.test \
 	 mms.ternary_2d_wall.test \
 	 mms.ternary_2d_inout.test \
 	 mms.general_wall.test

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -45,7 +45,16 @@ TESTS += cyl3d.gpu.python.test
 endif
 
 else
-TESTS += perfect_gas.test \
+TESTS += cyl3d.test \
+	 cyl3d.mflow.test \
+	 cyl3d.dtconst.test \
+	 averages.test \
+	 wedge.test \
+	 qms.rings.test \
+	 sponge_zone.test \
+	 annulus.test \
+	 pipe.test \
+	 perfect_gas.test \
 	 collision_integrals.test \
 	 argon_minimal.test \
 	 argon_minimal.binary.test \
@@ -80,7 +89,8 @@ TESTS           += cuda-memcheck.test
 endif
 
 if MASA_ENABLED
-TESTS += mms.ternary_2d.test \
+TESTS += mms.euler.test \
+	 mms.ternary_2d.test \
 	 mms.ternary_2d_wall.test \
 	 mms.ternary_2d_inout.test \
 	 mms.general_wall.test


### PR DESCRIPTION
- `collisionIndex_` is now parsed at `RunConfiguration` level and packed into `ArgonTransportInput`.
- `atomMap_`, `speciesNames_`, `composition_` are now unnecessary and removed.
- Internal methods of `ArgonMixtureTransport` are made `MFEM_HOST_DEVICE` and verified through cpu CI test.

This does not address the issue #154 , simply translating functions into `MFEM_HOST_DEVICE`.