### PR TITLE
Interpolation fixes

### DIFF
--- a/src/cycle_avg_joule_coupling.cpp
+++ b/src/cycle_avg_joule_coupling.cpp
@@ -138,6 +138,7 @@ void CycleAvgJouleCoupling::interpConductivityFromFlowToEM() {
     conductivity_em_gf->SetSubVector(vdofs, elem_dof_vals);
   }
 
+  conductivity_em_gf->SetTrueVector();
   conductivity_em_gf->SetFromTrueVector();
 #else
   mfem_error("Cannot interpolate without GSLIB support.");

--- a/src/cycle_avg_joule_coupling.hpp
+++ b/src/cycle_avg_joule_coupling.hpp
@@ -61,6 +61,9 @@ class CycleAvgJouleCoupling : public TPS::Solver {
   FindPointsGSLIB *interp_em_to_flow_;
 #endif
 
+  int n_em_interp_nodes_;
+  int n_flow_interp_nodes_;
+
  public:
   CycleAvgJouleCoupling(MPI_Session &mpi, string &inputFileName, TPS::Tps *tps, int max_out);
   ~CycleAvgJouleCoupling();

--- a/test/interp_em.test
+++ b/test/interp_em.test
@@ -13,3 +13,9 @@ setup() {
     ./test_interp_em -run $RUNFILE_AXISYM
 }
 
+@test "[$TEST] flow/em interpolation: test 2d (axisymmetric) interpolation capability (2 mpi ranks)" {
+    test -s $RUNFILE_AXISYM
+    test -e ./test_interp_em
+    mpirun -np 2 ./test_interp_em -run $RUNFILE_AXISYM
+}
+


### PR DESCRIPTION
This PR resolves two mesh interpolation issues:

* The flow to em interpolation in parallel was broken by 68ff89a.
* Since mfem+gslib now supports mixed mesh interpolation, we have generalized the indexing to allow mixed meshes in our code as well.