### PR TITLE
Gpu enable masa tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,6 +76,7 @@ jobs:
     name: Build/GPU (Cuda)
     env:
       MFEM_DIR: /home/karl/sw/mfem-gpu-4.4
+      MASA_DIR: /home/oliver/sw/masa
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.9.0

--- a/src/forcing_terms.cpp
+++ b/src/forcing_terms.cpp
@@ -880,7 +880,7 @@ void MASA_forcings::updateTerms(Vector &in) {
   int numElem = vfes->GetNE();
   int dof = vfes->GetNDofs();
 
-  double *data = in.GetData();
+  double *data = in.HostReadWrite();
   // const double *dataUp = Up->GetData();
 
   // get coords

--- a/src/source_term.cpp
+++ b/src/source_term.cpp
@@ -186,7 +186,7 @@ void SourceTerm::updateTerms(mfem::Vector &in) {
       for (int d = 0; d < _dim; d++) srcTerm[_num_equation - 1] += gradPe[d] * upn[d + 1];
 
       // energy transfer by elastic momentum transfer
-      const double me = _mixture->GetGasParams(numSpecies_ - 2, GasParams::SPECIES_MW);
+      const double me = _mixture->GetGasParams(_numSpecies - 2, GasParams::SPECIES_MW);
       const double ne = ns[_numSpecies - 2];
       for (int sp = 0; sp < _numSpecies; sp++) {
         if (sp == _numSpecies - 2) continue;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -99,8 +99,10 @@ if MASA_ENABLED
 TESTS += mms.euler.test \
 	 mms.ternary_2d.test \
 	 mms.ternary_2d_wall.test \
-	 mms.ternary_2d_inout.test \
-	 mms.general_wall.test
+	 mms.ternary_2d_inout.test
+if !GPU_ENABLED
+TESTS += mms.general_wall.test
+endif
 endif
 
 if !GPU_ENABLED

--- a/test/inputs/mms.euler.3d.r1.ini
+++ b/test/inputs/mms.euler.3d.r1.ini
@@ -18,7 +18,8 @@ outdirBase = output
 
 [time]
 integrator = rk4
-dt_fixed = 1e-04
+dt_fixed = 2e-05 #1e-04
+enableConstantTimestep = True
 
 [boundaryConditions]
 numWalls = 0

--- a/test/inputs/mms.euler.3d.r2.ini
+++ b/test/inputs/mms.euler.3d.r2.ini
@@ -18,7 +18,8 @@ outdirBase = output
 
 [time]
 integrator = rk4
-dt_fixed = 5e-05
+dt_fixed = 1e-05 #5e-05
+enableConstantTimestep = True
 
 [boundaryConditions]
 numWalls = 0

--- a/test/mms.euler.test
+++ b/test/mms.euler.test
@@ -22,7 +22,7 @@ RUNFILE_2="inputs/mms.euler.3d.r2.ini"
     # evaluate the convergence rate
     rho_rate=$(echo "l ($rho_err_r2 / $rho_err_r1) / l (0.5)" | bc -l)
 
-    # empirically observed rate 2.1676
+    # empirically observed rate 2.1646
     rate_p1_lo=2.16
     rate_p1_hi=2.17
 
@@ -41,7 +41,7 @@ RUNFILE_2="inputs/mms.euler.3d.r2.ini"
     # evaluate the convergence rate
     vel_rate=$(echo "l ($vel_err_r2 / $vel_err_r1) / l (0.5)" | bc -l)
 
-    # empirically observed rate 2.0344
+    # empirically observed rate 2.0385
     rate_p1_lo=2.03
     rate_p1_hi=2.04
 
@@ -60,9 +60,9 @@ RUNFILE_2="inputs/mms.euler.3d.r2.ini"
     # evaluate the convergence rate
     pre_rate=$(echo "l ($pre_err_r2 / $pre_err_r1) / l (0.5)" | bc -l)
 
-    # empirically observed rate 2.0698
-    rate_p1_lo=2.06
-    rate_p1_hi=2.08
+    # empirically observed rate 2.1718
+    rate_p1_lo=2.17
+    rate_p1_hi=2.18
 
     # make sure rate isn't too low or too high
     rate_check_lo=$( echo "$pre_rate > $rate_p1_lo" | bc -l )

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -112,6 +112,11 @@ if MASA_ENABLED
 compute_rhs_LDFLAGS += $(MASA_LIBS)
 endif
 
+if CUDA_ENABLED
+compute_rhs_LDFLAGS += $(CUDA_LDFLAGS)
+endif
+
+
 if !GPU_ENABLED
 
 endif # if !GPU_ENABLED


### PR DESCRIPTION
This PR enables tests that rely on [MASA](https://github.com/manufactured-solutions/MASA) to run for a CUDA build.  In the process, two coding bugs were fixed (see b33a009 and b4bb906) and minor modifications to the build and tests were made.