### PR TITLE
Post-process visualization

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1064,7 +1064,6 @@ void M2ulPhyS::initSolutionAndVisualizationVectors() {
   } else {
     // TODO(kevin): for now, keep the number of primitive variables same as conserved variables.
     // will need to add full list of species.
-    // visualizationVariables_.resize(numActiveSpecies);
     for (int sp = 0; sp < numActiveSpecies; sp++) {
       std::string speciesName = config.speciesNames[sp];
       visualizationVariables_.push_back(
@@ -1224,7 +1223,6 @@ void M2ulPhyS::initSolutionAndVisualizationVectors() {
     // Only for NS_PASSIVE.
     if ((eqSystem == NS_PASSIVE) && (sp == 1)) break;
 
-    // int inputSpeciesIndex = mixture->getInputIndexOf(sp);
     std::string speciesName = config.speciesNames[sp];
     ioData.registerIOVar("/solution", "rho-Y_" + speciesName, sp + nvel + 2);
   }
@@ -1272,33 +1270,11 @@ void M2ulPhyS::initSolutionAndVisualizationVectors() {
   paraviewColl->RegisterField("press", press);
   if (eqSystem == NS_PASSIVE) {
     paraviewColl->RegisterField("passiveScalar", passiveScalar);
-    // } else if (numActiveSpecies > 0) {
-    //   // TODO(kevin): for now, keep the number of primitive variables same as conserved variables.
-    //   // will need to add full list of species.
-    //   for (int sp = 0; sp < numActiveSpecies; sp++) {
-    //     // int inputSpeciesIndex = mixture->getInputIndexOf(sp);
-    //     std::string speciesName = config.speciesNames[sp];
-    //     paraviewColl->RegisterField("partial_density_" + speciesName, visualizationVariables_[sp]);
-    //   }
   }
 
   if (config.twoTemperature) {
     paraviewColl->RegisterField("Te", electron_temp_field);
   }
-
-  // // If mms, add exact solution.
-  // #ifdef HAVE_MASA
-  //   if (config.use_mms_ && config.mmsSaveDetails_) {
-  //     for (int eq = 0; eq < num_equation; eq++)
-  //       paraviewColl->RegisterField("U" + std::to_string(eq), visualizationVariables_[numActiveSpecies + eq]);
-  //     for (int eq = 0; eq < num_equation; eq++)
-  //       paraviewColl->RegisterField("mms_U" + std::to_string(eq),
-  //                                   visualizationVariables_[numActiveSpecies + num_equation + eq]);
-  //     for (int eq = 0; eq < num_equation; eq++)
-  //       paraviewColl->RegisterField("RHS" + std::to_string(eq),
-  //                                   visualizationVariables_[numActiveSpecies + 2 * num_equation + eq]);
-  //   }
-  // #endif
 
   for (int var = 0; var < visualizationVariables_.size(); var++) {
     paraviewColl->RegisterField(visualizationNames_[var], visualizationVariables_[var]);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -3426,7 +3426,6 @@ void M2ulPhyS::updateVisualizationVariables() {
       for (int r = 0; r < _numReactions; r++) {
         dataVis[visualIdxs.rxn + r][n] = progressRates[r];
       }
-
     }  // if (!isDryAir)
   }    // for (int n = 0; n < ndofs; n++)
 }

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1067,7 +1067,8 @@ void M2ulPhyS::initSolutionAndVisualizationVectors() {
     // visualizationVariables_.resize(numActiveSpecies);
     for (int sp = 0; sp < numActiveSpecies; sp++) {
       std::string speciesName = config.speciesNames[sp];
-      visualizationVariables_.push_back(new ParGridFunction(fes, U->HostReadWrite() + (sp + nvel + 2) * fes->GetNDofs()));
+      visualizationVariables_.push_back(
+          new ParGridFunction(fes, U->HostReadWrite() + (sp + nvel + 2) * fes->GetNDofs()));
       visualizationNames_.push_back(std::string("partial_density_" + speciesName));
     }
   }
@@ -1168,8 +1169,8 @@ void M2ulPhyS::initSolutionAndVisualizationVectors() {
         visualizationNames_.push_back(std::string("rxn_rate_" + std::to_string(r + 1)));
         // visualizationNames_.push_back(std::string("rxn_rate: " + config.reactionEquations[r]));
       }
-    }   // if (config.workFluid != DRY_AIR)
-  }   // if tpsP->isVisualizationMode()
+    }  // if (config.workFluid != DRY_AIR)
+  }    // if tpsP->isVisualizationMode()
 
   // If mms, add conserved and exact solution.
 #ifdef HAVE_MASA
