### PR TITLE
Add conductivity to EM

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1154,7 +1154,6 @@ void M2ulPhyS::initSolutionAndVisualizationVectors() {
     paraviewColl->RegisterField("Te", electron_temp_field);
   }
 
-
 // If mms, add exact solution.
 #ifdef HAVE_MASA
   if (config.use_mms_ && config.mmsSaveDetails_) {

--- a/src/em_options.hpp
+++ b/src/em_options.hpp
@@ -59,6 +59,10 @@ class ElectromagneticOptions {
   double yinterp_min;  /**< Begin value for uniformly spaced points */
   double yinterp_max;  /**< End value for uniformly spaced points */
 
+  double current_amplitude; /**< Amplitude of source current */
+  double current_frequency; /**< Frequency of source current */
+  double mu0;               /**< Permeability of free space */
+
   ElectromagneticOptions() {
     order = 1;
     ref_levels = 0;
@@ -70,6 +74,9 @@ class ElectromagneticOptions {
     yinterp_max = 1.0;
     top_only = false;
     bot_only = false;
+    current_amplitude = 1.0;
+    current_frequency = 1.0;
+    mu0 = 1.0;
   }
 
   void print(std::ostream &out) {
@@ -88,6 +95,9 @@ class ElectromagneticOptions {
     out << "  nBy         = " << nBy << std::endl;
     out << "  yinterp_min = " << yinterp_min << std::endl;
     out << "  yinterp_max = " << yinterp_max << std::endl;
+    out << "  current_amplitude = " << current_amplitude << std::endl;
+    out << "  current_frequency = " << current_frequency << std::endl;
+    out << "  mu0 = " << mu0 << std::endl;
     out << std::endl;
   }
 };

--- a/src/quasimagnetostatic.cpp
+++ b/src/quasimagnetostatic.cpp
@@ -43,7 +43,7 @@ using namespace mfem::common;
 void JFun(const Vector &x, Vector &f);
 
 QuasiMagnetostaticSolver3D::QuasiMagnetostaticSolver3D(MPI_Session &mpi, ElectromagneticOptions em_opts, TPS::Tps *tps)
-  : mpi_(mpi), em_opts_(em_opts), offsets_(3) {
+    : mpi_(mpi), em_opts_(em_opts), offsets_(3) {
   tpsP_ = tps;
 
   // verify running on cpu
@@ -450,7 +450,7 @@ void QuasiMagnetostaticSolver3D::solve() {
   paraview_dc.Save();
 
   // Compute and dump the magnetic field on the axis
-  //InterpolateToYAxis();
+  // InterpolateToYAxis();
 
   if (mpi_.Root()) {
     std::cout << "EM simulation complete" << std::endl;
@@ -486,7 +486,7 @@ void QuasiMagnetostaticSolver3D::InterpolateToYAxis() const {
   // And interpolate
   for (int ipt = 0; ipt < em_opts_.nBy; ipt++) {
     if (eid[ipt] >= 0) {
-      //B_->GetVectorValue(eid[ipt], ips[ipt], Bpoint);
+      // B_->GetVectorValue(eid[ipt], ips[ipt], Bpoint);
       Breal_->GetVectorValue(eid[ipt], ips[ipt], Bpoint);
       Byloc[ipt] = Bpoint[1];
     } else {
@@ -569,17 +569,12 @@ void JFun(const Vector &x, Vector &J) {
   J = axx;
 }
 
+static double radius(const Vector &x) { return x[0]; }
 
-static double radius(const Vector &x) {
-  return x[0];
-}
+static double oneOverRadius(const Vector &x) { return 1.0 / x[0]; }
 
-static double oneOverRadius(const Vector &x) {
-  return 1.0/x[0];
-}
-
-QuasiMagnetostaticSolverAxiSym::QuasiMagnetostaticSolverAxiSym(MPI_Session &mpi,
-                                                               ElectromagneticOptions em_opts, TPS::Tps *tps)
+QuasiMagnetostaticSolverAxiSym::QuasiMagnetostaticSolverAxiSym(MPI_Session &mpi, ElectromagneticOptions em_opts,
+                                                               TPS::Tps *tps)
     : mpi_(mpi), em_opts_(em_opts), offsets_(3) {
   tpsP_ = tps;
 
@@ -747,7 +742,6 @@ void QuasiMagnetostaticSolverAxiSym::InitializeCurrent() {
 
   current_initialized_ = true;
 }
-
 
 void QuasiMagnetostaticSolverAxiSym::parseSolverOptions() {
   tpsP_->getRequiredInput("em/mesh", em_opts_.mesh_file);

--- a/src/quasimagnetostatic.hpp
+++ b/src/quasimagnetostatic.hpp
@@ -61,6 +61,9 @@ class QuasiMagnetostaticSolver3D : public TPS::Solver {
   mfem::ParMesh *pmesh_;
   int dim_;
 
+  int true_size_;
+  Array<int> offsets_;
+
   mfem::FiniteElementCollection *hcurl_;
   mfem::FiniteElementCollection *h1_;
   mfem::FiniteElementCollection *hdiv_;
@@ -74,8 +77,15 @@ class QuasiMagnetostaticSolver3D : public TPS::Solver {
   mfem::ParBilinearForm *K_;
   mfem::ParLinearForm *r_;
 
-  mfem::ParGridFunction *A_;
-  mfem::ParGridFunction *B_;
+  mfem::ParGridFunction *Areal_;
+  mfem::ParGridFunction *Aimag_;
+
+  mfem::ParGridFunction *Breal_;
+  mfem::ParGridFunction *Bimag_;
+
+  mfem::ParGridFunction *plasma_conductivity_;
+  mfem::GridFunctionCoefficient *plasma_conductivity_coef_;
+
 
   bool operator_initialized_;
   bool current_initialized_;

--- a/src/quasimagnetostatic.hpp
+++ b/src/quasimagnetostatic.hpp
@@ -86,7 +86,6 @@ class QuasiMagnetostaticSolver3D : public TPS::Solver {
   mfem::ParGridFunction *plasma_conductivity_;
   mfem::GridFunctionCoefficient *plasma_conductivity_coef_;
 
-
   bool operator_initialized_;
   bool current_initialized_;
 

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -195,7 +195,11 @@ void Tps::chooseSolver() {
   } else if (input_solver_type_ == "em") {
     isEMOnlyMode_ = true;
     ElectromagneticOptions em_opt;
-    solver_ = new QuasiMagnetostaticSolver(mpi_, em_opt, this);
+    solver_ = new QuasiMagnetostaticSolver3D(mpi_, em_opt, this);
+  } else if (input_solver_type_ == "em-axi") {
+    isEMOnlyMode_ = true;
+    ElectromagneticOptions em_opt;
+    solver_ = new QuasiMagnetostaticSolverAxiSym(mpi_, em_opt, this);
   } else if (input_solver_type_ == "coupled") {
     isFlowEMCoupledMode_ = true;
     grvy_printf(GRVY_ERROR, "\nSlow your roll.  Solid high-five for whoever implements this coupled solver mode!\n");

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -23,7 +23,7 @@ EXTRA_DIST      = tap-driver.sh soln_differ inputs meshes ref_solns/*.h5 \
 		  ref_solns/collisions/*.h5 ref_solns/transport/*.h5 \
 		  vpath.sh die.sh cyl3d.gpu.test cyl3d.mflow.gpu.test wedge.gpu.test \
 	          averages.gpu.test cyl3d.test cyl3d.mflow.test cyl3d.dtconst.test \
-		  die.test averages.test wedge.test cyl3d.interp.test qms.rings.test \
+		  die.test averages.test wedge.test cyl3d.interp.test qms.rings.test qms.axisym.test \
 		  sponge_zone.test annulus.test pipe.test valgrind.test valgrind.suppressions \
 		  mms.euler.test reaction.test perfect_gas.test collision_integrals.test \
 	 	  argon_minimal.test argon_minimal.binary.test diffusion_wall.test \
@@ -58,6 +58,7 @@ TESTS += cyl3d.test \
 	 averages.test \
 	 wedge.test \
 	 qms.rings.test \
+	 qms.axisym.test \
 	 sponge_zone.test \
 	 annulus.test \
 	 pipe.test \

--- a/test/inputs/axisym-rings.ini
+++ b/test/inputs/axisym-rings.ini
@@ -1,0 +1,28 @@
+#---------------------
+# TPS runtime controls
+#---------------------
+
+# choice of solver
+[solver]
+type = em-axi
+
+
+[em]
+mesh = meshes/axisym-rings.msh
+order       =  1                 # FE order (polynomial degree)
+ref_levels  =  1
+max_iter    =  1000              # max number of iterations
+rtol        =  1.0e-12           # solver relative tolerance
+atol        =  1.0e-18           # solver absolute tolerance
+top_only    =  false             # run current through top branch only
+bot_only    =  false             # run current through bottom branch only
+yinterp_min =  0.0               # minimum y interpolation value
+yinterp_max =  0.3               # maximum y interpolation value
+nBy         =  129               # of interpolation points
+By_file     =  By-axi.h5   # file for By interpolant output
+
+# Run 4 (550K to ???)
+current_amplitude = 6e6        # A/m^2
+
+current_frequency = 6e6          # 1/s
+permeability = 1.25663706e-6     # m * kg / s^2 / A^2

--- a/test/meshes/axisym-rings.msh
+++ b/test/meshes/axisym-rings.msh
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72a1bd6b97f8e7f9d6fcafddfc81e94e6325a86ada131bbe9c91ac8bf83183ce
+size 165008

--- a/test/qms.axisym.test
+++ b/test/qms.axisym.test
@@ -1,0 +1,21 @@
+#!./bats
+# -*- mode: sh -*-
+
+TEST="qms"
+
+setup() {
+    MESH_FILE=meshes/axisym-rings.msh
+    #REF_FILE=ref_solns/rings.centerline.By.np1.h5
+    #OUT_FILE=ref_solns/By.h5
+    #CMD_LINE="--em-only -m $MESH_FILE --rtol 1e-12 --atol 1e-15 --maxiter 30 -ny 129 -y0 -2.0 -y1 2.0 -by $OUT_FILE"
+    CMD_LINE="--runFile inputs/axisym-rings.ini"
+}
+
+@test "[$TEST] verify tps axisymmetric quasimagnetostatic solver runs with np = 1" {
+    test -s $MESH_FILE
+    run mpirun -np 1 ../src/tps $CMD_LINE
+    [[ "${status}" -eq 0 ]]
+    [[ "${output}" =~ "EM simulation complete" ]]
+    #h5diff -v -p 1e-12 $REF_FILE $OUT_FILE
+}
+

--- a/test/qms.rings.test
+++ b/test/qms.rings.test
@@ -7,23 +7,26 @@ setup() {
     MESH_FILE=meshes/rings.msh
     REF_FILE=ref_solns/rings.centerline.By.np1.h5
     OUT_FILE=ref_solns/By.h5
-    #CMD_LINE="--em-only -m $MESH_FILE --rtol 1e-12 --atol 1e-15 --maxiter 30 -ny 129 -y0 -2.0 -y1 2.0 -by $OUT_FILE"
     CMD_LINE="--runFile inputs/rings.ini"
 }
 
 @test "[$TEST] verify tps quasimagnetostatic solver runs with np = 1" {
+    rm -f $OUT_FILE
     test -s $MESH_FILE
     run mpirun -np 1 ../src/tps $CMD_LINE
     [[ "${status}" -eq 0 ]]
     [[ "${output}" =~ "EM simulation complete" ]]
+    test -s $OUT_FILE
     h5diff -v -p 1e-12 $REF_FILE $OUT_FILE
 }
 
 @test "[$TEST] verify tps quasimagnetostatic solver runs with np = 4" {
+    rm -f $OUT_FILE
     test -s $MESH_FILE
     run mpirun -np 4 ../src/tps $CMD_LINE
     [[ "${status}" -eq 0 ]]
     [[ "${output}" =~ "EM simulation complete" ]]
+    test -s $OUT_FILE
     h5diff -v -p 1e-12 $REF_FILE $OUT_FILE
 }
 


### PR DESCRIPTION
This PR extends the frequency domain quasi-magnetostatic EM models (3D and 2D, axisymmetric) to include a conductivity.  The conductivity field is assumed to be real valued and is currently set to 0 s.t. we recover previous results.  In the future, this field can be populated by the plasma solver.