### PR TITLE
Extend simple coupling via cycle averaged Joule heating to 3D

### DIFF
--- a/src/cycle_avg_joule_coupling.cpp
+++ b/src/cycle_avg_joule_coupling.cpp
@@ -35,9 +35,13 @@
 #include "em_options.hpp"
 #include "quasimagnetostatic.hpp"
 
-CycleAvgJouleCoupling::CycleAvgJouleCoupling(MPI_Session &mpi, string &inputFileName, TPS::Tps *tps, int max_out)
+CycleAvgJouleCoupling::CycleAvgJouleCoupling(MPI_Session &mpi, string &inputFileName, TPS::Tps *tps, int max_out, bool axisym)
     : mpi_(mpi), em_opt_(), max_outer_iters_(max_out) {
-  qmsa_solver_ = new QuasiMagnetostaticSolverAxiSym(mpi, em_opt_, tps);
+  if (axisym) {
+    qmsa_solver_ = new QuasiMagnetostaticSolverAxiSym(mpi, em_opt_, tps);
+  } else {
+    qmsa_solver_ = new QuasiMagnetostaticSolver3D(mpi, em_opt_, tps);
+  }
   flow_solver_ = new M2ulPhyS(mpi, inputFileName, tps);
 #ifdef HAVE_GSLIB
   interp_flow_to_em_ = new FindPointsGSLIB(MPI_COMM_WORLD);

--- a/src/cycle_avg_joule_coupling.cpp
+++ b/src/cycle_avg_joule_coupling.cpp
@@ -35,7 +35,8 @@
 #include "em_options.hpp"
 #include "quasimagnetostatic.hpp"
 
-CycleAvgJouleCoupling::CycleAvgJouleCoupling(MPI_Session &mpi, string &inputFileName, TPS::Tps *tps, int max_out, bool axisym)
+CycleAvgJouleCoupling::CycleAvgJouleCoupling(MPI_Session &mpi, string &inputFileName, TPS::Tps *tps, int max_out,
+                                             bool axisym)
     : mpi_(mpi), em_opt_(), max_outer_iters_(max_out) {
   if (axisym) {
     qmsa_solver_ = new QuasiMagnetostaticSolverAxiSym(mpi, em_opt_, tps);

--- a/src/cycle_avg_joule_coupling.cpp
+++ b/src/cycle_avg_joule_coupling.cpp
@@ -241,6 +241,10 @@ void CycleAvgJouleCoupling::solve() {
     // EM
     interpConductivityFromFlowToEM();
     qmsa_solver_->solve();
+    const double tot_jh = qmsa_solver_->totalJouleHeating();
+    if (mpi_.Root()) {
+      grvy_printf(GRVY_INFO, "The total input Joule heating = %.6e\n", tot_jh);
+    }
 
     // flow
     interpJouleHeatingFromEMToFlow();

--- a/src/cycle_avg_joule_coupling.hpp
+++ b/src/cycle_avg_joule_coupling.hpp
@@ -51,7 +51,7 @@ class CycleAvgJouleCoupling : public TPS::Solver {
  private:
   MPI_Session &mpi_;
   ElectromagneticOptions em_opt_;
-  QuasiMagnetostaticSolverAxiSym *qmsa_solver_;
+  QuasiMagnetostaticSolverBase *qmsa_solver_;
   M2ulPhyS *flow_solver_;
 
   int max_outer_iters_;
@@ -65,7 +65,7 @@ class CycleAvgJouleCoupling : public TPS::Solver {
   int n_flow_interp_nodes_;
 
  public:
-  CycleAvgJouleCoupling(MPI_Session &mpi, string &inputFileName, TPS::Tps *tps, int max_out);
+  CycleAvgJouleCoupling(MPI_Session &mpi, string &inputFileName, TPS::Tps *tps, int max_out, bool axisym);
   ~CycleAvgJouleCoupling();
 
   void initializeInterpolationData();
@@ -77,6 +77,6 @@ class CycleAvgJouleCoupling : public TPS::Solver {
   void solve() override;
 
   M2ulPhyS *getFlowSolver() { return flow_solver_; }
-  QuasiMagnetostaticSolverAxiSym *getEMSolver() { return qmsa_solver_; }
+  QuasiMagnetostaticSolverBase *getEMSolver() { return qmsa_solver_; }
 };
 #endif  // CYCLE_AVG_JOULE_COUPLING_HPP_

--- a/src/em_options.hpp
+++ b/src/em_options.hpp
@@ -50,6 +50,7 @@ class ElectromagneticOptions {
   int max_iter; /**< Maximum number of linear solver iterations */
   double rtol;  /**< Linear solver relative tolerance */
   double atol;  /**< Linear solver absolute tolerance */
+  double preconditioner_background_sigma;  /**< Uniform conductivity to use to preconditioner (ignored if <= 0) */
 
   bool top_only; /**< Flag to specify current in top rings only */
   bool bot_only; /**< Flag to specify current in bottom rings only */
@@ -72,6 +73,7 @@ class ElectromagneticOptions {
     max_iter = 100;
     rtol = 1.0e-6;
     atol = 1.0e-10;
+    preconditioner_background_sigma = -1;
     evaluate_magnetic_field = true;
     nBy = 0;
     yinterp_min = 0.0;

--- a/src/em_options.hpp
+++ b/src/em_options.hpp
@@ -64,6 +64,8 @@ class ElectromagneticOptions {
   double current_frequency; /**< Frequency of source current */
   double mu0;               /**< Permeability of free space */
 
+  mfem::Vector current_axis;
+
   ElectromagneticOptions() {
     order = 1;
     ref_levels = 0;

--- a/src/em_options.hpp
+++ b/src/em_options.hpp
@@ -54,6 +54,7 @@ class ElectromagneticOptions {
   bool top_only; /**< Flag to specify current in top rings only */
   bool bot_only; /**< Flag to specify current in bottom rings only */
 
+  bool evaluate_magnetic_field;
   std::string By_file; /**< Filename for vertical component of magnetic field on y-axis */
   int nBy;             /**< Number of uniformly spaced points for By output */
   double yinterp_min;  /**< Begin value for uniformly spaced points */
@@ -69,6 +70,7 @@ class ElectromagneticOptions {
     max_iter = 100;
     rtol = 1.0e-6;
     atol = 1.0e-10;
+    evaluate_magnetic_field = true;
     nBy = 0;
     yinterp_min = 0.0;
     yinterp_max = 1.0;

--- a/src/em_options.hpp
+++ b/src/em_options.hpp
@@ -47,10 +47,10 @@ class ElectromagneticOptions {
   int order;      /**< Element order */
   int ref_levels; /**< Number of uniform mesh refinements */
 
-  int max_iter; /**< Maximum number of linear solver iterations */
-  double rtol;  /**< Linear solver relative tolerance */
-  double atol;  /**< Linear solver absolute tolerance */
-  double preconditioner_background_sigma;  /**< Uniform conductivity to use to preconditioner (ignored if <= 0) */
+  int max_iter;                           /**< Maximum number of linear solver iterations */
+  double rtol;                            /**< Linear solver relative tolerance */
+  double atol;                            /**< Linear solver absolute tolerance */
+  double preconditioner_background_sigma; /**< Uniform conductivity to use to preconditioner (ignored if <= 0) */
 
   bool top_only; /**< Flag to specify current in top rings only */
   bool bot_only; /**< Flag to specify current in bottom rings only */

--- a/src/forcing_terms.cpp
+++ b/src/forcing_terms.cpp
@@ -407,8 +407,6 @@ JouleHeating::JouleHeating(const int &_dim, const int &_num_equation, const int 
 }
 
 void JouleHeating::updateTerms(Vector &in) {
-  // make sure we are in a 2D case (otherwise can't be axisymmetric)
-  assert(dim == 2);
   assert(nvel == 3);
 
   int numElem = vfes->GetNE();

--- a/src/quasimagnetostatic.cpp
+++ b/src/quasimagnetostatic.cpp
@@ -954,5 +954,6 @@ double QuasiMagnetostaticSolverAxiSym::totalJouleHeating() {
   double total_int_jh = 0;
   MPI_Allreduce(&int_jh, &total_int_jh, 1, MPI_DOUBLE, MPI_SUM, fes->GetComm());
 
-  return total_int_jh;
+  // Factor of 2*pi from azimuthal direction integral
+  return 2 * M_PI * total_int_jh;
 }

--- a/src/quasimagnetostatic.cpp
+++ b/src/quasimagnetostatic.cpp
@@ -520,6 +520,13 @@ void QuasiMagnetostaticSolver3D::InterpolateToYAxis() const {
   delete By;
 }
 
+double QuasiMagnetostaticSolver3D::elementJouleHeating(const FiniteElement &el, ElementTransformation &Tr,
+                                                       const Vector &elfun) {
+  return 0;
+}
+
+double QuasiMagnetostaticSolver3D::totalJouleHeating() { return 0; }
+
 void JFun(const Vector &x, Vector &J) {
   Vector a(3);
   a(0) = 0.0;
@@ -867,4 +874,85 @@ void QuasiMagnetostaticSolverAxiSym::solve() {
   if (mpi_.Root()) {
     std::cout << "EM simulation complete" << std::endl;
   }
+}
+
+double QuasiMagnetostaticSolverAxiSym::elementJouleHeating(const FiniteElement &el, ElementTransformation &Tr,
+                                                           const Vector &elfun) {
+  // Get size info
+  const int dof = el.GetDof();
+  const int dim = el.GetDim();
+  const int nvar = 1;
+
+  assert(dim == 2);
+
+  // Storage for basis fcns, derivatives, fluxes
+  Vector shape;
+  shape.SetSize(dof);
+  Vector soln;
+  soln.SetSize(nvar);
+
+  // View elfun and elvec as matrices (make life easy below)
+  DenseMatrix elfun_mat(elfun.GetData(), dof, nvar);
+
+  // Get quadrature rule
+  const int order = el.GetOrder();
+  const int intorder = order + 1;
+  const IntegrationRule *ir = &IntRules.Get(el.GetGeomType(), intorder);
+
+  double elem_jh = 0;
+
+  // for every quadrature point...
+  for (int i = 0; i < ir->GetNPoints(); i++) {
+    const IntegrationPoint &ip = ir->IntPoint(i);
+    Tr.SetIntPoint(&ip);
+
+    // evaluate radius
+    double x[3];
+    Vector transip(x, 3);
+    Tr.Transform(ip, transip);
+    const double radius = transip[0];
+
+    // evaluate basis functions
+    el.CalcShape(ip, shape);
+
+    // Interpolate solution
+    elfun_mat.MultTranspose(shape, soln);
+
+    // Add quad point contribution to integral
+    double qpcontrib = soln[0] * radius;
+
+    const double wt = ip.weight * Tr.Weight();
+    elem_jh += qpcontrib * wt;
+  }
+
+  return elem_jh;
+}
+
+double QuasiMagnetostaticSolverAxiSym::totalJouleHeating() {
+  const int NE = pmesh_->GetNE();
+  const ParFiniteElementSpace *fes = this->getFESpace();
+
+  double int_jh = 0;
+
+  Array<int> vdofs;
+  Vector el_x;
+
+  // loop over elements on this mpi rank and integrate joule heating
+  for (int ielem = 0; ielem < NE; ielem++) {
+    const FiniteElement *fe = fes->GetFE(ielem);
+    DofTransformation *doftrans = fes->GetElementVDofs(ielem, vdofs);
+    ElementTransformation *T = fes->GetElementTransformation(ielem);
+    joule_heating_->GetSubVector(vdofs, el_x);
+    if (doftrans) {
+      doftrans->InvTransformPrimal(el_x);
+    }
+
+    int_jh += elementJouleHeating(*fe, *T, el_x);
+  }
+
+  // sum over mpi ranks
+  double total_int_jh = 0;
+  MPI_Allreduce(&int_jh, &total_int_jh, 1, MPI_DOUBLE, MPI_SUM, fes->GetComm());
+
+  return total_int_jh;
 }

--- a/src/quasimagnetostatic.cpp
+++ b/src/quasimagnetostatic.cpp
@@ -412,12 +412,11 @@ void QuasiMagnetostaticSolver3D::solve() {
     Paar->SetSingularProblem();
   }
 
-  Operator *Paai = new ScaledOperator(Paar,-1.0);
+  Operator *Paai = new ScaledOperator(Paar, -1.0);
 
   BlockDiagonalPreconditioner BDP(offsets_);
   BDP.SetDiagonalBlock(0, Paar);
   BDP.SetDiagonalBlock(1, Paai);
-
 
   // 1) Solve QMS (i.e., i \omega A + curl(curl(A)) = J) for magnetic
   //    vector potential using operators set up by Initialize() and

--- a/src/quasimagnetostatic.cpp
+++ b/src/quasimagnetostatic.cpp
@@ -1012,12 +1012,16 @@ double QuasiMagnetostaticSolverAxiSym::totalJouleHeating() {
   // loop over elements on this mpi rank and integrate joule heating
   for (int ielem = 0; ielem < NE; ielem++) {
     const FiniteElement *fe = fes->GetFE(ielem);
-    DofTransformation *doftrans = fes->GetElementVDofs(ielem, vdofs);
     ElementTransformation *T = fes->GetElementTransformation(ielem);
+#if MFEM_VERSION >= 40400
+    DofTransformation *doftrans = fes->GetElementVDofs(ielem, vdofs);
     joule_heating_->GetSubVector(vdofs, el_x);
     if (doftrans) {
       doftrans->InvTransformPrimal(el_x);
     }
+#else
+    joule_heating_->GetSubVector(vdofs, el_x);
+#endif
 
     int_jh += elementJouleHeating(*fe, *T, el_x);
   }

--- a/src/quasimagnetostatic.hpp
+++ b/src/quasimagnetostatic.hpp
@@ -85,6 +85,24 @@ class QuasiMagnetostaticSolverBase : public TPS::Solver {
   virtual double totalJouleHeating() = 0;
 };
 
+/** Helper class for Joule heating evaluation
+ *
+ *  Patterned off the mfem Joule miniapp:
+ *  https://github.com/mfem/mfem/blob/641078645f6eb2762ce7d9b05050a247e74aafb2/miniapps/electromagnetics/joule_solver.hpp#L225
+ */
+class JouleHeatingCoefficient3D : public Coefficient {
+ private:
+  GridFunctionCoefficient &sigma_;
+  ParGridFunction &Ereal_;
+  ParGridFunction &Eimag_;
+
+ public:
+  JouleHeatingCoefficient3D(GridFunctionCoefficient &sigma, ParGridFunction &Ereal, ParGridFunction &Eimag)
+      : sigma_(sigma), Ereal_(Ereal), Eimag_(Eimag) {}
+  virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+  virtual ~JouleHeatingCoefficient3D() {}
+};
+
 /** Solve quasi-magnetostatic approximation of Maxwell
  *
  *  Solves the quasi-magnetostatic approximation of Maxwell's
@@ -97,10 +115,12 @@ class QuasiMagnetostaticSolver3D : public QuasiMagnetostaticSolverBase {
   mfem::FiniteElementCollection *hcurl_;
   mfem::FiniteElementCollection *h1_;
   mfem::FiniteElementCollection *hdiv_;
+  mfem::FiniteElementCollection *L2_;
 
   mfem::ParFiniteElementSpace *Aspace_;
   mfem::ParFiniteElementSpace *pspace_;
   mfem::ParFiniteElementSpace *Bspace_;
+  mfem::ParFiniteElementSpace *jh_space_;
 
   mfem::Array<int> ess_bdr_tdofs_;
 

--- a/src/quasimagnetostatic.hpp
+++ b/src/quasimagnetostatic.hpp
@@ -68,7 +68,7 @@ class QuasiMagnetostaticSolverBase : public TPS::Solver {
 
  public:
   QuasiMagnetostaticSolverBase(mfem::MPI_Session &mpi, ElectromagneticOptions em_opts, TPS::Tps *tps);
-  virtual ~QuasiMagnetostaticSolverBase(){};
+  virtual ~QuasiMagnetostaticSolverBase() {}
 
   /** Initialize current for axisymmetric quasi-magnetostatic problem
    *

--- a/src/quasimagnetostatic.hpp
+++ b/src/quasimagnetostatic.hpp
@@ -40,6 +40,7 @@ class Tps;
 
 #include <iostream>
 
+#include "../utils/mfem_extras/pfem_extras.hpp"
 #include "em_options.hpp"
 #include "tps.hpp"
 #include "tps_mfem_wrap.hpp"
@@ -126,6 +127,9 @@ class QuasiMagnetostaticSolver3D : public QuasiMagnetostaticSolverBase {
 
   mfem::ParBilinearForm *K_;
   mfem::ParLinearForm *r_;
+
+  mfem::common::ParDiscreteGradOperator *grad_;
+  mfem::common::DivergenceFreeProjector *div_free_;
 
   mfem::ParGridFunction *Areal_;
   mfem::ParGridFunction *Aimag_;

--- a/src/quasimagnetostatic.hpp
+++ b/src/quasimagnetostatic.hpp
@@ -165,7 +165,7 @@ class QuasiMagnetostaticSolver3D : public QuasiMagnetostaticSolverBase {
   /** Solve quasi-magnetostatic problem */
   void solve() override;
 
-  mfem::ParFiniteElementSpace *getFESpace() { return Aspace_; }
+  mfem::ParFiniteElementSpace *getFESpace() { return pspace_; }
 
   double elementJouleHeating(const FiniteElement &el, ElementTransformation &Tr, const Vector &elfun) override;
   double totalJouleHeating() override;

--- a/src/quasimagnetostatic.hpp
+++ b/src/quasimagnetostatic.hpp
@@ -80,6 +80,9 @@ class QuasiMagnetostaticSolverBase : public TPS::Solver {
   mfem::ParGridFunction *getJouleHeatingGF() { return joule_heating_; }
 
   virtual mfem::ParFiniteElementSpace *getFESpace() = 0;
+
+  virtual double elementJouleHeating(const FiniteElement &el, ElementTransformation &Tr, const Vector &elfun) = 0;
+  virtual double totalJouleHeating() = 0;
 };
 
 /** Solve quasi-magnetostatic approximation of Maxwell
@@ -143,6 +146,9 @@ class QuasiMagnetostaticSolver3D : public QuasiMagnetostaticSolverBase {
   void solve() override;
 
   mfem::ParFiniteElementSpace *getFESpace() { return Aspace_; }
+
+  double elementJouleHeating(const FiniteElement &el, ElementTransformation &Tr, const Vector &elfun) override;
+  double totalJouleHeating() override;
 };
 
 /** Solve quasi-magnetostatic approximation of Maxwell for 2-D axisymmetric
@@ -194,6 +200,9 @@ class QuasiMagnetostaticSolverAxiSym : public QuasiMagnetostaticSolverBase {  //
   void solve() override;
 
   mfem::ParFiniteElementSpace *getFESpace() { return Atheta_space_; }
+
+  double elementJouleHeating(const FiniteElement &el, ElementTransformation &Tr, const Vector &elfun) override;
+  double totalJouleHeating() override;
 };
 
 #endif  // QUASIMAGNETOSTATIC_HPP_

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -210,7 +210,9 @@ void Tps::chooseSolver() {
     isFlowEMCoupledMode_ = true;
     int max_out;
     getRequiredInput("solver/max-outer-iters", max_out);
-    solver_ = new CycleAvgJouleCoupling(mpi_, iFile_, this, max_out);
+    bool axisym = false;
+    getInput("solver/axisymmetric", axisym, false);
+    solver_ = new CycleAvgJouleCoupling(mpi_, iFile_, this, max_out, axisym);
   } else if (input_solver_type_ == "coupled") {
     isFlowEMCoupledMode_ = true;
     grvy_printf(GRVY_ERROR, "\nSlow your roll.  Solid high-five for whoever implements this coupled solver mode!\n");

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -287,6 +287,21 @@ void Tps::getRequiredVec(const char *name, Vector &vec, size_t numElems) {
   }
 }
 
+/// read an input vector for keyword [name] and store in MFEM vector. The size of the vector
+/// is numElems
+void Tps::getVec(const char *name, Vector &vec, size_t numElems, const Vector &vdef) {
+  if ((size_t)vdef.Size() < numElems) exit(ERROR);
+  if ((size_t)vec.Size() < numElems) vec.SetSize(numElems);
+  if (!iparse_.Read_Var_Vec(name, vec.HostWrite(), numElems)) {
+    grvy_printf(GRVY_INFO, "Setting input vector %s to default.", name);
+    double *hv = vec.HostWrite();
+    const double *hd = vdef.HostRead();
+    for (size_t i = 0; i < numElems; i++) {
+      hv[i] = hd[i];
+    }
+  }
+}
+
 /// read the ith entry from an input vector for keyword [name].
 void Tps::getRequiredVecElem(const char *name, double &value, int ithElem) {
 #if 1

--- a/src/tps.hpp
+++ b/src/tps.hpp
@@ -103,6 +103,9 @@ class Tps {
   template <typename T>
   void getInput(const char *name, T &var, T varDefault);
 
+  // read optional mfem::Vector input (set to vdef if absent in input file)
+  void getVec(const char *name, Vector &vec, size_t numElems, const Vector &vdef);
+
   // input parsing support (variants where value is required to be provided)
   // supported types are T={int,double,std::string}
   template <typename T>

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -30,7 +30,7 @@ EXTRA_DIST      = tap-driver.sh soln_differ inputs meshes ref_solns/*.h5 \
 	 	  inflow_outflow.test mms.ternary_2d.test mms.ternary_2d_wall.test \
 	 	  mms.ternary_2d_inout.test cuda-memcheck.test mms.general_wall.test \
 		  independent_coupling.test interp_em.test mms.euler_2d.test mms.cns_2d.test \
-		  gradient.test
+		  gradient.test coupled-3d.test
 
 TESTS = vpath.sh
 XFAIL_TESTS =
@@ -72,7 +72,8 @@ TESTS += cyl3d.test \
 	 inflow_outflow.test \
 	 independent_coupling.test \
 	 interp_em.test \
-	 gradient.test
+	 gradient.test \
+	 coupled-3d.test
 
 if PYTHON_ENABLED
 TESTS += cyl3d.python.test

--- a/test/coupled-3d.test
+++ b/test/coupled-3d.test
@@ -1,0 +1,20 @@
+#!./bats
+# -*- mode: sh -*-
+
+TEST="coupling/cycle-avg-joule-coupling"
+RUNFILE="inputs/coupled-3d.ini"
+
+setup() {
+    SOLN_FILE=restart_output-coupled-3d.sol.h5
+    REF_FILE=ref_solns/coupled-3d.sol.h5
+}
+
+@test "[$TEST] verify tps runs in cylce-avg-joule-coupling mode (3D)" {
+    test -s $RUNFILE
+    mpirun -np 2 ../src/tps --runFile $RUNFILE
+
+    test -s $SOLN_FILE
+    test -s $REF_FILE
+
+    ./soln_differ -r $SOLN_FILE $REF_FILE
+}

--- a/test/inputs/coupled-3d.ini
+++ b/test/inputs/coupled-3d.ini
@@ -1,0 +1,135 @@
+#---------------------
+# TPS runtime controls
+#---------------------
+
+# choice of solver
+[solver]
+type = cycle-avg-joule-coupled
+max-outer-iters = 1
+axisymmetric = False
+
+#---------------------------------------
+# Controls for flow solver
+#---------------------------------------
+[flow]
+mesh = meshes/coupled-3d-flow.msh
+order = 1
+integrationRule = 0
+basisType = 0
+maxIters = 10
+outputFreq = 10
+useRoe = 0
+enableSummationByParts = 0
+fluid = user_defined
+refLength = 1.
+equation_system = navier-stokes
+timingFreq = 5
+
+[io]
+outdirBase = output-coupled-3d
+enableRestart = False
+restartMode = singleFileReadWrite
+
+[time]
+cfl = 0.5
+integrator = rk3
+
+[initialConditions]
+rho = 1.632853e+00
+rhoU = 1.1407243319093
+rhoV = 0.
+rhoW = 0.
+pressure = 101325.
+
+[boundaryConditions/wall1]
+patch = 4
+type = viscous_isothermal
+temperature = 298.1
+
+[boundaryConditions/inlet1]
+patch = 2
+type = subsonic
+density = 1.632853e+00
+uvw = '6.986081e-01 0 0'
+mass_fraction/species1 = 1.37e-11
+mass_fraction/species2 = 0.9999989999863
+mass_fraction/species3 = 1.00e-6
+
+[boundaryConditions/outlet1]
+patch = 3
+type = subsonicPressure
+pressure = 101325.0
+
+[boundaryConditions]
+numWalls = 1
+numInlets = 1
+numOutlets = 1
+
+#--------------------------------------------------------------
+[plasma_models]
+ambipolar = True
+two_temperature = False
+gas_model = perfect_mixture
+transport_model = argon_minimal
+chemistry_model = n/a
+
+const_plasma_conductivity = 50.0
+
+[atoms]
+numAtoms = 2
+
+[atoms/atom1]
+name = 'Ar'
+mass = 3.99e-2
+
+[atoms/atom2]
+name = 'E'
+mass = 5.478e-7
+
+[species]
+numSpecies = 3
+background_index = 2
+
+[species/species3]
+name = 'Ar.+1'
+composition = '{Ar : 1, E : -1}'
+formation_energy = 1.521e4
+initialMassFraction = 1.00e-6
+perfect_mixture/constant_molar_cv = 1.5
+
+[species/species1]
+name = 'E'
+composition = '{E : 1}'
+formation_energy = 0.0
+initialMassFraction = 1.37e-11
+# if gas_model is perfect_mixture, requires heat capacities from input.
+# molar heat capacities in unit of universal gas constant.
+perfect_mixture/constant_molar_cv = 1.5
+
+[species/species2]
+name = 'Ar'
+composition = '{Ar : 1}'
+formation_energy = 0.0
+initialMassFraction = 0.9999989999863
+perfect_mixture/constant_molar_cv = 1.5
+
+
+# controls for standalone EM-only solver
+[em]
+mesh        =  meshes/coupled-3d-em.msh  # mesh filename
+order       =  1                 # FE order (polynomial degree)
+max_iter    =  200                # max number of iterations
+rtol        =  1.0e-10           # solver relative tolerance
+atol        =  1.0e-15           # solver absolute tolerance
+top_only    =  false             # run current through top branch only
+bot_only    =  false             # run current through bottom branch only
+
+evaluate_magnetic_field = false
+nBy         =  0                 # of interpolation points
+
+current_axis = '1 0 0'
+current_amplitude = 2.0e6 #1.04e6        # A/m^2 ( ~40 A current)
+current_frequency = 6e6          # 1/s
+permeability = 1.25663706e-6     # m * kg / s^2 / A^2
+
+preconditioner_background_sigma = 0.01

--- a/test/meshes/coupled-3d-em.msh
+++ b/test/meshes/coupled-3d-em.msh
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5f0875b82a97ebab0f1aace3f16812d7baabb200646a335b8416517dc159867
+size 9636844

--- a/test/meshes/coupled-3d-flow.msh
+++ b/test/meshes/coupled-3d-flow.msh
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5aefc2d22697ceeba8eacaaa2631f5777d5d60c1638866e954e70437fcabab14
+size 2037342

--- a/test/ref_solns/.gitattributes
+++ b/test/ref_solns/.gitattributes
@@ -1,0 +1,1 @@
+coupled-3d.sol.h5 filter=lfs diff=lfs merge=lfs -text

--- a/test/ref_solns/coupled-3d.sol.h5
+++ b/test/ref_solns/coupled-3d.sol.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:535974e05cb8d44159f1c8d247e5771b7a3cb01b19dc77f47a7ef2548ea55f45
+size 5681944

--- a/test/ref_solns/coupled-3d.sol.h5
+++ b/test/ref_solns/coupled-3d.sol.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:535974e05cb8d44159f1c8d247e5771b7a3cb01b19dc77f47a7ef2548ea55f45
+oid sha256:f093369de2a0dc3f22bd67565af2cc7bd302315be37d9cf2848c69896240c5c1
 size 5681944

--- a/test/test_interp_em.cpp
+++ b/test/test_interp_em.cpp
@@ -123,7 +123,7 @@ int main (int argc, char *argv[])
 
   int max_out = 1;
   CycleAvgJouleCoupling *solver = new CycleAvgJouleCoupling(tps.getMPISession(), tps.getInputFilename(), &tps,
-                                                            max_out);
+                                                            max_out, true);
 
   solver->parseSolverOptions();
   solver->initialize();

--- a/utils/mfem_extras/pfem_extras.cpp
+++ b/utils/mfem_extras/pfem_extras.cpp
@@ -119,14 +119,10 @@ IrrotationalProjector
    ess_bdr_ = 1;
    H1FESpace_->GetEssentialTrueDofs(ess_bdr_, ess_bdr_tdofs_);
 
-   int geom = H1FESpace_->GetFE(0)->GetGeomType();
-   const IntegrationRule * ir = &IntRules.Get(geom, irOrder);
-
    if ( s0 == NULL )
    {
       s0_ = new ParBilinearForm(H1FESpace_);
       BilinearFormIntegrator * diffInteg = new DiffusionIntegrator;
-      diffInteg->SetIntRule(ir);
       s0_->AddDomainIntegrator(diffInteg);
       s0_->Assemble();
       s0_->Finalize();
@@ -136,7 +132,6 @@ IrrotationalProjector
    {
       weakDiv_ = new ParMixedBilinearForm(HCurlFESpace_, H1FESpace_);
       BilinearFormIntegrator * wdivInteg = new VectorFEWeakDivergenceIntegrator;
-      wdivInteg->SetIntRule(ir);
       weakDiv_->AddDomainIntegrator(wdivInteg);
       weakDiv_->Assemble();
       weakDiv_->Finalize();


### PR DESCRIPTION
This PR adds 3D support for coupling the flow/plasma solver with the frequency domain EM solver through the cycle averaged Joule heating.  It is the analog of PR #167.