@@ -1271,33 +1272,33 @@ void M2ulPhyS::initSolutionAndVisualizationVectors() {
   paraviewColl->RegisterField("press", press);
   if (eqSystem == NS_PASSIVE) {
     paraviewColl->RegisterField("passiveScalar", passiveScalar);
-  // } else if (numActiveSpecies > 0) {
-  //   // TODO(kevin): for now, keep the number of primitive variables same as conserved variables.
-  //   // will need to add full list of species.
-  //   for (int sp = 0; sp < numActiveSpecies; sp++) {
-  //     // int inputSpeciesIndex = mixture->getInputIndexOf(sp);
-  //     std::string speciesName = config.speciesNames[sp];
-  //     paraviewColl->RegisterField("partial_density_" + speciesName, visualizationVariables_[sp]);
-  //   }
+    // } else if (numActiveSpecies > 0) {
+    //   // TODO(kevin): for now, keep the number of primitive variables same as conserved variables.
+    //   // will need to add full list of species.
+    //   for (int sp = 0; sp < numActiveSpecies; sp++) {
+    //     // int inputSpeciesIndex = mixture->getInputIndexOf(sp);
+    //     std::string speciesName = config.speciesNames[sp];
+    //     paraviewColl->RegisterField("partial_density_" + speciesName, visualizationVariables_[sp]);
+    //   }
   }
 
   if (config.twoTemperature) {
     paraviewColl->RegisterField("Te", electron_temp_field);
   }
 
-// // If mms, add exact solution.
-// #ifdef HAVE_MASA
-//   if (config.use_mms_ && config.mmsSaveDetails_) {
-//     for (int eq = 0; eq < num_equation; eq++)
-//       paraviewColl->RegisterField("U" + std::to_string(eq), visualizationVariables_[numActiveSpecies + eq]);
-//     for (int eq = 0; eq < num_equation; eq++)
-//       paraviewColl->RegisterField("mms_U" + std::to_string(eq),
-//                                   visualizationVariables_[numActiveSpecies + num_equation + eq]);
-//     for (int eq = 0; eq < num_equation; eq++)
-//       paraviewColl->RegisterField("RHS" + std::to_string(eq),
-//                                   visualizationVariables_[numActiveSpecies + 2 * num_equation + eq]);
-//   }
-// #endif
+  // // If mms, add exact solution.
+  // #ifdef HAVE_MASA
+  //   if (config.use_mms_ && config.mmsSaveDetails_) {
+  //     for (int eq = 0; eq < num_equation; eq++)
+  //       paraviewColl->RegisterField("U" + std::to_string(eq), visualizationVariables_[numActiveSpecies + eq]);
+  //     for (int eq = 0; eq < num_equation; eq++)
+  //       paraviewColl->RegisterField("mms_U" + std::to_string(eq),
+  //                                   visualizationVariables_[numActiveSpecies + num_equation + eq]);
+  //     for (int eq = 0; eq < num_equation; eq++)
+  //       paraviewColl->RegisterField("RHS" + std::to_string(eq),
+  //                                   visualizationVariables_[numActiveSpecies + 2 * num_equation + eq]);
+  //   }
+  // #endif
 
   for (int var = 0; var < visualizationVariables_.size(); var++) {
     paraviewColl->RegisterField(visualizationNames_[var], visualizationVariables_[var]);
@@ -1368,8 +1369,7 @@ void M2ulPhyS::projectInitialSolution() {
     // Only save IC from fresh start.  On restart, will save viz at
     // next requested iter.  This avoids possibility of trying to
     // overwrite existing paraview data for the current iteration.
-    if (!(tpsP->isVisualizationMode()))
-      paraviewColl->Save();
+    if (!(tpsP->isVisualizationMode())) paraviewColl->Save();
   }
 }
 
@@ -3420,8 +3420,7 @@ void M2ulPhyS::updateVisualizationVariables() {
         dataVis[visualIdxs.FluxTrns + t][n] = fluxTrns[t];
       }
       for (int sp = 0; sp < _numSpecies; sp++) {
-        for (int v = 0; v < _nvel; v++)
-          dataVis[visualIdxs.diffVel + sp][n + v * ndofs] = diffVel[sp + v * _numSpecies];
+        for (int v = 0; v < _nvel; v++) dataVis[visualIdxs.diffVel + sp][n + v * ndofs] = diffVel[sp + v * _numSpecies];
       }
 
       // update source transport properties.
@@ -3452,7 +3451,6 @@ void M2ulPhyS::updateVisualizationVariables() {
         dataVis[visualIdxs.rxn + r][n] = progressRates[r];
       }
 
-    }   // if (!isDryAir)
-  }   // for (int n = 0; n < ndofs; n++)
-
+    }  // if (!isDryAir)
+  }    // for (int n = 0; n < ndofs; n++)
 }

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1131,7 +1131,7 @@ void M2ulPhyS::initSolutionAndVisualizationVectors() {
       for (int t = 0; t < SrcTrns::NUM_SRC_TRANS; t++) {
         std::string fieldName;
         switch (t) {
-          case SrcTrans::ELECTRIC_CONDUCTIVITY:
+          case SrcTrns::ELECTRIC_CONDUCTIVITY:
             fieldName = "electric_cond";
             break;
           default:

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1165,7 +1165,8 @@ void M2ulPhyS::initSolutionAndVisualizationVectors() {
       visualizationIndexes_.rxn = visualizationVariables_.size();
       for (int r = 0; r < config.numReactions; r++) {
         visualizationVariables_.push_back(new ParGridFunction(fes));
-        visualizationNames_.push_back(std::string("rxn_rate: " + config.reactionEquations[r]));
+        visualizationNames_.push_back(std::string("rxn_rate_" + std::to_string(r + 1)));
+        // visualizationNames_.push_back(std::string("rxn_rate: " + config.reactionEquations[r]));
       }
     }   // if (config.workFluid != DRY_AIR)
   }   // if tpsP->isVisualizationMode()

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -231,7 +231,8 @@ class M2ulPhyS : public TPS::Solver {
   ParGridFunction *temperature, *dens, *vel, *vtheta, *passiveScalar;
   ParGridFunction *electron_temp_field;
   ParGridFunction *press;
-  std::vector<ParGridFunction *> visualizationVariables;
+  std::vector<ParGridFunction *> visualizationVariables_;
+  std::vector<std::string> visualizationNames_;
   ParGridFunction *plasma_conductivity_;
   ParGridFunction *joule_heating_;
 

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -100,7 +100,7 @@ class M2ulPhyS : public TPS::Solver {
   // History file
   std::ofstream histFile;
 
-  // Number of simensions
+  // Number of dimensions
   int dim;
   int nvel;
 
@@ -176,6 +176,9 @@ class M2ulPhyS : public TPS::Solver {
 
   // Finite element space for a mesh-dim vector quantity (momentum)
   ParFiniteElementSpace *dfes;
+
+  // Finite element space for a nvel vector quantity. only for visualization (diffusion velocity).
+  ParFiniteElementSpace *nvelfes;
 
   // Finite element space for all variables together (total thermodynamic state)
   ParFiniteElementSpace *vfes;

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -233,6 +233,7 @@ class M2ulPhyS : public TPS::Solver {
   ParGridFunction *press;
   std::vector<ParGridFunction *> visualizationVariables_;
   std::vector<std::string> visualizationNames_;
+  AuxiliaryVisualizationIndexes visualizationIndexes_;
   ParGridFunction *plasma_conductivity_;
   ParGridFunction *joule_heating_;
 
@@ -380,6 +381,7 @@ class M2ulPhyS : public TPS::Solver {
 
   void solve() override;
   void visualization() override;
+  void updateVisualizationVariables();
 
   // Accessors
   RHSoperator *getRHSoperator() { return rhsOperator; }

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -361,6 +361,7 @@ class M2ulPhyS : public TPS::Solver {
   void parseReactionInputs();
   void parseBCInputs();
   void parseSpongeZoneInputs();
+  void parsePostProcessVisualizationInputs();
 
   void packUpGasMixtureInput();
   void identifySpeciesType(Array<ArgonSpcs> &speciesType);
@@ -377,6 +378,7 @@ class M2ulPhyS : public TPS::Solver {
   }
 
   void solve() override;
+  void visualization() override;
 
   // Accessors
   RHSoperator *getRHSoperator() { return rhsOperator; }

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -407,9 +407,9 @@ struct PostProcessInput {
 };
 
 struct AuxiliaryVisualizationIndexes {
-  int Xsp, Ysp, nsp;  // species primitive.
+  int Xsp, Ysp, nsp;                            // species primitive.
   int FluxTrns, SrcTrns, SpeciesTrns, diffVel;  // transport.
-  int rxn;  // reactions.
+  int rxn;                                      // reactions.
 };
 
 #endif  // DATASTRUCTURES_HPP_

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -54,6 +54,8 @@ const int MAXCHEMPARAMS = 3;
 
 const int MAXTABLE = 512;
 const int MAXTABLEDIM = 2;
+
+const int MAXVISUAL = 128;
 }  // namespace gpudata
 
 enum Equations {
@@ -402,6 +404,10 @@ struct PostProcessInput {
   int startIter;
   int endIter;
   int freq;
+};
+
+struct AuxiliaryVisualizationIndexes {
+  int Xsp, Ysp, nsp;  // species primitive.
 };
 
 #endif  // DATASTRUCTURES_HPP_

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -409,6 +409,7 @@ struct PostProcessInput {
 struct AuxiliaryVisualizationIndexes {
   int Xsp, Ysp, nsp;  // species primitive.
   int FluxTrns, SrcTrns, SpeciesTrns, diffVel;  // transport.
+  int rxn;  // reactions.
 };
 
 #endif  // DATASTRUCTURES_HPP_

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -397,4 +397,11 @@ struct ChemistryInput {
   ReactionInput reactionInputs[gpudata::MAXREACTIONS];
 };
 
+struct PostProcessInput {
+  std::string prefix;
+  int startIter;
+  int endIter;
+  int freq;
+};
+
 #endif  // DATASTRUCTURES_HPP_

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -408,6 +408,7 @@ struct PostProcessInput {
 
 struct AuxiliaryVisualizationIndexes {
   int Xsp, Ysp, nsp;  // species primitive.
+  int FluxTrns, SrcTrns, SpeciesTrns, diffVel;  // transport.
 };
 
 #endif  // DATASTRUCTURES_HPP_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,11 @@ int main(int argc, char *argv[]) {
     tps.chooseSolver();
     tps.initialize();
 
-    tps.solve();
+    if (tps.isVisualizationMode()) {  // post-process visualization process.
+      tps.visualization();
+    } else {  // regular forward time-integration.
+      tps.solve();
+    }
 
     status = tps.getStatus();
   }

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -155,6 +155,7 @@ class RHSoperator : public TimeDependentOperator {
 
   virtual void Mult(const Vector &x, Vector &y) const;
   void updatePrimitives(const Vector &x) const;
+  void updateGradients(const Vector &x, const bool &primitiveUpdated) const;
 
   virtual ~RHSoperator();
 

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -251,6 +251,8 @@ class RunConfiguration {
 
   double const_plasma_conductivity_;
 
+  PostProcessInput postprocessInput;
+
   RunConfiguration();
   ~RunConfiguration();
 

--- a/src/solver.hpp
+++ b/src/solver.hpp
@@ -58,6 +58,10 @@ class Solver {
     cout << "ERROR: " << __func__ << " remains unimplemented" << endl;
     exit(1);
   }
+  virtual void visualization() {
+    cout << "ERROR: " << __func__ << " remains unimplemented" << endl;
+    exit(1);
+  }
 };
 
 }  // end namespace TPS

--- a/src/source_term.cpp
+++ b/src/source_term.cpp
@@ -151,11 +151,10 @@ void SourceTerm::updateTerms(mfem::Vector &in) {
     _chemistry->computeEquilibriumConstants(Th, Te, kC);
 
     // get reaction rates
-    double progressRates[gpudata::MAXREACTIONS], creationRates[gpudata::MAXREACTIONS];
-    for (int r = 0; r < _numReactions; r++) {
-      progressRates[r] = 0.0;
-      creationRates[r] = 0.0;
-    }
+    double progressRates[gpudata::MAXREACTIONS], creationRates[gpudata::MAXSPECIES];
+    for (int r = 0; r < _numReactions; r++) progressRates[r] = 0.0;
+    for (int sp = 0; sp < _numSpecies; sp++) creationRates[sp] = 0.0;
+
     _chemistry->computeProgressRate(ns, kfwd, kC, progressRates);
     _chemistry->computeCreationRate(progressRates, creationRates);
 

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -63,6 +63,9 @@ Tps::Tps() {
   isEMOnlyMode_ = false;
   isFlowEMCoupledMode_ = false;
 
+  // default post-process visualization mode
+  isVisualizationMode_ = false;
+
   // execution device inferred from build setup
 #ifdef _HIP_
   deviceConfig_ = "hip";
@@ -102,6 +105,7 @@ void Tps::parseCommandLineArgs(int argc, char *argv[]) {
   mfem::OptionsParser args(argc, argv);
   bool showVersion = false;
   bool debugMode = false;
+  bool visualMode = false;
   const char *astring = iFile_.c_str();
 
   if (isRank0_) {
@@ -113,6 +117,7 @@ void Tps::parseCommandLineArgs(int argc, char *argv[]) {
   args.AddOption(&showVersion, "-v", "--version", "", "--no-version", "Print code version and exit,");
   args.AddOption(&astring, "-run", "--runFile", "Name of the input file with run options.");
   args.AddOption(&debugMode, "-d", "--debug", "", "--no-debug", "Launch in debug mode for gdb attach.");
+  args.AddOption(&visualMode, "-visual", "--visualization", "", "--no-visualization", "Launch post-process visualization.");
 
   args.Parse();
 
@@ -122,6 +127,7 @@ void Tps::parseCommandLineArgs(int argc, char *argv[]) {
   }
 
   iFile_ = astring;
+  isVisualizationMode_ = visualMode;
 
   // Version info
   printHeader();

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -117,7 +117,8 @@ void Tps::parseCommandLineArgs(int argc, char *argv[]) {
   args.AddOption(&showVersion, "-v", "--version", "", "--no-version", "Print code version and exit,");
   args.AddOption(&astring, "-run", "--runFile", "Name of the input file with run options.");
   args.AddOption(&debugMode, "-d", "--debug", "", "--no-debug", "Launch in debug mode for gdb attach.");
-  args.AddOption(&visualMode, "-visual", "--visualization", "", "--no-visualization", "Launch post-process visualization.");
+  args.AddOption(&visualMode, "-visual", "--visualization", "", "--no-visualization",
+                 "Launch post-process visualization.");
 
   args.Parse();
 

--- a/src/tps.hpp
+++ b/src/tps.hpp
@@ -87,6 +87,9 @@ class Tps {
   // pointer to solver implementation chosen at runtime
   TPS::Solver *solver_ = NULL;
 
+  // post-process visualization mode
+  bool isVisualizationMode_;
+
  public:
   Tps();                           // constructor
   ~Tps();                          // destructor
@@ -126,6 +129,10 @@ class Tps {
     solver_->solve();
     return;
   }
+  void visualization() {
+    solver_->visualization();
+    return;
+  }
   void printHeader();
   void parseCommandLineArgs(int argc, char *argv[]);  // variant used in C++ interface
   void parseArgs(std::vector<std::string> argv);      // variant used in python interface
@@ -134,6 +141,7 @@ class Tps {
   mfem::MPI_Session &getMPISession() { return mpi_; }
   std::string &getInputFilename() { return iFile_; }
   bool isFlowEMCoupled() const { return isFlowEMCoupledMode_; }
+  bool isVisualizationMode() const { return isVisualizationMode_; }
   const std::string &getSolverType() { return input_solver_type_; }
 };
 


### PR DESCRIPTION
`tps` now supports a post-process visualization mode, which generates paraview files from a list of solution restart files.

Basic command for this visualization mode is `tps -visual -run your_input_file.ini`.

When running in the visualization mode, it requires the following input options in the input file:

```
[post-process/visualization]
prefix = mms.ternary_2d
start-iter = 100 
end-iter = 500 
frequency = 100
```

`tps` will try to access to the files names as `"%s-%08d.h5" % (prefix, iter)`, with `iter` iterating from `start-iter` to `end-iter` at the frequency of `frequency`. Note that `tps` currently uses a fixed filename for the restart file: `"restart_%s.sol.h5" % config.outputFile`, where `config.outputFile` is read from the input file with option `io/outdirBase`. Because `tps` does not specify the time-step in the filename, and also because `tps` will overwrite every time it saves the restart file, the users must manually rename the restart files with the time-step specified whenever they are created, in order to use this post-process visualization mode. Note that the `iter` specified in the restart-file names do not have to correspond the actual time-step of the solution.

The I/O mechanism still follows the options specified as `io/restartMode` in the input file. If it is either `"singleFileRead"` or `"singleFileReadWrite"`, a single solution file will be required at each `iter`, however many processors `tps` is run on. If it is `"standard"`, the number of restart files at each `iter` must match the number of processors, and must respect the format `"%s-%08d.%d.h5" % (prefix, iter, rank)` with mpi `rank`.

For each restart file, it computes and saves the following auxiliary variables:
- Species primitives: mole/mass fraction and number density
- Transport properties listed in `FluxTrns`, `SrcTrns`, and `SpeciesTrns`.
- Diffusion velocity of each species
- Reaction rates with indexes as listed in the input file

TODO:
- Currently only cpu path is implemented for visualization mode. However, most part of it is written in a gpu-compatible way, and only the loop in `M2ulPhyS::updateVisualizationVariables()` will need a minor revision of adding a gpu-loop wrapper with `#ifdef _GPU_`.
- In the future, it will be good if the user can specify what variables to be visualized.