### PR TITLE
Fix const_plasma_conductivity input

### DIFF
--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -509,10 +509,10 @@ double EquationOfState::pressure( double *state,
 //////////////////////////////////////////////////////////////////////////
 
 PerfectMixture::PerfectMixture(RunConfiguration &_runfile, int _dim, int nvel)
-    : PerfectMixture(_runfile.perfectMixtureInput, _dim, nvel) {}
+    : PerfectMixture(_runfile.perfectMixtureInput, _dim, nvel, _runfile.const_plasma_conductivity_) {}
 
-MFEM_HOST_DEVICE PerfectMixture::PerfectMixture(PerfectMixtureInput inputs, int _dim, int nvel)
-    : GasMixture(inputs.f, _dim, nvel) {
+MFEM_HOST_DEVICE PerfectMixture::PerfectMixture(PerfectMixtureInput inputs, int _dim, int nvel, double pc)
+    : GasMixture(inputs.f, _dim, nvel, pc) {
   numSpecies = inputs.numSpecies;
   assert(nvel_ <= gpudata::MAXDIM);
   assert(numSpecies <= gpudata::MAXSPECIES);

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -617,7 +617,7 @@ class PerfectMixture : public GasMixture {
   // virtual void SetNumEquations();
  public:
   PerfectMixture(RunConfiguration &_runfile, int _dim, int nvel);
-  MFEM_HOST_DEVICE PerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel);
+  MFEM_HOST_DEVICE PerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel, double pc = 0);
 
   // FIXME: Generates compiler warning b/c this dtor implicitly calls
   // Vector dtor, which is only a __host__ function!


### PR DESCRIPTION
It wasn't being used by PerfectMixture.  Now it is.