### PR TITLE
Fix sponge zone input parsing with species

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -2931,7 +2931,7 @@ void M2ulPhyS::parseSpongeZoneInputs() {
       config.spongeData_[sz].normal.SetSize(3);
       config.spongeData_[sz].point0.SetSize(3);
       config.spongeData_[sz].pointInit.SetSize(3);
-      config.spongeData_[sz].targetUp.SetSize(5);
+      config.spongeData_[sz].targetUp.SetSize(5 + config.numSpecies + 2);  // always large enough now
 
       tpsP->getRequiredVec((base + "/normal").c_str(), config.spongeData_[sz].normal, 3);
       tpsP->getRequiredVec((base + "/p0").c_str(), config.spongeData_[sz].point0, 3);

--- a/test/inputs/input.sponge_zone.periodic.species.ini
+++ b/test/inputs/input.sponge_zone.periodic.species.ini
@@ -1,0 +1,109 @@
+[solver]
+type = flow
+
+[flow]
+mesh = meshes/periodic-square.mesh
+order = 1
+integrationRule = 1
+basisType = 1
+maxIters = 3000
+outputFreq = 100
+enableSummationByParts = 0
+fluid = user_defined
+equation_system = navier-stokes
+
+[io]
+outdirBase = sponge_zone
+
+[time]
+cfl = 0.12
+integrator = rk4
+
+[initialConditions]
+rho = 1.2
+rhoU = 100.
+rhoV = 100
+rhoW = 0.
+pressure = 101300
+
+[spongezone]
+numSpongeZones = 1
+
+[spongezone1]
+type = planar
+normal = '-1 0 0'
+p0 = '1 0 0'
+pInit = '-1 0 0'
+targetSolType = userDef
+density = 1.2
+uvw = '100 100 0'
+pressure = 101300
+multiplier = 1
+mass_fraction/species1 = 1.37e-12
+mass_fraction/species2 = 0.99999989999863
+mass_fraction/species3 = 1.00e-7
+
+[boundaryConditions]
+numWalls = 0
+numInlets = 0
+numOutlets = 0
+
+#--------------------------------------------------------------
+[plasma_models]
+ambipolar = True
+two_temperature = False
+gas_model = perfect_mixture
+chemistry_model = n/a
+const_plasma_conductivity = 50.0
+
+transport_model = constant
+
+transport_model/constant/viscosity = 2.27e-5  # Pa * sec
+transport_model/constant/bulk_viscosity = 0
+transport_model/constant/thermal_conductivity = 0.0175 # W / (m * K)
+transport_model/constant/electron_thermal_conductivity = 0  # not important for "cold" spin up run
+transport_model/constant/diffusivity/species1 = 2.08e-5 # set all same for now
+transport_model/constant/diffusivity/species2 = 2.08e-5 # b/c it doesn't matter much
+transport_model/constant/diffusivity/species3 = 2.08e-5 # for the "cold" case
+transport_model/constant/momentum_transfer_frequency/species1 = 0 # irrelevant for 1 T
+transport_model/constant/momentum_transfer_frequency/species2 = 0
+transport_model/constant/momentum_transfer_frequency/species3 = 0
+
+[atoms]
+numAtoms = 2
+
+[atoms/atom1]
+name = 'Ar'
+mass = 3.99e-2
+
+[atoms/atom2]
+name = 'E'
+mass = 5.478e-7
+
+[species]
+numSpecies = 3
+background_index = 2
+#electron_index = 1
+
+[species/species3]
+name = 'Ar.+1'
+composition = '{Ar : 1, E : -1}'
+formation_energy = 1.521e6
+initialMassFraction = 1.00e-7
+perfect_mixture/constant_molar_cv = 1.5
+
+[species/species1]
+name = 'E'
+composition = '{E : 1}'
+formation_energy = 0.0
+initialMassFraction = 1.37e-12
+# if gas_model is perfect_mixture, requires heat capacities from input.
+# molar heat capacities in unit of universal gas constant.
+perfect_mixture/constant_molar_cv = 1.5
+
+[species/species2]
+name = 'Ar'
+composition = '{Ar : 1}'
+formation_energy = 0.0
+initialMassFraction = 0.99999989999863
+perfect_mixture/constant_molar_cv = 1.5

--- a/test/sponge_zone.test
+++ b/test/sponge_zone.test
@@ -3,6 +3,7 @@
 
 TEST="sponge_zone.test"
 RUNFILE="inputs/input.sponge_zone.periodic.ini"
+RUNFILE_SP="inputs/input.sponge_zone.periodic.species.ini"
 SOLN_FILE=restart_sponge_zone.sol.h5
 REF_FILE=ref_solns/forcing-periodic-square.h5
 
@@ -22,4 +23,12 @@ REF_FILE=ref_solns/forcing-periodic-square.h5
     
     test -s $SOLN_FILE
     ./soln_differ -d 2 $SOLN_FILE $REF_FILE
+}
+
+@test "[$TEST] verify ability to run sponge-zone with species" {
+    rm -f $SOLN_FILE
+
+    ../src/tps --runFile $RUNFILE_SP
+
+    test -s $SOLN_FILE
 }


### PR DESCRIPTION
Set size of `targetUp` large enough to handle species and temperatures if necesssary.

Resolves #181 