### PR TITLE
Call FaceElementTransformations::SetIntPoint in boundary area calc

### DIFF
--- a/src/BoundaryCondition.cpp
+++ b/src/BoundaryCondition.cpp
@@ -63,7 +63,8 @@ double BoundaryCondition::aggregateArea(int bndry_patchnum, MPI_Comm bc_comm) {
       const IntegrationRule &ir = IntRules.Get(Tr->GetGeometryType(), Tr->OrderJ());
 
       for (int p = 0; p < ir.GetNPoints(); p++) {
-        const IntegrationPoint &ip = ir.IntPoint(p);
+        const IntegrationPoint ip = ir.IntPoint(p);
+        Tr->SetIntPoint(&ip);
         area += Tr->Weight() * ip.weight;
       }
     }


### PR DESCRIPTION
This PR fixes a long standing issue in the boundary area calculation.  Before using the `FaceElementTransformations` object, we have to set the integration point by calling `SetIntPoint`, which we had failed to do.  Since we're only using the `FaceElementTransformations::Weight` function, which won't actually depend on the quadrature point for linear elements, it seems we were getting away with it... until #168.

After b5ea27a, I have been unable to reproduce #168, so this PR resolves #168.