### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/docker-cpu.yaml
+++ b/.github/workflows/docker-cpu.yaml
@@ -13,7 +13,7 @@ jobs:
      env:
        DOCKERPATH: docker/test
      steps:
-       - uses: actions/checkout@v2
+       - uses: actions/checkout@v3
          with:
            fetch-depth: 0
 #       - uses: jitterbit/get-changed-files@v1

--- a/.github/workflows/docker-quartz.yaml
+++ b/.github/workflows/docker-quartz.yaml
@@ -13,10 +13,10 @@ jobs:
        DOCKERPATH: docker/quartz
      steps:
        - name: Cancel previous runs
-         uses: styfle/cancel-workflow-action@0.9.0
+         uses: styfle/cancel-workflow-action@0.11.0
          with:
            access_token: ${{ github.token }}     
-       - uses: actions/checkout@v2
+       - uses: actions/checkout@v3
          with:
            fetch-depth: 0
        - uses: Ana06/get-changed-files@v2.1.0       

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,11 +26,11 @@ jobs:
      name: Code style
      steps:
        - name: Cancel previous runs
-         uses: styfle/cancel-workflow-action@0.9.0
+         uses: styfle/cancel-workflow-action@0.11.0
          with:
            access_token: ${{ github.token }}
        - name: Checkout code
-         uses: actions/checkout@v2
+         uses: actions/checkout@v3
        - name: Bootstrap
          run:  ./bootstrap
        - name: Configure
@@ -46,11 +46,11 @@ jobs:
      name: Build/CPU
      steps:
        - name: Cancel previous runs
-         uses: styfle/cancel-workflow-action@0.9.0
+         uses: styfle/cancel-workflow-action@0.11.0
          with:
            access_token: ${{ github.token }}     
        - name: Checkout code
-         uses: actions/checkout@v2
+         uses: actions/checkout@v3
          with:
            lfs: true
        - name: Query modules loaded
@@ -79,11 +79,11 @@ jobs:
       MASA_DIR: /home/oliver/sw/masa
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}    
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           lfs: true
       - name: MFEM Tree
@@ -105,11 +105,11 @@ jobs:
       MFEM_DIR: /home/karl/sw/mfem-hip-4.3
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}    
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           lfs: true
       - name: Set ROCm path
@@ -143,11 +143,11 @@ jobs:
      name: Create dist tarball
      steps:
        - name: Cancel previous runs
-         uses: styfle/cancel-workflow-action@0.9.0
+         uses: styfle/cancel-workflow-action@0.11.0
          with:
            access_token: ${{ github.token }}     
        - name: Checkout code
-         uses: actions/checkout@v2
+         uses: actions/checkout@v3
          with:
            lfs: true         
        - name: Bootstrap
@@ -157,7 +157,7 @@ jobs:
        - name: Dist
          run:  make dist
        - name: Archive tarball
-         uses: actions/upload-artifact@v2
+         uses: actions/upload-artifact@v3
          with:
            name: tarball-${{ github.event.pull_request.head.sha }}
            path: tps-*.tar.gz
@@ -170,11 +170,11 @@ jobs:
      name: CPU release tarball tests
      steps:
        - name: Cancel previous runs
-         uses: styfle/cancel-workflow-action@0.9.0
+         uses: styfle/cancel-workflow-action@0.11.0
          with:
            access_token: ${{ github.token }}     
        - name: Access tarball
-         uses: actions/download-artifact@v2
+         uses: actions/download-artifact@v3
          with:
            name: tarball-${{ github.event.pull_request.head.sha }}
        - name: Expand
@@ -203,11 +203,11 @@ jobs:
        MFEM_DIR: /home/karl/sw/mfem-gpu-4.4
      steps:
        - name: Cancel previous runs
-         uses: styfle/cancel-workflow-action@0.9.0
+         uses: styfle/cancel-workflow-action@0.11.0
          with:
            access_token: ${{ github.token }}    
        - name: Access tarball
-         uses: actions/download-artifact@v2
+         uses: actions/download-artifact@v3
          with:
            name: tarball-${{ github.event.pull_request.head.sha }}
        - name: Expand


### PR DESCRIPTION
Clear some warnings regarding Node.js 12 deprecation.

NB: This does not clear all the warnings.  In particular, one of these warnings says:

```
The `set-output` command is deprecated and will be disabled soon.
Please upgrade to using Environment Files. For more information see:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

We are not using `set-output` directly but via `Ana06/get-changed-files@v2.1.0`.  It appears this action hasn't been patched yet.  For now, I will just wait and hope they handle it soon.