### PR TITLE
Pfix pfield interpolator

### DIFF
--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -233,12 +233,10 @@ void Tps::chooseSolver() {
   solver_->parseSolverOptions();
 }
 
-
 void Tps::parseInput(std::string iFile) {
   iFile_ = iFile;
   parseInput();
 }
-
 
 /// Read runtime input file on single MPI process and distribute so that
 /// runtime inputs are available for query on on all processors.

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -233,6 +233,13 @@ void Tps::chooseSolver() {
   solver_->parseSolverOptions();
 }
 
+
+void Tps::parseInput(std::string iFile) {
+  iFile_ = iFile;
+  parseInput();
+}
+
+
 /// Read runtime input file on single MPI process and distribute so that
 /// runtime inputs are available for query on on all processors.
 void Tps::parseInput() {

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -233,7 +233,7 @@ void Tps::chooseSolver() {
   solver_->parseSolverOptions();
 }
 
-void Tps::parseInput(std::string iFile) {
+void Tps::parseInputFile(std::string iFile) {
   iFile_ = iFile;
   parseInput();
 }

--- a/src/tps.hpp
+++ b/src/tps.hpp
@@ -136,7 +136,10 @@ class Tps {
   void printHeader();
   void parseCommandLineArgs(int argc, char *argv[]);  // variant used in C++ interface
   void parseArgs(std::vector<std::string> argv);      // variant used in python interface
+
   void parseInput();
+  void parseInput(std::string iFile);
+  void closeInput() { iparse_.Close(); }
 
   mfem::MPI_Session &getMPISession() { return mpi_; }
   std::string &getInputFilename() { return iFile_; }

--- a/src/tps.hpp
+++ b/src/tps.hpp
@@ -138,8 +138,8 @@ class Tps {
   void parseArgs(std::vector<std::string> argv);      // variant used in python interface
 
   void parseInput();
-  void parseInput(std::string iFile);
-  void closeInput() { iparse_.Close(); }
+  void parseInputFile(std::string iFile);
+  void closeInputFile() { iparse_.Close(); }
 
   mfem::MPI_Session &getMPISession() { return mpi_; }
   std::string &getInputFilename() { return iFile_; }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -83,7 +83,7 @@ endif
 endif
 
 if GSLIB_ENABLED
-#TESTS += cyl3d.interp.test
+TESTS += cyl3d.interp.test
 endif
 
 check_PROGRAMS =

--- a/test/cyl3d.interp.test
+++ b/test/cyl3d.interp.test
@@ -1,7 +1,9 @@
-#!../utils/bats/bin/bats
+#!./bats
 # -*- mode: sh -*-
 
 TEST="cyl3d.interp"
+TPS="../src/tps"
+EXE="../utils/interp"
 
 setup() {
     SOLN_FILE=restart_output.sol.h5
@@ -12,19 +14,26 @@ setup() {
     INTERP_FILE_P0=restart_output_ref0.sol.0.h5
     INTERP_FILE_P1=restart_output_ref0.sol.1.h5
 
-    RUNFILE_FRESH="inputs/input.dtconst.cyl"
-    RUNFILE_RESTART="inputs/input.dtconst.restart.cyl"
-    RUNFILE_INTERP0="inputs/input.refine0.cyl"
-    RUNFILE_INTERP1="inputs/input.refine1.cyl"
+    RUNFILE_FRESH="inputs/input.dtconst.cyl.ini"
+    RUNFILE_RESTART="inputs/input.dtconst.restart.cyl.ini"
+    RUNFILE_INTERP0="inputs/input.refine0.cyl.ini"
+#    RUNFILE_INTERP1="inputs/input.refine1.cyl"
+}
+
+@test "[$TEST] check for pfield_interpolate executable and input files" {
+    test -x $EXE
+    test -s $RUNFILE_FRESH
+    test -s $RUNFILE_RESTART
+    test -s $RUNFILE_INTERP0
 }
 
 @test "[$TEST] run serial interp with same input and output grids" {
     # generate restart file
-    ../src/tps --runFile $RUNFILE_FRESH
+    $TPS --runFile $RUNFILE_FRESH
     test -s $SOLN_FILE
 
     # interpolation
-    ../utils/interp -r1 $RUNFILE_RESTART -r2 $RUNFILE_INTERP0
+    $EXE -r1 $RUNFILE_RESTART -r2 $RUNFILE_INTERP0
     test -s $INTERP_FILE
 
     # verify soln didn't change
@@ -38,12 +47,12 @@ setup() {
 
 @test "[$TEST] run parallel (np=2) interp with same input and output grids" {
     # generate restart file
-    mpirun -np 2 ../src/tps --runFile $RUNFILE_FRESH
+    mpirun -np 2 $TPS --runFile $RUNFILE_FRESH
     test -s $SOLN_FILE_P0
     test -s $SOLN_FILE_P1
 
     # interpolation
-    mpirun -np 2 ../utils/interp -r1 $RUNFILE_RESTART -r2 $RUNFILE_INTERP0
+    mpirun -np 2 $EXE -r1 $RUNFILE_RESTART -r2 $RUNFILE_INTERP0
     test -s $INTERP_FILE_P0
     test -s $INTERP_FILE_P1
 

--- a/test/inputs/input.refine0.cyl.ini
+++ b/test/inputs/input.refine0.cyl.ini
@@ -1,0 +1,52 @@
+[solver]
+type = flow
+
+[flow]
+mesh = meshes/cyl-tet-coarse.msh
+order = 1
+integrationRule = 0
+basisType = 0
+maxIters = 4
+outputFreq = 5
+useRoe = 0
+enableSummationByParts = 0
+fluid = dry_air
+refLength = 1.
+equation_system = navier-stokes
+
+[io]
+outdirBase = output_ref0
+
+[time]
+cfl = 0.80
+enableConstantTimestep = True
+integrator = rk4
+
+[initialConditions]
+rho = 1.2
+rhoU = 0.2
+rhoV = 0.
+rhoW = 0.
+pressure = 102300
+
+[boundaryConditions/inlet1]
+patch = 1
+type = subsonic
+density = 1.2
+uvw = '20 0 0'
+
+[boundaryConditions/outlet1]
+patch = 2
+type = subsonicPressure
+pressure = 101300
+
+[boundaryConditions/wall1]
+patch = 3
+type = viscous_isothermal
+temperature = 300
+
+[boundaryConditions]
+numWalls = 1
+numInlets = 1
+numOutlets = 1
+

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -46,15 +46,15 @@ endif
 #simmesh_LDFLAGS += -L$(GSLIB_LIB) -lgs
 
 if GSLIB_ENABLED
-#bin_PROGRAMS   += interp
-#interp_SOURCES  = pfield_interpolate.cpp
-#interp_LDADD    = ../src/libtps.la
-#interp_LDADD    += $(HDF5_LIBS)
-#interp_LDADD    += $(GRVY_LIBS)
-#interp_LDFLAGS  = $(PYTHON_LIBS) $(MFEM_LIBS)
-#if MASA_ENABLED
-#interp_LDFLAGS += $(MASA_LIBS)
-#endif
+bin_PROGRAMS   += interp
+interp_SOURCES  = pfield_interpolate.cpp
+interp_LDADD    = ../src/libtps.la
+interp_LDADD    += $(HDF5_LIBS)
+interp_LDADD    += $(GRVY_LIBS)
+interp_LDFLAGS  = $(PYTHON_LIBS) $(MFEM_LIBS)
+if MASA_ENABLED
+interp_LDFLAGS += $(MASA_LIBS)
+endif
 endif
 
 bin_PROGRAMS += binaryic

--- a/utils/pfield_interpolate.cpp
+++ b/utils/pfield_interpolate.cpp
@@ -41,14 +41,14 @@ int main (int argc, char *argv[])
   string srcFileName(src_input_file);
 
   TPS::Tps tps;
-  tps.parseInput(srcFileName);
+  tps.parseInputFile(srcFileName);
   tps.chooseDevices();
 
   M2ulPhyS srcField( tps.getMPISession(), srcFileName, &tps );
   RunConfiguration& srcConfig = srcField.GetConfig();
   assert(srcConfig.GetRestartCycle()>0);
 
-  tps.closeInput();
+  tps.closeInputFile();
 
   ParMesh* mesh_1 = srcField.GetMesh();
   const int dim = mesh_1->Dimension();
@@ -58,13 +58,13 @@ int main (int argc, char *argv[])
   // target run file, since the target restart files do not exist yet.
   string tarFileName(tar_input_file);
 
-  tps.parseInput(tarFileName);
+  tps.parseInputFile(tarFileName);
 
   M2ulPhyS tarField( tps.getMPISession(), tarFileName, &tps );
   RunConfiguration& tarConfig = tarField.GetConfig();
   assert(tarConfig.GetRestartCycle()==0);
 
-  tps.closeInput();
+  tps.closeInputFile();
 
   // Get meshes
   ParMesh* mesh_2 = tarField.GetMesh();


### PR DESCRIPTION
When the top-level class `Tps` was introduced, the pfield interpolator utility (useful for interpolating the state in a restart file onto a different mesh) was broken.  This was not noticed initially, since the regression test was only active with gslib support present, which was not the default scenario at the time.

This PR introduces changes to enable this utility again.  Since gslib support is now the default in our test container and the regression test has been added back, it shouldn't break again without anyone realizing.