### PR TITLE
TableInterpolater class and Tabulated reaction

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,4 @@ test/ref_solns/transport/Devoto1973.transport.h5 filter=lfs diff=lfs merge=lfs -
 test/ref_solns/reaction.test.h5 filter=lfs diff=lfs merge=lfs -text
 test/ref_solns/collisions/Amdur_Mason.estimated.h5 filter=lfs diff=lfs merge=lfs -text
 test/ref_solns/collisions/Amdur_Mason.h5 filter=lfs diff=lfs merge=lfs -text
+test/ref_solns/reaction/excitation.3000K.ion1e-4.h5 filter=lfs diff=lfs merge=lfs -text

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -2454,6 +2454,7 @@ void M2ulPhyS::parseReactionInputs() {
     config.detailedBalance.SetSize(config.numReactions);
     // config.equilibriumConstantParams.resize(config.numReactions);
   }
+  config.rxnModelParamsHost.clear();
 
   for (int r = 1; r <= config.numReactions; r++) {
     std::string basepath("reactions/reaction" + std::to_string(r));
@@ -2481,11 +2482,13 @@ void M2ulPhyS::parseReactionInputs() {
       tpsP->getRequiredInput((basepath + "/arrhenius/A").c_str(), A);
       tpsP->getRequiredInput((basepath + "/arrhenius/b").c_str(), b);
       tpsP->getRequiredInput((basepath + "/arrhenius/E").c_str(), E);
+      config.rxnModelParamsHost.push_back(Vector({A, b, E}));
 
-      config.chemistryInput.reactionInputs[r - 1].modelParams = new double[gpudata::MAXCHEMPARAMS];
-      config.chemistryInput.reactionInputs[r - 1].modelParams[0] = A;
-      config.chemistryInput.reactionInputs[r - 1].modelParams[1] = b;
-      config.chemistryInput.reactionInputs[r - 1].modelParams[2] = E;
+      config.chemistryInput.reactionInputs[r - 1].modelParams = config.rxnModelParamsHost.back().Read();
+//      config.chemistryInput.reactionInputs[r - 1].modelParams = new double[gpudata::MAXCHEMPARAMS];
+//      config.chemistryInput.reactionInputs[r - 1].modelParams[0] = A;
+//      config.chemistryInput.reactionInputs[r - 1].modelParams[1] = b;
+//      config.chemistryInput.reactionInputs[r - 1].modelParams[2] = E;
       // config.reactionModelParams[0 + (r - 1) * gpudata::MAXCHEMPARAMS] = A;
       // config.reactionModelParams[1 + (r - 1) * gpudata::MAXCHEMPARAMS] = b;
       // config.reactionModelParams[2 + (r - 1) * gpudata::MAXCHEMPARAMS] = E;
@@ -2497,12 +2500,14 @@ void M2ulPhyS::parseReactionInputs() {
       tpsP->getRequiredInput((basepath + "/arrhenius/A").c_str(), A);
       tpsP->getRequiredInput((basepath + "/arrhenius/b").c_str(), b);
       tpsP->getRequiredInput((basepath + "/arrhenius/E").c_str(), E);
+      config.rxnModelParamsHost.push_back(Vector({A, b, E}));
 
+      config.chemistryInput.reactionInputs[r - 1].modelParams = config.rxnModelParamsHost.back().Read();
       // NOTE(kevin): this array keeps max param in the indexing, as reactions can have different number of params.
-      config.chemistryInput.reactionInputs[r - 1].modelParams = new double[gpudata::MAXCHEMPARAMS];
-      config.chemistryInput.reactionInputs[r - 1].modelParams[0] = A;
-      config.chemistryInput.reactionInputs[r - 1].modelParams[1] = b;
-      config.chemistryInput.reactionInputs[r - 1].modelParams[2] = E;
+//      config.chemistryInput.reactionInputs[r - 1].modelParams = new double[gpudata::MAXCHEMPARAMS];
+//      config.chemistryInput.reactionInputs[r - 1].modelParams[0] = A;
+//      config.chemistryInput.reactionInputs[r - 1].modelParams[1] = b;
+//      config.chemistryInput.reactionInputs[r - 1].modelParams[2] = E;
       // config.reactionModelParams[0 + (r - 1) * gpudata::MAXCHEMPARAMS] = A;
       // config.reactionModelParams[1 + (r - 1) * gpudata::MAXCHEMPARAMS] = b;
       // config.reactionModelParams[2 + (r - 1) * gpudata::MAXCHEMPARAMS] = E;

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -2469,17 +2469,26 @@ void M2ulPhyS::parseReactionInputs() {
     tpsP->getRequiredInput((basepath + "/reaction_energy").c_str(), energy);
     config.reactionEnergies[r - 1] = energy;
 
+    // NOTE: reaction inputs are stored directly into ChemistryInput.
+    // Initialize the pointers with null.
+    config.chemistryInput.reactionInputs[r - 1].tableInput = NULL;
+    config.chemistryInput.reactionInputs[r - 1].modelParams = NULL;
+
     if (model == "arrhenius") {
       config.reactionModels[r - 1] = ARRHENIUS;
-      // config.reactionModelParams[r - 1].resize(3);
+
       double A, b, E;
       tpsP->getRequiredInput((basepath + "/arrhenius/A").c_str(), A);
       tpsP->getRequiredInput((basepath + "/arrhenius/b").c_str(), b);
       tpsP->getRequiredInput((basepath + "/arrhenius/E").c_str(), E);
-      // config.reactionModelParams[r - 1] = {A, b, E};
-      config.reactionModelParams[0 + (r - 1) * gpudata::MAXCHEMPARAMS] = A;
-      config.reactionModelParams[1 + (r - 1) * gpudata::MAXCHEMPARAMS] = b;
-      config.reactionModelParams[2 + (r - 1) * gpudata::MAXCHEMPARAMS] = E;
+
+      config.chemistryInput.reactionInputs[r - 1].modelParams = new double[gpudata::MAXCHEMPARAMS];
+      config.chemistryInput.reactionInputs[r - 1].modelParams[0] = A;
+      config.chemistryInput.reactionInputs[r - 1].modelParams[1] = b;
+      config.chemistryInput.reactionInputs[r - 1].modelParams[2] = E;
+      // config.reactionModelParams[0 + (r - 1) * gpudata::MAXCHEMPARAMS] = A;
+      // config.reactionModelParams[1 + (r - 1) * gpudata::MAXCHEMPARAMS] = b;
+      // config.reactionModelParams[2 + (r - 1) * gpudata::MAXCHEMPARAMS] = E;
 
     } else if (model == "hoffert_lien") {
       config.reactionModels[r - 1] = HOFFERTLIEN;
@@ -2488,11 +2497,15 @@ void M2ulPhyS::parseReactionInputs() {
       tpsP->getRequiredInput((basepath + "/arrhenius/A").c_str(), A);
       tpsP->getRequiredInput((basepath + "/arrhenius/b").c_str(), b);
       tpsP->getRequiredInput((basepath + "/arrhenius/E").c_str(), E);
-      // config.reactionModelParams[r - 1] = {A, b, E};
+
       // NOTE(kevin): this array keeps max param in the indexing, as reactions can have different number of params.
-      config.reactionModelParams[0 + (r - 1) * gpudata::MAXCHEMPARAMS] = A;
-      config.reactionModelParams[1 + (r - 1) * gpudata::MAXCHEMPARAMS] = b;
-      config.reactionModelParams[2 + (r - 1) * gpudata::MAXCHEMPARAMS] = E;
+      config.chemistryInput.reactionInputs[r - 1].modelParams = new double[gpudata::MAXCHEMPARAMS];
+      config.chemistryInput.reactionInputs[r - 1].modelParams[0] = A;
+      config.chemistryInput.reactionInputs[r - 1].modelParams[1] = b;
+      config.chemistryInput.reactionInputs[r - 1].modelParams[2] = E;
+      // config.reactionModelParams[0 + (r - 1) * gpudata::MAXCHEMPARAMS] = A;
+      // config.reactionModelParams[1 + (r - 1) * gpudata::MAXCHEMPARAMS] = b;
+      // config.reactionModelParams[2 + (r - 1) * gpudata::MAXCHEMPARAMS] = E;
 
     } else {
       grvy_printf(GRVY_ERROR, "\nUnknown reaction_model -> %s", model.c_str());
@@ -2503,12 +2516,11 @@ void M2ulPhyS::parseReactionInputs() {
     tpsP->getInput((basepath + "/detailed_balance").c_str(), detailedBalance, false);
     config.detailedBalance[r - 1] = detailedBalance;
     if (detailedBalance) {
-      // config.equilibriumConstantParams[r - 1].resize(3);
       double A, b, E;
       tpsP->getRequiredInput((basepath + "/equilibrium_constant/A").c_str(), A);
       tpsP->getRequiredInput((basepath + "/equilibrium_constant/b").c_str(), b);
       tpsP->getRequiredInput((basepath + "/equilibrium_constant/E").c_str(), E);
-      // config.equilibriumConstantParams[r - 1] = {A, b, E};
+
       // NOTE(kevin): this array keeps max param in the indexing, as reactions can have different number of params.
       config.equilibriumConstantParams[0 + (r - 1) * gpudata::MAXCHEMPARAMS] = A;
       config.equilibriumConstantParams[1 + (r - 1) * gpudata::MAXCHEMPARAMS] = b;
@@ -2603,8 +2615,8 @@ void M2ulPhyS::parseReactionInputs() {
 
       config.chemistryInput.reactionModels[r] = config.reactionModels[r];
       for (int p = 0; p < gpudata::MAXCHEMPARAMS; p++) {
-        config.chemistryInput.reactionModelParams[p + r * gpudata::MAXCHEMPARAMS] =
-            config.reactionModelParams[p + r * gpudata::MAXCHEMPARAMS];
+        // config.chemistryInput.reactionModelParams[p + r * gpudata::MAXCHEMPARAMS] =
+        //     config.reactionModelParams[p + r * gpudata::MAXCHEMPARAMS];
         config.chemistryInput.equilibriumConstantParams[p + r * gpudata::MAXCHEMPARAMS] =
             config.equilibriumConstantParams[p + r * gpudata::MAXCHEMPARAMS];
       }

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -2506,7 +2506,10 @@ void M2ulPhyS::parseReactionInputs() {
       // config.reactionModelParams[0 + (r - 1) * gpudata::MAXCHEMPARAMS] = A;
       // config.reactionModelParams[1 + (r - 1) * gpudata::MAXCHEMPARAMS] = b;
       // config.reactionModelParams[2 + (r - 1) * gpudata::MAXCHEMPARAMS] = E;
-
+    } else if (model == "tabulated") {
+      config.reactionModels[r - 1] = TABULATED;
+      std::string inputPath(basepath + "/tabulated");
+      config.chemistryInput.reactionInputs[r - 1].tableInput = readTable(inputPath);
     } else {
       grvy_printf(GRVY_ERROR, "\nUnknown reaction_model -> %s", model.c_str());
       exit(ERROR);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -2606,8 +2606,6 @@ void M2ulPhyS::parseReactionInputs() {
 
       config.chemistryInput.reactionModels[r] = config.reactionModels[r];
       for (int p = 0; p < gpudata::MAXCHEMPARAMS; p++) {
-        // config.chemistryInput.reactionModelParams[p + r * gpudata::MAXCHEMPARAMS] =
-        //     config.reactionModelParams[p + r * gpudata::MAXCHEMPARAMS];
         config.chemistryInput.equilibriumConstantParams[p + r * gpudata::MAXCHEMPARAMS] =
             config.equilibriumConstantParams[p + r * gpudata::MAXCHEMPARAMS];
       }

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -2459,8 +2459,6 @@ void M2ulPhyS::parseReactionInputs() {
   for (int r = 1; r <= config.numReactions; r++) {
     std::string basepath("reactions/reaction" + std::to_string(r));
 
-    // TODO(kevin): make tps input parser accessible to all classes.
-    // TODO(kevin): reaction classes read input options directly in their initialization.
     std::string equation, model;
     tpsP->getRequiredInput((basepath + "/equation").c_str(), equation);
     config.reactionEquations[r - 1] = equation;
@@ -2472,7 +2470,6 @@ void M2ulPhyS::parseReactionInputs() {
 
     // NOTE: reaction inputs are stored directly into ChemistryInput.
     // Initialize the pointers with null.
-    config.chemistryInput.reactionInputs[r - 1].tableInput = NULL;
     config.chemistryInput.reactionInputs[r - 1].modelParams = NULL;
 
     if (model == "arrhenius") {
@@ -2485,17 +2482,9 @@ void M2ulPhyS::parseReactionInputs() {
       config.rxnModelParamsHost.push_back(Vector({A, b, E}));
 
       config.chemistryInput.reactionInputs[r - 1].modelParams = config.rxnModelParamsHost.back().Read();
-//      config.chemistryInput.reactionInputs[r - 1].modelParams = new double[gpudata::MAXCHEMPARAMS];
-//      config.chemistryInput.reactionInputs[r - 1].modelParams[0] = A;
-//      config.chemistryInput.reactionInputs[r - 1].modelParams[1] = b;
-//      config.chemistryInput.reactionInputs[r - 1].modelParams[2] = E;
-      // config.reactionModelParams[0 + (r - 1) * gpudata::MAXCHEMPARAMS] = A;
-      // config.reactionModelParams[1 + (r - 1) * gpudata::MAXCHEMPARAMS] = b;
-      // config.reactionModelParams[2 + (r - 1) * gpudata::MAXCHEMPARAMS] = E;
 
     } else if (model == "hoffert_lien") {
       config.reactionModels[r - 1] = HOFFERTLIEN;
-      // config.reactionModelParams[r - 1].resize(3);
       double A, b, E;
       tpsP->getRequiredInput((basepath + "/arrhenius/A").c_str(), A);
       tpsP->getRequiredInput((basepath + "/arrhenius/b").c_str(), b);
@@ -2504,18 +2493,11 @@ void M2ulPhyS::parseReactionInputs() {
 
       config.chemistryInput.reactionInputs[r - 1].modelParams = config.rxnModelParamsHost.back().Read();
       // NOTE(kevin): this array keeps max param in the indexing, as reactions can have different number of params.
-//      config.chemistryInput.reactionInputs[r - 1].modelParams = new double[gpudata::MAXCHEMPARAMS];
-//      config.chemistryInput.reactionInputs[r - 1].modelParams[0] = A;
-//      config.chemistryInput.reactionInputs[r - 1].modelParams[1] = b;
-//      config.chemistryInput.reactionInputs[r - 1].modelParams[2] = E;
-      // config.reactionModelParams[0 + (r - 1) * gpudata::MAXCHEMPARAMS] = A;
-      // config.reactionModelParams[1 + (r - 1) * gpudata::MAXCHEMPARAMS] = b;
-      // config.reactionModelParams[2 + (r - 1) * gpudata::MAXCHEMPARAMS] = E;
+
     } else if (model == "tabulated") {
       config.reactionModels[r - 1] = TABULATED;
       std::string inputPath(basepath + "/tabulated");
-      config.chemistryInput.reactionInputs[r - 1].tableInput = new TableInput;
-      readTable(inputPath, *(config.chemistryInput.reactionInputs[r - 1].tableInput));
+      readTable(inputPath, config.chemistryInput.reactionInputs[r - 1].tableInput);
     } else {
       grvy_printf(GRVY_ERROR, "\nUnknown reaction_model -> %s", model.c_str());
       exit(ERROR);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -2509,7 +2509,8 @@ void M2ulPhyS::parseReactionInputs() {
     } else if (model == "tabulated") {
       config.reactionModels[r - 1] = TABULATED;
       std::string inputPath(basepath + "/tabulated");
-      config.chemistryInput.reactionInputs[r - 1].tableInput = readTable(inputPath);
+      config.chemistryInput.reactionInputs[r - 1].tableInput = new TableInput;
+      readTable(inputPath, *(config.chemistryInput.reactionInputs[r - 1].tableInput));
     } else {
       grvy_printf(GRVY_ERROR, "\nUnknown reaction_model -> %s", model.c_str());
       exit(ERROR);

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -393,6 +393,7 @@ class M2ulPhyS : public TPS::Solver {
   IntegrationRules *getIntegrationRules() { return intRules; }
   RunConfiguration &GetConfig() { return config; }
   GasMixture *getMixture() { return mixture; }
+  Chemistry *getChemistry() { return chemistry_; }
 
   void updatePrimitives();
 

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -411,6 +411,8 @@ class M2ulPhyS : public TPS::Solver {
   int getMaximumIterations() const { return MaxIters; }
   int getCurrentIterations() const { return iter; }
   void setMaximumIterations(int value) { MaxIters = value; }
+
+  TableInput readTable(const std::string &inputPath);
 };
 
 #endif  // M2ULPHYS_HPP_

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -412,7 +412,7 @@ class M2ulPhyS : public TPS::Solver {
   int getCurrentIterations() const { return iter; }
   void setMaximumIterations(int value) { MaxIters = value; }
 
-  TableInput readTable(const std::string &inputPath);
+  void readTable(const std::string &inputPath, TableInput &result);
 };
 
 #endif  // M2ULPHYS_HPP_

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,7 +31,7 @@ cxx_sources          = averaging_and_rms.cpp faceGradientIntegration.cpp M2ulPhy
 	               sbp_integrators.cpp equation_of_state.cpp transport_properties.cpp inletBC.cpp outletBC.cpp utils.cpp io.cpp \
 		       dgNonlinearForm.cpp gradients.cpp gradNonLinearForm.cpp quasimagnetostatic.cpp tps.cpp chemistry.cpp \
                        reaction.cpp collision_integrals.cpp argon_transport.cpp source_term.cpp gpu_constructor.cpp \
-                       independent_coupling.cpp cycle_avg_joule_coupling.cpp
+                       independent_coupling.cpp cycle_avg_joule_coupling.cpp table.cpp
 
 mfem_extra_sources   = ../utils/mfem_extras/pfem_extras.cpp
 
@@ -42,7 +42,7 @@ headers              = averaging_and_rms.hpp equation_of_state.hpp transport_pro
 		       dgNonlinearForm.hpp gradNonLinearForm.hpp dataStructures.hpp utils.hpp io.hpp em_options.hpp \
 		       quasimagnetostatic.hpp gradients.hpp logger.hpp solver.hpp tps.hpp chemistry.hpp reaction.hpp \
 	               collision_integrals.hpp argon_transport.hpp source_term.hpp tps_mfem_wrap.hpp gpu_constructor.hpp \
-                       independent_coupling.hpp cycle_avg_joule_coupling.hpp
+                       independent_coupling.hpp cycle_avg_joule_coupling.hpp table.hpp
 
 mfem_extra_headers   = ../utils/mfem_extras/pfem_extras.hpp
 

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -127,10 +127,8 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::computeEffectiveMass(const double *
 MFEM_HOST_DEVICE void ArgonMinimalTransport::setArtificialMultipliers(const ArgonTransportInput &inputs) {
   multiply_ = inputs.multiply;
   if (multiply_) {
-    for (int t = 0; t < FluxTrns::NUM_FLUX_TRANS; t++)
-      fluxTrnsMultiplier_[t] = inputs.fluxTrnsMultiplier[t];
-    for (int t = 0; t < SpeciesTrns::NUM_SPECIES_COEFFS; t++)
-      spcsTrnsMultiplier_[t] = inputs.spcsTrnsMultiplier[t];
+    for (int t = 0; t < FluxTrns::NUM_FLUX_TRANS; t++) fluxTrnsMultiplier_[t] = inputs.fluxTrnsMultiplier[t];
+    for (int t = 0; t < SpeciesTrns::NUM_SPECIES_COEFFS; t++) spcsTrnsMultiplier_[t] = inputs.spcsTrnsMultiplier[t];
     diffMult_ = inputs.diffMult;
     mobilMult_ = inputs.mobilMult;
   }
@@ -242,8 +240,7 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeFluxTransportProperties(cons
 
   // Apply artificial multipliers.
   if (multiply_) {
-    for (int t = 0; t < FluxTrns::NUM_FLUX_TRANS; t++)
-      transportBuffer[t] *= fluxTrnsMultiplier_[t];
+    for (int t = 0; t < FluxTrns::NUM_FLUX_TRANS; t++) transportBuffer[t] *= fluxTrnsMultiplier_[t];
     for (int sp = 0; sp < numSpecies; sp++) {
       diffusivity[sp] *= diffMult_;
       mobility[sp] *= mobilMult_;
@@ -860,8 +857,7 @@ MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeFluxTransportProperties(cons
 
   // Apply artificial multipliers.
   if (multiply_) {
-    for (int t = 0; t < FluxTrns::NUM_FLUX_TRANS; t++)
-      transportBuffer[t] *= fluxTrnsMultiplier_[t];
+    for (int t = 0; t < FluxTrns::NUM_FLUX_TRANS; t++) transportBuffer[t] *= fluxTrnsMultiplier_[t];
     for (int sp = 0; sp < numSpecies; sp++) {
       diffusivity[sp] *= diffMult_;
       mobility[sp] *= mobilMult_;

--- a/src/chemistry.cpp
+++ b/src/chemistry.cpp
@@ -89,7 +89,7 @@ MFEM_HOST_DEVICE Chemistry::Chemistry(GasMixture *mixture, const ChemistryInput 
       case TABULATED: {
         assert(inputs.reactionInputs[r].tableInput != NULL);
         reactions_[r] = new Tabulated(*(inputs.reactionInputs[r].tableInput));
-      }
+      } break;
       default:
         printf("Unknown reactionModel.");
         assert(false);

--- a/src/chemistry.cpp
+++ b/src/chemistry.cpp
@@ -71,9 +71,7 @@ MFEM_HOST_DEVICE Chemistry::Chemistry(GasMixture *mixture, const ChemistryInput 
         double A = inputs.reactionInputs[r].modelParams[0];
         double b = inputs.reactionInputs[r].modelParams[1];
         double E = inputs.reactionInputs[r].modelParams[2];
-        // double A = inputs.reactionModelParams[0 + r * gpudata::MAXCHEMPARAMS];
-        // double b = inputs.reactionModelParams[1 + r * gpudata::MAXCHEMPARAMS];
-        // double E = inputs.reactionModelParams[2 + r * gpudata::MAXCHEMPARAMS];
+
         reactions_[r] = new Arrhenius(A, b, E);
       } break;
       case HOFFERTLIEN: {
@@ -81,14 +79,11 @@ MFEM_HOST_DEVICE Chemistry::Chemistry(GasMixture *mixture, const ChemistryInput 
         double A = inputs.reactionInputs[r].modelParams[0];
         double b = inputs.reactionInputs[r].modelParams[1];
         double E = inputs.reactionInputs[r].modelParams[2];
-        // double A = inputs.reactionModelParams[0 + r * gpudata::MAXCHEMPARAMS];
-        // double b = inputs.reactionModelParams[1 + r * gpudata::MAXCHEMPARAMS];
-        // double E = inputs.reactionModelParams[2 + r * gpudata::MAXCHEMPARAMS];
+
         reactions_[r] = new HoffertLien(A, b, E);
       } break;
       case TABULATED: {
-        assert(inputs.reactionInputs[r].tableInput != NULL);
-        reactions_[r] = new Tabulated(*(inputs.reactionInputs[r].tableInput));
+        reactions_[r] = new Tabulated(inputs.reactionInputs[r].tableInput);
       } break;
       default:
         printf("Unknown reactionModel.");

--- a/src/chemistry.cpp
+++ b/src/chemistry.cpp
@@ -67,20 +67,20 @@ MFEM_HOST_DEVICE Chemistry::Chemistry(GasMixture *mixture, const ChemistryInput 
 
     switch (inputs.reactionModels[r]) {
       case ARRHENIUS: {
-        assert(inputs.reactionInputs[r - 1].modelParams != NULL);
-        double A = inputs.reactionInputs[r - 1].modelParams[0];
-        double b = inputs.reactionInputs[r - 1].modelParams[1];
-        double E = inputs.reactionInputs[r - 1].modelParams[2];
+        assert(inputs.reactionInputs[r].modelParams != NULL);
+        double A = inputs.reactionInputs[r].modelParams[0];
+        double b = inputs.reactionInputs[r].modelParams[1];
+        double E = inputs.reactionInputs[r].modelParams[2];
         // double A = inputs.reactionModelParams[0 + r * gpudata::MAXCHEMPARAMS];
         // double b = inputs.reactionModelParams[1 + r * gpudata::MAXCHEMPARAMS];
         // double E = inputs.reactionModelParams[2 + r * gpudata::MAXCHEMPARAMS];
         reactions_[r] = new Arrhenius(A, b, E);
       } break;
       case HOFFERTLIEN: {
-        assert(inputs.reactionInputs[r - 1].modelParams != NULL);
-        double A = inputs.reactionInputs[r - 1].modelParams[0];
-        double b = inputs.reactionInputs[r - 1].modelParams[1];
-        double E = inputs.reactionInputs[r - 1].modelParams[2];
+        assert(inputs.reactionInputs[r].modelParams != NULL);
+        double A = inputs.reactionInputs[r].modelParams[0];
+        double b = inputs.reactionInputs[r].modelParams[1];
+        double E = inputs.reactionInputs[r].modelParams[2];
         // double A = inputs.reactionModelParams[0 + r * gpudata::MAXCHEMPARAMS];
         // double b = inputs.reactionModelParams[1 + r * gpudata::MAXCHEMPARAMS];
         // double E = inputs.reactionModelParams[2 + r * gpudata::MAXCHEMPARAMS];

--- a/src/chemistry.cpp
+++ b/src/chemistry.cpp
@@ -86,6 +86,10 @@ MFEM_HOST_DEVICE Chemistry::Chemistry(GasMixture *mixture, const ChemistryInput 
         // double E = inputs.reactionModelParams[2 + r * gpudata::MAXCHEMPARAMS];
         reactions_[r] = new HoffertLien(A, b, E);
       } break;
+      case TABULATED: {
+        assert(inputs.reactionInputs[r].tableInput != NULL);
+        reactions_[r] = new Tabulated(*(inputs.reactionInputs[r].tableInput));
+      }
       default:
         printf("Unknown reactionModel.");
         assert(false);

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -381,7 +381,7 @@ struct TableInput {
 struct ReactionInput {
   TableInput *tableInput;
   double *modelParams;
-  double *equilibriumConstantParams;
+  // double *equilibriumConstantParams;
 };
 
 struct ChemistryInput {
@@ -394,9 +394,9 @@ struct ChemistryInput {
   double reactantStoich[gpudata::MAXSPECIES * gpudata::MAXREACTIONS];
   double productStoich[gpudata::MAXSPECIES * gpudata::MAXREACTIONS];
   ReactionModel reactionModels[gpudata::MAXREACTIONS];
-  double reactionModelParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
+  // double reactionModelParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
   double equilibriumConstantParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
-  // ReactionInput reactionInputs[gpudata::MAXREACTIONS];
+  ReactionInput reactionInputs[gpudata::MAXREACTIONS];
 };
 
 #endif  // DATASTRUCTURES_HPP_

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -366,10 +366,8 @@ struct ArgonTransportInput {
 
 struct TableInput {
   int Ndata;
-  // double xdata[gpudata::MAXTABLE];
-  // double fdata[gpudata::MAXTABLE];
-  double *xdata;
-  double *fdata;
+  const double *xdata;
+  const double *fdata;
   bool xLogScale;
   bool fLogScale;
 
@@ -380,10 +378,8 @@ struct TableInput {
 // At the same time, allocating maximum size of memory can be prohibitive in gpu device.
 // the datatype therefore contains pointers, which can be allocated only when they are used.
 struct ReactionInput {
-  TableInput *tableInput;
+  TableInput tableInput;
   const double *modelParams;
-//  double modelParams[gpudata::MAXCHEMPARAMS];
-  // double *equilibriumConstantParams;
 };
 
 struct ChemistryInput {

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -51,6 +51,8 @@ const int MAXEQUATIONS = MAXDIM + 2 + MAXSPECIES;  // momentum + two energies + 
 
 const int MAXREACTIONS = 20;
 const int MAXCHEMPARAMS = 3;
+
+const int MAXTABLE = 512;
 }  // namespace gpudata
 
 enum Equations {

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -53,6 +53,7 @@ const int MAXREACTIONS = 20;
 const int MAXCHEMPARAMS = 3;
 
 const int MAXTABLE = 512;
+const int MAXTABLEDIM = 2;
 }  // namespace gpudata
 
 enum Equations {

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -379,6 +379,7 @@ struct TableInput {
 // the datatype therefore contains pointers, which can be allocated only when they are used.
 struct ReactionInput {
   TableInput tableInput;
+  // NOTE(kevin): with gpu, this pointer is only valid on the device.
   const double *modelParams;
 };
 

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -381,7 +381,8 @@ struct TableInput {
 // the datatype therefore contains pointers, which can be allocated only when they are used.
 struct ReactionInput {
   TableInput *tableInput;
-  double *modelParams;
+  const double *modelParams;
+//  double modelParams[gpudata::MAXCHEMPARAMS];
   // double *equilibriumConstantParams;
 };
 

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -71,7 +71,7 @@ enum TransportModel { ARGON_MINIMAL, ARGON_MIXTURE, CONSTANT, NUM_TRANSPORTMODEL
 
 enum ChemistryModel { /* CANTERA, */ NUM_CHEMISTRYMODEL };
 
-enum ReactionModel { ARRHENIUS, HOFFERTLIEN, NUM_REACTIONMODEL };
+enum ReactionModel { ARRHENIUS, HOFFERTLIEN, TABULATED, NUM_REACTIONMODEL };
 
 enum GasParams { SPECIES_MW, SPECIES_CHARGES, FORMATION_ENERGY, /* SPECIES_HEAT_RATIO, */ NUM_GASPARAMS };
 
@@ -371,6 +371,8 @@ struct TableInput {
   double *fdata;
   bool xLogScale;
   bool fLogScale;
+
+  int order;  // interpolation order. Currently only support order=1.
 };
 
 // ReactionInput must be able to support various types of evaluation.

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -363,6 +363,25 @@ struct ArgonTransportInput {
   double mobilMult;
 };
 
+struct TableInput {
+  int Ndata;
+  // double xdata[gpudata::MAXTABLE];
+  // double fdata[gpudata::MAXTABLE];
+  double *xdata;
+  double *fdata;
+  bool xLogScale;
+  bool fLogScale;
+};
+
+// ReactionInput must be able to support various types of evaluation.
+// At the same time, allocating maximum size of memory can be prohibitive in gpu device.
+// the datatype therefore contains pointers, which can be allocated only when they are used.
+struct ReactionInput {
+  TableInput *tableInput;
+  double *modelParams;
+  double *equilibriumConstantParams;
+};
+
 struct ChemistryInput {
   ChemistryModel model;
 
@@ -375,14 +394,7 @@ struct ChemistryInput {
   ReactionModel reactionModels[gpudata::MAXREACTIONS];
   double reactionModelParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
   double equilibriumConstantParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
-};
-
-struct TableInput {
-  int Ndata;
-  double xdata[gpudata::MAXTABLE];
-  double fdata[gpudata::MAXTABLE];
-  bool xLogScale;
-  bool fLogScale;
+  // ReactionInput reactionInputs[gpudata::MAXREACTIONS];
 };
 
 #endif  // DATASTRUCTURES_HPP_

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -377,4 +377,12 @@ struct ChemistryInput {
   double equilibriumConstantParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
 };
 
+struct TableInput {
+  int Ndata;
+  double xdata[gpudata::MAXTABLE];
+  double fdata[gpudata::MAXTABLE];
+  bool xLogScale;
+  bool fLogScale;
+};
+
 #endif  // DATASTRUCTURES_HPP_

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -393,7 +393,6 @@ struct ChemistryInput {
   double reactantStoich[gpudata::MAXSPECIES * gpudata::MAXREACTIONS];
   double productStoich[gpudata::MAXSPECIES * gpudata::MAXREACTIONS];
   ReactionModel reactionModels[gpudata::MAXREACTIONS];
-  // double reactionModelParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
   double equilibriumConstantParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
   ReactionInput reactionInputs[gpudata::MAXREACTIONS];
 };

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -687,8 +687,7 @@ void M2ulPhyS::writeHistoryFile() {
   if (mpi.Root()) histFile << endl;
 }
 
-TableInput M2ulPhyS::readTable(const std::string &inputPath) {
-  TableInput result;
+void M2ulPhyS::readTable(const std::string &inputPath, TableInput &result) {
   result.xdata = new double[gpudata::MAXTABLE];
   result.fdata = new double[gpudata::MAXTABLE];
 
@@ -721,7 +720,7 @@ TableInput M2ulPhyS::readTable(const std::string &inputPath) {
     result.xdata[k] = xdata[k];
     result.fdata[k] = fdata[k];
   }
-  return result;
+  return;
 }
 
 // ---------------------------------------------

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -693,13 +693,14 @@ void M2ulPhyS::readTable(const std::string &inputPath, TableInput &result) {
 
   tpsP->getInput((inputPath + "/x_log").c_str(), result.xLogScale, false);
   tpsP->getInput((inputPath + "/f_log").c_str(), result.fLogScale, false);
-  tpsP->getRequiredInput((inputPath + "/f_log").c_str(), result.order);
+  tpsP->getInput((inputPath + "/order").c_str(), result.order, 1);
 
   int Ndata;
   double xdata[gpudata::MAXTABLE], fdata[gpudata::MAXTABLE];
   if (mpi.Root()) {
     DenseMatrix data;
-    std::string filename(inputPath + "/filename");
+    std::string filename;
+    tpsP->getRequiredInput((inputPath + "/filename").c_str(), filename);
     Array<int> dims = h5ReadTable(filename, "table", data);
     assert(dims[0] > 0);
     assert(dims[1] == 2);

--- a/src/masa_handler.cpp
+++ b/src/masa_handler.cpp
@@ -593,9 +593,12 @@ void initTernary2DBase(GasMixture *mixture, RunConfiguration &config, const doub
     assert(config.productStoich(1, 0) == 2);
     assert(config.productStoich(2, 0) == 0);
 
-    Af = (config.reactionModelParams[0 + 0]);
-    bf = (config.reactionModelParams[1 + 0]);
-    Ef = (config.reactionModelParams[2 + 0]);
+    Af = config.chemistryInput.reactionInputs[0].modelParams[0];
+    bf = config.chemistryInput.reactionInputs[0].modelParams[1];
+    Ef = config.chemistryInput.reactionInputs[0].modelParams[2];
+    // Af = (config.reactionModelParams[0 + 0]);
+    // bf = (config.reactionModelParams[1 + 0]);
+    // Ef = (config.reactionModelParams[2 + 0]);
 
     Ab = (config.equilibriumConstantParams[0 + 0]);
     bb = (config.equilibriumConstantParams[1 + 0]);

--- a/src/masa_handler.cpp
+++ b/src/masa_handler.cpp
@@ -593,12 +593,13 @@ void initTernary2DBase(GasMixture *mixture, RunConfiguration &config, const doub
     assert(config.productStoich(1, 0) == 2);
     assert(config.productStoich(2, 0) == 0);
 
-    Af = config.chemistryInput.reactionInputs[0].modelParams[0];
-    bf = config.chemistryInput.reactionInputs[0].modelParams[1];
-    Ef = config.chemistryInput.reactionInputs[0].modelParams[2];
-    // Af = (config.reactionModelParams[0 + 0]);
-    // bf = (config.reactionModelParams[1 + 0]);
-    // Ef = (config.reactionModelParams[2 + 0]);
+    // NOTE(kevin): need to read params from host.
+    Af = config.rxnModelParamsHost[0](0);
+    bf = config.rxnModelParamsHost[0](1);
+    Ef = config.rxnModelParamsHost[0](2);
+    // Af = config.chemistryInput.reactionInputs[0].modelParams[0];
+    // bf = config.chemistryInput.reactionInputs[0].modelParams[1];
+    // Ef = config.chemistryInput.reactionInputs[0].modelParams[2];
 
     Ab = (config.equilibriumConstantParams[0 + 0]);
     bb = (config.equilibriumConstantParams[1 + 0]);

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -55,3 +55,25 @@ MFEM_HOST_DEVICE double HoffertLien::computeRateCoefficient(const double &T_h, c
 
   return A_ * pow(temp, b_) * (tempFactor + 2.0) * exp(-tempFactor);
 }
+
+MFEM_HOST_DEVICE Tabulated::Tabulated(const TableInput &input) : Reaction() {
+  switch (input.order) {
+    case 1: {
+      table_ = new LinearTable(input);
+    } break;
+    default: {
+      printf("Given interpolation order is not supported for TableInterpolator!")
+      assert(false);
+    } break;
+  }
+}
+
+MFEM_HOST_DEVICE Tabulated::~Tabulated() {
+  delete table_;
+}
+
+MFEM_HOST_DEVICE double Tabulated::computeRateCoefficient(const double &T_h, const double &T_e,
+                                                          const bool isElectronInvolved) {
+  double temp = (isElectronInvolved) ? T_e : T_h;
+  return table_->eval(temp);
+}

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -63,7 +63,7 @@ MFEM_HOST_DEVICE Tabulated::Tabulated(const TableInput &input) : Reaction() {
     } break;
     default: {
       printf("Given interpolation order is not supported for TableInterpolator!");
-      exit(-1);
+      assert(false);
     } break;
   }
 }

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -62,8 +62,8 @@ MFEM_HOST_DEVICE Tabulated::Tabulated(const TableInput &input) : Reaction() {
       table_ = new LinearTable(input);
     } break;
     default: {
-      printf("Given interpolation order is not supported for TableInterpolator!")
-      assert(false);
+      printf("Given interpolation order is not supported for TableInterpolator!");
+      exit(-1);
     } break;
   }
 }

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -68,9 +68,7 @@ MFEM_HOST_DEVICE Tabulated::Tabulated(const TableInput &input) : Reaction() {
   }
 }
 
-MFEM_HOST_DEVICE Tabulated::~Tabulated() {
-  delete table_;
-}
+MFEM_HOST_DEVICE Tabulated::~Tabulated() { delete table_; }
 
 MFEM_HOST_DEVICE double Tabulated::computeRateCoefficient(const double &T_h, const double &T_e,
                                                           const bool isElectronInvolved) {

--- a/src/reaction.hpp
+++ b/src/reaction.hpp
@@ -101,10 +101,10 @@ class HoffertLien : public Reaction {
 };
 
 class Tabulated : public Reaction {
-private:
+ private:
   TableInterpolator *table_ = NULL;
 
-public:
+ public:
   MFEM_HOST_DEVICE Tabulated(const TableInput &input);
 
   MFEM_HOST_DEVICE virtual ~Tabulated();

--- a/src/reaction.hpp
+++ b/src/reaction.hpp
@@ -44,6 +44,7 @@
 #include "dataStructures.hpp"
 #include "equation_of_state.hpp"
 #include "run_configuration.hpp"
+#include "table.hpp"
 #include "tps_mfem_wrap.hpp"
 
 using namespace mfem;
@@ -94,6 +95,19 @@ class HoffertLien : public Reaction {
   MFEM_HOST_DEVICE HoffertLien(const double &A, const double &b, const double &E);
 
   MFEM_HOST_DEVICE virtual ~HoffertLien() {}
+
+  MFEM_HOST_DEVICE virtual double computeRateCoefficient(const double &T_h, const double &T_e,
+                                                         const bool isElectronInvolved = false);
+};
+
+class Tabulated : public Reaction {
+private:
+  TableInterpolator *table_ = NULL;
+
+public:
+  MFEM_HOST_DEVICE Tabulated(const TableInput &input);
+
+  MFEM_HOST_DEVICE virtual ~Tabulated();
 
   MFEM_HOST_DEVICE virtual double computeRateCoefficient(const double &T_h, const double &T_e,
                                                          const bool isElectronInvolved = false);

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -198,11 +198,11 @@ class RunConfiguration {
   std::vector<std::string> reactionEquations;
   Array<ReactionModel> reactionModels;
   // std::vector<std::vector<double>> reactionModelParams;
-  double reactionModelParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
+  // double reactionModelParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
   DenseMatrix reactantStoich, productStoich;
   Array<bool> detailedBalance;
   // std::vector<std::vector<double>> equilibriumConstantParams;
-  double equilibriumConstantParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
+  // double equilibriumConstantParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
 
   std::map<int, int> mixtureToInputMap;
   std::map<std::string, int> speciesMapping;

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -199,6 +199,9 @@ class RunConfiguration {
   Array<ReactionModel> reactionModels;
   // std::vector<std::vector<double>> reactionModelParams;
   // double reactionModelParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
+  // NOTE(kevin): this array of Vectors is to provide a proper pointer for both gpu and cpu.
+  // Indexes of this array do not correspond exactly to reaction index.
+  std::vector<mfem::Vector> rxnModelParamsHost;
   DenseMatrix reactantStoich, productStoich;
   Array<bool> detailedBalance;
   // std::vector<std::vector<double>> equilibriumConstantParams;

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -202,7 +202,7 @@ class RunConfiguration {
   DenseMatrix reactantStoich, productStoich;
   Array<bool> detailedBalance;
   // std::vector<std::vector<double>> equilibriumConstantParams;
-  // double equilibriumConstantParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
+  double equilibriumConstantParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
 
   std::map<int, int> mixtureToInputMap;
   std::map<std::string, int> speciesMapping;

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -197,8 +197,6 @@ class RunConfiguration {
   Vector reactionEnergies;
   std::vector<std::string> reactionEquations;
   Array<ReactionModel> reactionModels;
-  // std::vector<std::vector<double>> reactionModelParams;
-  // double reactionModelParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
   // NOTE(kevin): this array of Vectors is to provide a proper pointer for both gpu and cpu.
   // Indexes of this array do not correspond exactly to reaction index.
   std::vector<mfem::Vector> rxnModelParamsHost;
@@ -206,6 +204,11 @@ class RunConfiguration {
   Array<bool> detailedBalance;
   // std::vector<std::vector<double>> equilibriumConstantParams;
   double equilibriumConstantParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
+
+  // NOTE(kevin): this vector of DenseMatrix stores all the tables and provides a proper pointer for both gpu and cpu.
+  // note that this will store all types of tabulated data- rxn rate, collision integrals, etc.
+  // Indexes of this vector therefore do not correspond exactly to rxn index or other quantities.
+  std::vector<mfem::DenseMatrix> tableHost;
 
   std::map<int, int> mixtureToInputMap;
   std::map<std::string, int> speciesMapping;

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -70,7 +70,7 @@ MFEM_HOST_DEVICE int TableInterpolator::findInterval(const double &xEval) {
 //////// Linear interpolation
 //////////////////////////////////////////////////////
 
-MFEM_HOST_DEVICE LinearTable::LinearTable(const TableInput &input) : TableInterpolator(input.Ndata, input.xdata, input.ydata, input.xLogScale, input.fLogScale) {
+MFEM_HOST_DEVICE LinearTable::LinearTable(const TableInput &input) : TableInterpolator(input.Ndata, input.xdata, input.fdata, input.xLogScale, input.fLogScale) {
   for (int k = 0; k < Ndata_-1; k++) {
     a_[k] = (fLogScale_) ? log(fdata_[k]) : fdata_[k];
     double df = (fLogScale_) ? (log(fdata_[k+1]) - log(fdata_[k])) : (fdata_[k+1] - fdata_[k]);

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -33,7 +33,7 @@
 #include "table.hpp"
 
 MFEM_HOST_DEVICE TableInterpolator::TableInterpolator(const int &Ndata, const double *xdata, const double *fdata, const bool &xLogScale, const bool &fLogScale)
-    : Ndata_(Ndata), xLogScale_(xLogScale), yLogScale_(yLogScale) {
+    : Ndata_(Ndata), xLogScale_(xLogScale), fLogScale_(fLogScale) {
   for (int k = 0; k < Ndata_; k++) {
     xdata_[k] = xdata[k];
     fdata_[k] = fdata[k];

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -32,7 +32,8 @@
 
 #include "table.hpp"
 
-MFEM_HOST_DEVICE TableInterpolator::TableInterpolator(const int &Ndata, const double *xdata, const double *fdata, const bool &xLogScale, const bool &fLogScale)
+MFEM_HOST_DEVICE TableInterpolator::TableInterpolator(const int &Ndata, const double *xdata, const double *fdata,
+                                                      const bool &xLogScale, const bool &fLogScale)
     : Ndata_(Ndata), xLogScale_(xLogScale), fLogScale_(fLogScale) {
   assert((xdata != NULL) && (fdata != NULL));
   for (int k = 0; k < Ndata_; k++) {
@@ -62,7 +63,7 @@ MFEM_HOST_DEVICE int TableInterpolator::findInterval(const double &xEval) {
     }
   }
   // if xEval is outside the range, first has either 0 or Ndata_. Limit the value.
-  first = max(1, min(Ndata_-1, first));
+  first = max(1, min(Ndata_ - 1, first));
   // We want the left index of the interval.
   return first - 1;
 }
@@ -71,11 +72,12 @@ MFEM_HOST_DEVICE int TableInterpolator::findInterval(const double &xEval) {
 //////// Linear interpolation
 //////////////////////////////////////////////////////
 
-MFEM_HOST_DEVICE LinearTable::LinearTable(const TableInput &input) : TableInterpolator(input.Ndata, input.xdata, input.fdata, input.xLogScale, input.fLogScale) {
-  for (int k = 0; k < Ndata_-1; k++) {
+MFEM_HOST_DEVICE LinearTable::LinearTable(const TableInput &input)
+    : TableInterpolator(input.Ndata, input.xdata, input.fdata, input.xLogScale, input.fLogScale) {
+  for (int k = 0; k < Ndata_ - 1; k++) {
     a_[k] = (fLogScale_) ? log(fdata_[k]) : fdata_[k];
-    double df = (fLogScale_) ? (log(fdata_[k+1]) - log(fdata_[k])) : (fdata_[k+1] - fdata_[k]);
-    b_[k] = (xLogScale_) ? df / (log(xdata_[k+1]) - log(xdata_[k])) : df / (xdata_[k+1] - xdata_[k]);
+    double df = (fLogScale_) ? (log(fdata_[k + 1]) - log(fdata_[k])) : (fdata_[k + 1] - fdata_[k]);
+    b_[k] = (xLogScale_) ? df / (log(xdata_[k + 1]) - log(xdata_[k])) : df / (xdata_[k + 1] - xdata_[k]);
     a_[k] -= (xLogScale_) ? b_[k] * log(xdata_[k]) : b_[k] * xdata_[k];
   }
 }

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------------------bl-
+// BSD 3-Clause License
+//
+// Copyright (c) 2020-2022, The PECOS Development Team, University of Texas at Austin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// -----------------------------------------------------------------------------------el-
+
+#include "table.hpp"
+
+MFEM_HOST_DEVICE TableInterpolator::TableInterpolator(const int &Ndata, const double *xdata, const double *fdata, const bool &xLogScale, const bool &fLogScale)
+    : Ndata_(Ndata), xLogScale_(xLogScale), yLogScale_(yLogScale) {
+  for (int k = 0; k < Ndata_; k++) {
+    xdata_[k] = xdata[k];
+    fdata_[k] = fdata[k];
+  }
+}

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -34,6 +34,7 @@
 
 MFEM_HOST_DEVICE TableInterpolator::TableInterpolator(const int &Ndata, const double *xdata, const double *fdata, const bool &xLogScale, const bool &fLogScale)
     : Ndata_(Ndata), xLogScale_(xLogScale), fLogScale_(fLogScale) {
+  assert((xdata != NULL) && (fdata != NULL));
   for (int k = 0; k < Ndata_; k++) {
     xdata_[k] = xdata[k];
     fdata_[k] = fdata[k];

--- a/src/table.hpp
+++ b/src/table.hpp
@@ -41,7 +41,7 @@
 using namespace std;
 
 class TableInterpolator {
-protected:
+ protected:
   double xdata_[gpudata::MAXTABLE];
   double fdata_[gpudata::MAXTABLE];
   int Ndata_;
@@ -49,8 +49,9 @@ protected:
   bool xLogScale_;
   bool fLogScale_;
 
-public:
-  MFEM_HOST_DEVICE TableInterpolator(const int &Ndata, const double *xdata, const double *fdata, const bool &xLogScale, const bool &fLogScale);
+ public:
+  MFEM_HOST_DEVICE TableInterpolator(const int &Ndata, const double *xdata, const double *fdata, const bool &xLogScale,
+                                     const bool &fLogScale);
 
   MFEM_HOST_DEVICE virtual ~TableInterpolator() {}
 
@@ -67,12 +68,12 @@ public:
 //////////////////////////////////////////////////////
 
 class LinearTable : public TableInterpolator {
-private:
+ private:
   // f[j](x) = a + b * x
   double a_[gpudata::MAXTABLE];
   double b_[gpudata::MAXTABLE];
 
-public:
+ public:
   MFEM_HOST_DEVICE LinearTable(const TableInput &input);
 
   MFEM_HOST_DEVICE virtual ~LinearTable() {}

--- a/src/table.hpp
+++ b/src/table.hpp
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------------------bl-
+// BSD 3-Clause License
+//
+// Copyright (c) 2020-2022, The PECOS Development Team, University of Texas at Austin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// -----------------------------------------------------------------------------------el-
+#ifndef TABLE_HPP_
+#define TABLE_HPP_
+
+#include <math.h>
+
+#include <mfem/general/forall.hpp>
+
+#include "dataStructures.hpp"
+
+using namespace std;
+
+class TableInterpolator {
+protected:
+  double xdata_[gpudata::MAXTABLE];
+  double fdata_[gpudata::MAXTABLE];
+  int Ndata_;
+
+  bool xLogScale_;
+  bool fLogScale_;
+
+public:
+  MFEM_HOST_DEVICE TableInterpolator(const int Ndata, const double *xdata, const double *fdata, const bool xLogScale, const bool fLogScale);
+
+  MFEM_HOST_DEVICE virtual ~TableInterpolator() {}
+
+  MFEM_HOST_DEVICE virtual double eval(const double &xEval) {
+    printf("TableInterpolator not initialized!");
+    return nan("");
+  }
+}
+
+#endif  // TABLE_HPP_

--- a/src/table.hpp
+++ b/src/table.hpp
@@ -54,10 +54,30 @@ public:
 
   MFEM_HOST_DEVICE virtual ~TableInterpolator() {}
 
+  MFEM_HOST_DEVICE int findInterval(const double &xEval);
+
   MFEM_HOST_DEVICE virtual double eval(const double &xEval) {
     printf("TableInterpolator not initialized!");
     return nan("");
   }
+};
+
+//////////////////////////////////////////////////////
+//////// Linear interpolation
+//////////////////////////////////////////////////////
+
+class LinearTable : public TableInterpolator {
+private:
+  // f[j](x) = a + b * x
+  double a_[gpudata::MAXTABLE];
+  double b_[gpudata::MAXTABLE];
+
+public:
+  MFEM_HOST_DEVICE LinearTable(const TableInput &input);
+
+  MFEM_HOST_DEVICE virtual ~LinearTable() {}
+
+  MFEM_HOST_DEVICE virtual double eval(const double &xEval);
 };
 
 #endif  // TABLE_HPP_

--- a/src/table.hpp
+++ b/src/table.hpp
@@ -50,7 +50,7 @@ protected:
   bool fLogScale_;
 
 public:
-  MFEM_HOST_DEVICE TableInterpolator(const int Ndata, const double *xdata, const double *fdata, const bool xLogScale, const bool fLogScale);
+  MFEM_HOST_DEVICE TableInterpolator(const int &Ndata, const double *xdata, const double *fdata, const bool &xLogScale, const bool &fLogScale);
 
   MFEM_HOST_DEVICE virtual ~TableInterpolator() {}
 
@@ -58,6 +58,6 @@ public:
     printf("TableInterpolator not initialized!");
     return nan("");
   }
-}
+};
 
 #endif  // TABLE_HPP_

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -268,7 +268,7 @@ void GlobalProjectDiscCoefficient(ParGridFunction &gf, VectorCoefficient &coeff)
   delete tv;
 }
 
-mfem::Array<int> h5ReadTable(const std::string fileName, const std::string datasetName, mfem::DenseMatrix &output) {
+mfem::Array<int> h5ReadTable(const std::string &fileName, const std::string &datasetName, mfem::DenseMatrix &output) {
   hid_t file = -1;
   if (file_exists(fileName)) {
     file = H5Fopen(fileName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
@@ -305,4 +305,3 @@ mfem::Array<int> h5ReadTable(const std::string fileName, const std::string datas
 
   return shape;
 }
-

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -285,7 +285,7 @@ mfem::Array<int> h5ReadTable(const std::string &fileName, const std::string &dat
   const int ndims = H5Sget_simple_extent_ndims(dataspace);
   hsize_t dims[ndims];
   // int dummy = H5Sget_simple_extent_dims(dataspace,dims,NULL);
-  H5Sget_simple_extent_dims(dataspace,dims,NULL);
+  H5Sget_simple_extent_dims(dataspace, dims, NULL);
 
   // DenseMatrix memory is column-major, while HDF5 follows row-major.
   output.SetSize(dims[1], dims[0]);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -267,3 +267,42 @@ void GlobalProjectDiscCoefficient(ParGridFunction &gf, VectorCoefficient &coeff)
   gf.Distribute(tv);
   delete tv;
 }
+
+mfem::Array<int> h5ReadTable(const std::string fileName, const std::string datasetName, mfem::DenseMatrix &output) {
+  hid_t file = -1;
+  if (file_exists(fileName)) {
+    file = H5Fopen(fileName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+  } else {
+    grvy_printf(GRVY_ERROR, "[ERROR]: Unable to open file -> %s\n", fileName.c_str());
+    exit(ERROR);
+  }
+  assert(file >= 0);
+
+  hid_t datasetID, dataspace;
+  datasetID = H5Dopen2(file, datasetName.c_str(), H5P_DEFAULT);
+  assert(datasetID >= 0);
+  dataspace = H5Dget_space(datasetID);
+  const int ndims = H5Sget_simple_extent_ndims(dataspace);
+  hsize_t dims[ndims];
+  // int dummy = H5Sget_simple_extent_dims(dataspace,dims,NULL);
+  H5Sget_simple_extent_dims(dataspace,dims,NULL);
+
+  // DenseMatrix memory is column-major, while HDF5 follows row-major.
+  output.SetSize(dims[1], dims[0]);
+
+  herr_t status;
+  status = H5Dread(datasetID, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, output.HostReadWrite());
+  assert(status >= 0);
+  H5Dclose(datasetID);
+  H5Fclose(file);
+
+  // DenseMatrix memory is column-major, while HDF5 follows row-major.
+  output.Transpose();
+
+  mfem::Array<int> shape(2);
+  shape[0] = dims[0];
+  shape[1] = dims[1];
+
+  return shape;
+}
+

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -283,7 +283,7 @@ mfem::Array<int> h5ReadTable(const std::string &fileName, const std::string &dat
   assert(datasetID >= 0);
   dataspace = H5Dget_space(datasetID);
   const int ndims = H5Sget_simple_extent_ndims(dataspace);
-  hsize_t dims[ndims];
+  hsize_t dims[gpudata::MAXTABLEDIM];
   // int dummy = H5Sget_simple_extent_dims(dataspace,dims,NULL);
   H5Sget_simple_extent_dims(dataspace, dims, NULL);
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -79,7 +79,7 @@ void h5_read_attribute(hid_t source, std::string attribute, T &value) {
 
 // A simple HDF5 routine to read two-dimensional array into DenseMatrix.
 // Return shape of the DenseMatrix.
-mfem::Array<int> h5ReadTable(const std::string fileName, const std::string datasetName, mfem::DenseMatrix &output);
+mfem::Array<int> h5ReadTable(const std::string &fileName, const std::string &datasetName, mfem::DenseMatrix &output);
 
 // MFEM extensions
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -78,8 +78,9 @@ void h5_read_attribute(hid_t source, std::string attribute, T &value) {
 }
 
 // A simple HDF5 routine to read two-dimensional array into DenseMatrix.
-// Return shape of the DenseMatrix.
-mfem::Array<int> h5ReadTable(const std::string &fileName, const std::string &datasetName, mfem::DenseMatrix &output);
+// Return result as boolean.
+bool h5ReadTable(const std::string &fileName, const std::string &datasetName, mfem::DenseMatrix &output,
+                 mfem::Array<int> &shape);
 
 // MFEM extensions
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -79,43 +79,7 @@ void h5_read_attribute(hid_t source, std::string attribute, T &value) {
 
 // A simple HDF5 routine to read two-dimensional array into DenseMatrix.
 // Return shape of the DenseMatrix.
-Array<int> h5ReadTable(const string fileName, const string datasetName, DenseMatrix &output) {
-  hid_t file = -1;
-  if (file_exists(fileName)) {
-    file = H5Fopen(fileName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
-  } else {
-    grvy_printf(GRVY_ERROR, "[ERROR]: Unable to open file -> %s\n", fileName.c_str());
-    exit(ERROR);
-  }
-  assert(file >= 0);
-
-  hid_t datasetID, dataspace;
-  datasetID = H5Dopen2(file, datasetName.c_str(), H5P_DEFAULT);
-  assert(datasetID >= 0);
-  dataspace = H5Dget_space(datasetID);
-  const int ndims = H5Sget_simple_extent_ndims(dataspace);
-  hsize_t dims[ndims];
-  // int dummy = H5Sget_simple_extent_dims(dataspace,dims,NULL);
-  H5Sget_simple_extent_dims(dataspace,dims,NULL);
-
-  // DenseMatrix memory is column-major, while HDF5 follows row-major.
-  output.SetSize(dims[1], dims[0]);
-
-  herr_t status;
-  status = H5Dread(datasetID, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, output.HostReadWrite());
-  assert(status >= 0);
-  H5Dclose(datasetID);
-  H5Fclose(file);
-
-  // DenseMatrix memory is column-major, while HDF5 follows row-major.
-  output.Transpose();
-
-  Array<int> shape(2);
-  shape[0] = dims[0];
-  shape[1] = dims[1];
-
-  return shape;
-}
+mfem::Array<int> h5ReadTable(const std::string fileName, const std::string datasetName, mfem::DenseMatrix &output);
 
 // MFEM extensions
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -77,6 +77,46 @@ void h5_read_attribute(hid_t source, std::string attribute, T &value) {
   H5Aclose(attr);
 }
 
+// A simple HDF5 routine to read two-dimensional array into DenseMatrix.
+// Return shape of the DenseMatrix.
+Array<int> h5ReadTable(const string fileName, const string datasetName, DenseMatrix &output) {
+  hid_t file = -1;
+  if (file_exists(fileName)) {
+    file = H5Fopen(fileName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+  } else {
+    grvy_printf(GRVY_ERROR, "[ERROR]: Unable to open file -> %s\n", fileName.c_str());
+    exit(ERROR);
+  }
+  assert(file >= 0);
+
+  hid_t datasetID, dataspace;
+  datasetID = H5Dopen2(file, datasetName.c_str(), H5P_DEFAULT);
+  assert(datasetID >= 0);
+  dataspace = H5Dget_space(datasetID);
+  const int ndims = H5Sget_simple_extent_ndims(dataspace);
+  hsize_t dims[ndims];
+  // int dummy = H5Sget_simple_extent_dims(dataspace,dims,NULL);
+  H5Sget_simple_extent_dims(dataspace,dims,NULL);
+
+  // DenseMatrix memory is column-major, while HDF5 follows row-major.
+  output.SetSize(dims[1], dims[0]);
+
+  herr_t status;
+  status = H5Dread(datasetID, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, output.HostReadWrite());
+  assert(status >= 0);
+  H5Dclose(datasetID);
+  H5Fclose(file);
+
+  // DenseMatrix memory is column-major, while HDF5 follows row-major.
+  output.Transpose();
+
+  Array<int> shape(2);
+  shape[0] = dims[0];
+  shape[1] = dims[1];
+
+  return shape;
+}
+
 // MFEM extensions
 
 /** Project discontinous function onto FE space

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -192,4 +192,11 @@ if MASA_ENABLED
 test_grad_LDFLAGS += $(MASA_LIBS)
 endif
 
+check_PROGRAMS += test_table
+test_table_SOURCES  = test_table.cpp
+test_table_LDADD    = ../src/libtps.la
+test_table_LDADD    += $(HDF5_LIBS)
+test_table_LDADD    += $(GRVY_LIBS)
+test_table_LDFLAGS  = $(PYTHON_LIBS) $(MFEM_LIBS)
+
 endif # if !GPU_ENABLED

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -30,7 +30,7 @@ EXTRA_DIST      = tap-driver.sh soln_differ inputs meshes ref_solns/*.h5 \
 	 	  inflow_outflow.test mms.ternary_2d.test mms.ternary_2d_wall.test \
 	 	  mms.ternary_2d_inout.test cuda-memcheck.test mms.general_wall.test \
 		  independent_coupling.test interp_em.test mms.euler_2d.test mms.cns_2d.test \
-		  gradient.test coupled-3d.test
+		  gradient.test coupled-3d.test tabulated.test
 
 TESTS = vpath.sh
 XFAIL_TESTS =
@@ -73,7 +73,8 @@ TESTS += cyl3d.test \
 	 independent_coupling.test \
 	 interp_em.test \
 	 gradient.test \
-	 coupled-3d.test
+	 coupled-3d.test \
+	 tabulated.test
 
 if PYTHON_ENABLED
 TESTS += cyl3d.python.test

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -20,7 +20,7 @@ endif
 TEST_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/test/tap-driver.sh
 
 EXTRA_DIST      = tap-driver.sh soln_differ inputs meshes ref_solns/*.h5 \
-		  ref_solns/collisions/*.h5 ref_solns/transport/*.h5 \
+		  ref_solns/collisions/*.h5 ref_solns/transport/*.h5 ref_solns/reaction/*.h5 \
 		  vpath.sh die.sh cyl3d.gpu.test cyl3d.mflow.gpu.test wedge.gpu.test \
 	          averages.gpu.test cyl3d.test cyl3d.mflow.test cyl3d.dtconst.test \
 		  die.test averages.test wedge.test cyl3d.interp.test qms.rings.test qms.axisym.test \

--- a/test/inputs/input.tabulated_reaction.ini
+++ b/test/inputs/input.tabulated_reaction.ini
@@ -1,0 +1,105 @@
+[solver]
+type = flow
+
+[flow]
+mesh = meshes/periodic-square.mesh
+order = 2
+integrationRule = 1
+basisType = 1
+maxIters = 3000
+outputFreq = 400
+fluid = 'user_defined'
+viscosityMultiplier = 99000.
+equation_system = 'navier-stokes'
+
+[io]
+outdirBase = output
+
+[time]
+cfl = 0.2
+integrator = rk4
+enableConstantTimestep = True
+dt_fixed = 2.0e-4
+
+[initialConditions]
+rho = 1.2
+rhoU = 0.
+rhoV = 0.
+rhoW = 0.
+pressure = 101300
+
+###########################################
+#        PLASMA MODELS
+###########################################
+[plasma_models]
+ambipolar = False
+two_temperature = False
+gas_model = perfect_mixture
+transport_model = constant
+chemistry_model = 'mass_action_law'
+
+[plasma_models/transport_model/constant]
+viscosity = 0.0
+bulk_viscosity = 0.0
+thermal_conductivity = 0.0
+electron_thermal_conductivity = 0.0
+diffusivity/species1 = 0.0
+diffusivity/species2 = 0.0
+diffusivity/species3 = 0.0
+momentum_transfer_frequency/species1 = 0.0
+momentum_transfer_frequency/species2 = 0.0
+momentum_transfer_frequency/species3 = 0.0
+
+[atoms]
+numAtoms = 2
+
+[atoms/atom1]
+name = 'Ar'
+mass = 2.896439e-2
+
+[atoms/atom2]
+name = 'E'
+mass = 1e-7
+
+[species]
+numSpecies = 3
+background_index = 3
+
+[species/species1]
+name = 'Ar.+1'
+composition = '{Ar : 1, E : -1}'
+initialMassFraction = 0.
+formation_energy = 10000
+perfect_mixture/constant_molar_cv = 2.49996
+
+[species/species2]
+name = 'E'
+composition = '{E : 1}'
+initialMassFraction = 0.
+initialElectronTemperature = 300.;
+formation_energy = 0.
+perfect_mixture/constant_molar_cv = 2.49996
+
+[species/species3]
+name = 'Ar'
+composition = '{Ar : 1}'
+initialMassFraction = 1.
+formation_energy = 0.
+perfect_mixture/constant_molar_cv = 2.49996
+
+[reactions]
+number_of_reactions = 1
+
+# a fictitious reaction only to check the tabulated value.
+[reactions/reaction1]
+equation = 'Ar + E <=> Ar.+1 + 2 E'
+reaction_energy = 1.0e4
+reactant_stoichiometry = '0 0 1'
+product_stoichiometry = '1 1 0'
+model = tabulated
+tabulated/filename = 'ref_solns/reaction/excitation.3000K.ion1e-4.h5'
+tabulated/x_log = True
+tabulated/f_log = True
+tabulated/order = 1
+
+detailed_balance = False

--- a/test/ref_solns/reaction/excitation.3000K.ion1e-4.h5
+++ b/test/ref_solns/reaction/excitation.3000K.ion1e-4.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aab71154a12fc3c56e7384efa9e13506d0154596273147daac1d0f8f1f0dc0b3
+size 9168

--- a/test/ref_solns/reaction/excitation.3000K.ion1e-4.h5
+++ b/test/ref_solns/reaction/excitation.3000K.ion1e-4.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e89bab8e5b6357b4efcb155e34adee62da1cd51a7b073f022e7e24eb1df0347a
+oid sha256:3f2604298f6a9260db95c6abb12af8082b92f8bd783adffe849c008e0ceae354
 size 9168

--- a/test/ref_solns/reaction/excitation.3000K.ion1e-4.h5
+++ b/test/ref_solns/reaction/excitation.3000K.ion1e-4.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f2604298f6a9260db95c6abb12af8082b92f8bd783adffe849c008e0ceae354
+oid sha256:4563e087949527de1519139013ebdb43c0624beeef5cfe77a9826aa5d7454f54
 size 9168

--- a/test/ref_solns/reaction/excitation.3000K.ion1e-4.h5
+++ b/test/ref_solns/reaction/excitation.3000K.ion1e-4.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aab71154a12fc3c56e7384efa9e13506d0154596273147daac1d0f8f1f0dc0b3
+oid sha256:e89bab8e5b6357b4efcb155e34adee62da1cd51a7b073f022e7e24eb1df0347a
 size 9168

--- a/test/tabulated.test
+++ b/test/tabulated.test
@@ -1,0 +1,14 @@
+#!./bats
+# -*- mode: sh -*-
+
+TEST="tabulated reaction"
+RUNFILE="inputs/input.tabulated_reaction.ini"
+
+@test "[$TEST] Test exact interpolation from tabulated values" {
+    test -s $RUNFILE
+    test -s ./test_table
+
+    # mpirun to check if the table is broadcast to all ranks.
+    mpirun -n 2 ./test_table -run $RUNFILE
+}
+

--- a/test/tabulated.test
+++ b/test/tabulated.test
@@ -3,10 +3,12 @@
 
 TEST="tabulated reaction"
 RUNFILE="inputs/input.tabulated_reaction.ini"
+REFFILE="ref_solns/reaction/excitation.3000K.ion1e-4.h5"
 
 @test "[$TEST] Test exact interpolation from tabulated values" {
     test -s $RUNFILE
     test -s ./test_table
+#    test -s $REFFILE
 
     # mpirun to check if the table is broadcast to all ranks.
     mpirun -n 2 ./test_table -run $RUNFILE

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -1,0 +1,57 @@
+#include "../src/table.hpp"
+#include "../src/tps.hpp"
+#include "mfem.hpp"
+#include <fstream>
+
+using namespace mfem;
+using namespace std;
+
+const double scalarErrorThreshold = 5e-13;
+const int nTrials = 10;
+
+double uniformRandomNumber() {
+  return (double) rand() / (RAND_MAX);
+}
+
+int main (int argc, char *argv[])
+{
+  TPS::Tps tps;
+  tps.parseCommandLineArgs(argc, argv);
+  tps.parseInput();
+  tps.chooseDevices();
+
+  srand (time(NULL));
+  // double dummy = uniformRandomNumber();
+
+  const int Ndata = 57;
+  const double L = 5.0 * uniformRandomNumber();
+  double dx = L / (Ndata - 1);
+
+  TableInput input;
+  input.Ndata = Ndata;
+  input.xdata = new double[gpudata::MAXTABLE];
+  input.fdata = new double[gpudata::MAXTABLE];
+  for (int k = 0; k < Ndata; k++) {
+    input.xdata[k] = k * dx + 0.4 * dx * (2.0 * uniformRandomNumber() - 1.0);
+  }
+  TableInterpolator *table = new LinearTable(input);
+
+  // test findInterval routine.
+  const int Ntest = 1000;
+  for (int k = 0; k < Ntest; k++) {
+    double xEval = input.xdata[0] + (input.xdata[Ndata-1] - input.xdata[0]) * uniformRandomNumber();
+    int index = table->findInterval(xEval);
+    if ((input.xdata[index] > xEval) || (input.xdata[index+1] < xEval)) {
+      grvy_printf(GRVY_ERROR, "findIndex failed!: %.5f < xEval: %.5f < %.5f\n", input.xdata[index], xEval, input.xdata[index+1]);
+      exit(ERROR);
+    }
+  }
+//std::cout << "before" << std::endl;
+//  TableInput *test;
+//  test = new TableInput[10];
+//std::cout << "after" << std::endl;
+  delete table;
+
+  return 0;
+}
+

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -1,7 +1,9 @@
 #include "../src/table.hpp"
 #include "../src/tps.hpp"
 #include "mfem.hpp"
+#include "../src/utils.hpp"
 #include <fstream>
+#include <hdf5.h>
 
 using namespace mfem;
 using namespace std;
@@ -11,6 +13,44 @@ const int nTrials = 10;
 
 double uniformRandomNumber() {
   return (double) rand() / (RAND_MAX);
+}
+
+Array<int> readTable(const string fileName, const string datasetName, DenseMatrix &output) {
+  hid_t file = -1;
+  if (file_exists(fileName)) {
+    file = H5Fopen(fileName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+  } else {
+    grvy_printf(GRVY_ERROR, "[ERROR]: Unable to open file -> %s\n", fileName.c_str());
+    exit(ERROR);
+  }
+  assert(file >= 0);
+
+  hid_t datasetID, dataspace;
+  datasetID = H5Dopen2(file, datasetName.c_str(), H5P_DEFAULT);
+  assert(datasetID >= 0);
+  dataspace = H5Dget_space(datasetID);
+  const int ndims = H5Sget_simple_extent_ndims(dataspace);
+  hsize_t dims[ndims];
+  // int dummy = H5Sget_simple_extent_dims(dataspace,dims,NULL);
+  H5Sget_simple_extent_dims(dataspace,dims,NULL);
+
+  // DenseMatrix memory is column-major, while HDF5 follows row-major.
+  output.SetSize(dims[1], dims[0]);
+
+  herr_t status;
+  status = H5Dread(datasetID, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, output.HostReadWrite());
+  assert(status >= 0);
+  H5Dclose(datasetID);
+  H5Fclose(file);
+
+  // DenseMatrix memory is column-major, while HDF5 follows row-major.
+  output.Transpose();
+
+  Array<int> shape(2);
+  shape[0] = dims[0];
+  shape[1] = dims[1];
+
+  return shape;
 }
 
 int main (int argc, char *argv[])
@@ -37,7 +77,7 @@ int main (int argc, char *argv[])
   TableInterpolator *table = new LinearTable(input);
 
   // test findInterval routine.
-  const int Ntest = 1000;
+  const int Ntest = 100;
   for (int k = 0; k < Ntest; k++) {
     double xEval = input.xdata[0] + (input.xdata[Ndata-1] - input.xdata[0]) * uniformRandomNumber();
     int index = table->findInterval(xEval);
@@ -46,10 +86,33 @@ int main (int argc, char *argv[])
       exit(ERROR);
     }
   }
-//std::cout << "before" << std::endl;
-//  TableInput *test;
-//  test = new TableInput[10];
-//std::cout << "after" << std::endl;
+
+  delete table;
+
+  std::string fileName = "ref_solns/reaction/excitation.3000K.ion1e-4.h5";
+  std::string datasetName = "table";
+  DenseMatrix refValues;
+  Array<int> dims1 = readTable(fileName, datasetName, refValues);
+  input.Ndata = dims1[0];
+  for (int k = 0; k < input.Ndata; k++) {
+    input.xdata[k] = refValues(k, 0);
+    input.fdata[k] = refValues(k, 1);
+  }
+  input.xLogScale = true;
+  input.fLogScale = true;
+  table = new LinearTable(input);
+
+  // TODO(kevin): write a sort of sanity check for this. The values are manually checked at this point.
+//  std::cout << "[";
+//  for (int k = 0; k < Ntest; k++) {
+//    double xtest = 300.0 * pow(1.0e4 / 300.0, 1.0 * k / Ntest);
+//    double ftest = table->eval(xtest);
+//    std::cout << "[" << xtest << "," << ftest << "]";
+//    if (k < Ntest-1) std::cout << ",";
+//    std::cout << std::endl; 
+//  }
+//  std::cout << "]" << std::endl;
+
   delete table;
 
   return 0;

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -80,7 +80,12 @@ int main (int argc, char *argv[])
   tps.getRequiredInput((basePath + "/filename").c_str(), fileName);
   std::string datasetName = "table";
   DenseMatrix refValues;
-  Array<int> dims1 = h5ReadTable(fileName, datasetName, refValues);
+  Array<int> dims1(2);
+  bool success = h5ReadTable(fileName, datasetName, refValues, dims1);
+  if (!success) {
+    grvy_printf(GRVY_ERROR, "Reading the table file %s failed!\n", fileName.c_str());
+    exit(ERROR);
+  }
 
   if (rank == 0) printf("Table read.\n");
 

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -30,11 +30,13 @@ int main (int argc, char *argv[])
 
   TableInput input;
   input.Ndata = Ndata;
-  input.xdata = new double[gpudata::MAXTABLE];
-  input.fdata = new double[gpudata::MAXTABLE];
+  DenseMatrix data;
+  data.SetSize(Ndata, 2);
   for (int k = 0; k < Ndata; k++) {
-    input.xdata[k] = k * dx + 0.4 * dx * (2.0 * uniformRandomNumber() - 1.0);
+    data(k, 0) = k * dx + 0.4 * dx * (2.0 * uniformRandomNumber() - 1.0);
   }
+  input.xdata = data.Read();
+  input.fdata = data.Read() + Ndata;
   TableInterpolator *table = new LinearTable(input);
 
   // test findInterval routine.

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -14,44 +14,44 @@ const int nTrials = 10;
 double uniformRandomNumber() {
   return (double) rand() / (RAND_MAX);
 }
-
-Array<int> readTable(const string fileName, const string datasetName, DenseMatrix &output) {
-  hid_t file = -1;
-  if (file_exists(fileName)) {
-    file = H5Fopen(fileName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
-  } else {
-    grvy_printf(GRVY_ERROR, "[ERROR]: Unable to open file -> %s\n", fileName.c_str());
-    exit(ERROR);
-  }
-  assert(file >= 0);
-
-  hid_t datasetID, dataspace;
-  datasetID = H5Dopen2(file, datasetName.c_str(), H5P_DEFAULT);
-  assert(datasetID >= 0);
-  dataspace = H5Dget_space(datasetID);
-  const int ndims = H5Sget_simple_extent_ndims(dataspace);
-  hsize_t dims[ndims];
-  // int dummy = H5Sget_simple_extent_dims(dataspace,dims,NULL);
-  H5Sget_simple_extent_dims(dataspace,dims,NULL);
-
-  // DenseMatrix memory is column-major, while HDF5 follows row-major.
-  output.SetSize(dims[1], dims[0]);
-
-  herr_t status;
-  status = H5Dread(datasetID, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, output.HostReadWrite());
-  assert(status >= 0);
-  H5Dclose(datasetID);
-  H5Fclose(file);
-
-  // DenseMatrix memory is column-major, while HDF5 follows row-major.
-  output.Transpose();
-
-  Array<int> shape(2);
-  shape[0] = dims[0];
-  shape[1] = dims[1];
-
-  return shape;
-}
+//
+// Array<int> readTable(const string fileName, const string datasetName, DenseMatrix &output) {
+//   hid_t file = -1;
+//   if (file_exists(fileName)) {
+//     file = H5Fopen(fileName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+//   } else {
+//     grvy_printf(GRVY_ERROR, "[ERROR]: Unable to open file -> %s\n", fileName.c_str());
+//     exit(ERROR);
+//   }
+//   assert(file >= 0);
+//
+//   hid_t datasetID, dataspace;
+//   datasetID = H5Dopen2(file, datasetName.c_str(), H5P_DEFAULT);
+//   assert(datasetID >= 0);
+//   dataspace = H5Dget_space(datasetID);
+//   const int ndims = H5Sget_simple_extent_ndims(dataspace);
+//   hsize_t dims[ndims];
+//   // int dummy = H5Sget_simple_extent_dims(dataspace,dims,NULL);
+//   H5Sget_simple_extent_dims(dataspace,dims,NULL);
+//
+//   // DenseMatrix memory is column-major, while HDF5 follows row-major.
+//   output.SetSize(dims[1], dims[0]);
+//
+//   herr_t status;
+//   status = H5Dread(datasetID, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, output.HostReadWrite());
+//   assert(status >= 0);
+//   H5Dclose(datasetID);
+//   H5Fclose(file);
+//
+//   // DenseMatrix memory is column-major, while HDF5 follows row-major.
+//   output.Transpose();
+//
+//   Array<int> shape(2);
+//   shape[0] = dims[0];
+//   shape[1] = dims[1];
+//
+//   return shape;
+// }
 
 int main (int argc, char *argv[])
 {
@@ -92,7 +92,7 @@ int main (int argc, char *argv[])
   std::string fileName = "ref_solns/reaction/excitation.3000K.ion1e-4.h5";
   std::string datasetName = "table";
   DenseMatrix refValues;
-  Array<int> dims1 = readTable(fileName, datasetName, refValues);
+  Array<int> dims1 = h5ReadTable(fileName, datasetName, refValues);
   input.Ndata = dims1[0];
   for (int k = 0; k < input.Ndata; k++) {
     input.xdata[k] = refValues(k, 0);
@@ -109,7 +109,7 @@ int main (int argc, char *argv[])
 //    double ftest = table->eval(xtest);
 //    std::cout << "[" << xtest << "," << ftest << "]";
 //    if (k < Ntest-1) std::cout << ",";
-//    std::cout << std::endl; 
+//    std::cout << std::endl;
 //  }
 //  std::cout << "]" << std::endl;
 
@@ -117,4 +117,3 @@ int main (int argc, char *argv[])
 
   return 0;
 }
-

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -14,44 +14,6 @@ const int nTrials = 10;
 double uniformRandomNumber() {
   return (double) rand() / (RAND_MAX);
 }
-//
-// Array<int> readTable(const string fileName, const string datasetName, DenseMatrix &output) {
-//   hid_t file = -1;
-//   if (file_exists(fileName)) {
-//     file = H5Fopen(fileName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
-//   } else {
-//     grvy_printf(GRVY_ERROR, "[ERROR]: Unable to open file -> %s\n", fileName.c_str());
-//     exit(ERROR);
-//   }
-//   assert(file >= 0);
-//
-//   hid_t datasetID, dataspace;
-//   datasetID = H5Dopen2(file, datasetName.c_str(), H5P_DEFAULT);
-//   assert(datasetID >= 0);
-//   dataspace = H5Dget_space(datasetID);
-//   const int ndims = H5Sget_simple_extent_ndims(dataspace);
-//   hsize_t dims[ndims];
-//   // int dummy = H5Sget_simple_extent_dims(dataspace,dims,NULL);
-//   H5Sget_simple_extent_dims(dataspace,dims,NULL);
-//
-//   // DenseMatrix memory is column-major, while HDF5 follows row-major.
-//   output.SetSize(dims[1], dims[0]);
-//
-//   herr_t status;
-//   status = H5Dread(datasetID, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, output.HostReadWrite());
-//   assert(status >= 0);
-//   H5Dclose(datasetID);
-//   H5Fclose(file);
-//
-//   // DenseMatrix memory is column-major, while HDF5 follows row-major.
-//   output.Transpose();
-//
-//   Array<int> shape(2);
-//   shape[0] = dims[0];
-//   shape[1] = dims[1];
-//
-//   return shape;
-// }
 
 int main (int argc, char *argv[])
 {
@@ -85,6 +47,19 @@ int main (int argc, char *argv[])
       grvy_printf(GRVY_ERROR, "findIndex failed!: %.5f < xEval: %.5f < %.5f\n", input.xdata[index], xEval, input.xdata[index+1]);
       exit(ERROR);
     }
+  }
+  // Check the values outside the range.
+  double xEval = input.xdata[0] - 0.1 * (input.xdata[Ndata-1] - input.xdata[0]);
+  int index = table->findInterval(xEval);
+  if (index != 0) {
+    grvy_printf(GRVY_ERROR, "findIndex below the range failed!: %d != %d\n", index, 0);
+    exit(ERROR);
+  }
+  xEval = input.xdata[Ndata-1] + 0.1 * (input.xdata[Ndata-1] - input.xdata[0]);
+  index = table->findInterval(xEval);
+  if (index != (Ndata-2)) {
+    grvy_printf(GRVY_ERROR, "findIndex above the range failed!: %d != %d\n", index, Ndata-2);
+    exit(ERROR);
   }
 
   delete table;


### PR DESCRIPTION
This PR sets a ground for using tabulated data in `M2ulPhyS` class.

- Tabulated data are supposed to be stored in HDF5 format, with a dataset name `table`.
- `struct TableInput` contains necessary information for using tabulated data:
```
struct TableInput {
  int Ndata;
  const double *xdata;
  const double *fdata;
  bool xLogScale;
  bool fLogScale;

  int order;  // interpolation order. Currently only support order=1.
};
```
`xdata` and `fdata` point to the data. Currently both `xdata` and `fdata` are only one-column array, therefore only supporting one-dimensional table.
- `TableInterpolator` base class is initialized with the information in `TableInput`. `TableInterpolator::eval` evaluates the function value at given evaluation point, which is differently defined per derived class. Currently, only `LinearTable` is available as a derived class.
- `LinearTable` derived class supports simple linear interpolation (respecting the log scale options).
- `h5ReadTable` reads the table into `mfem::DenseMatrix` variable, and returns the size of the table.
- `M2ulPhyS::readTable` reads the input options for the tabulated data, then reads the hdf5 file on the root rank using `h5ReadTable`. The data is stored as `DenseMatrix` in `std::vector<DenseMatrix> M2ulPhyS.config.tableHost`. Each `DenseMatrix` is broadcast to all mpi ranks, and its device pointer is stored in a `TableInput` struct, which can be used for objects in the device.
- In essence, only the pointers to data is passed when initializing an object inside the device. Passing the entire data within a fixed-size array is prohibitive, where the size of tabulated data can easily exceed that of formal parameter size (4096 bytes).

This PR also supports reaction with tabulated rate data.

- `Tabulated` class is derived from `Reaction`, having a `TableInterpolator` pointer. Although only `LinearTable` is available, any other `TableInterpolator` can be used once it is implemented.
- Previously, model parameters for all reactions are stored into one array `ChemistryInput.reactionModelParams`. Since now `Tabulated` is available, this is no longer effective to pass down inputs for all reactions. Instead, an array of `ReactionInput` is used:
```
struct ReactionInput {
  TableInput tableInput;
  // NOTE(kevin): with gpu, this pointer is only valid on the device.
  const double *modelParams;
};
```
- Just as `TableInput`, only pointers to model parameters are stored in `ReactionInput`. Actual parameters are stored in `std::vector<mfem::Vector> M2ulPhyS.config.rxnModelParamsHost`.

A simply sanity check test `test/tabulated.test` is included on cpu side.

TODO:
- hdf5 format: currently does not read any attribute in the file. Some more functionalities such as unit conversion can be added, reading attributes from the hdf5 file.
- high-order interpolation: a natural cubic spline interpolation algorithm is available ([wikipedia](https://en.wikipedia.org/wiki/Spline_(mathematics))), though it is observed that a natural cubic spline cannot avoid overshooting outside the data range. Other spline interpolation libraries are usually object-oriented, which classes cannot be easily incorporated into `mfem` gpu framework.
- collision integrals also must support using tabulated data.