### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/docker-cpu.yaml
+++ b/.github/workflows/docker-cpu.yaml
@@ -17,7 +17,7 @@ jobs:
          with:
            fetch-depth: 0
 #       - uses: jitterbit/get-changed-files@v1
-       - uses: Ana06/get-changed-files@v2.1.0       
+       - uses: Ana06/get-changed-files@v2.2.0       
          id: files
 #         continue-on-error: true
        - name: DockerPATH configuration

--- a/.github/workflows/docker-quartz.yaml
+++ b/.github/workflows/docker-quartz.yaml
@@ -19,7 +19,7 @@ jobs:
        - uses: actions/checkout@v3
          with:
            fetch-depth: 0
-       - uses: Ana06/get-changed-files@v2.1.0       
+       - uses: Ana06/get-changed-files@v2.2.0       
          id: files
        - name: Dockerpath configuration
          run: echo "DOCKERPATH=$DOCKERPATH"

--- a/docker/quartz/Dockerfile
+++ b/docker/quartz/Dockerfile
@@ -109,9 +109,9 @@ RUN ldconfig
 
 # additional packages
 RUN pip3 install numpy
-RUN yum -y install pybind11-devel
-RUN yum -y install python38-devel
 RUN yum -y install perl-Data-Dumper
+
+RUN pip3 install "pybind11[global]"
 
 # load mfem by default
 RUN echo "module try-add metis" >> /etc/profile.d/lmod.sh

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -137,8 +137,6 @@ RUN yum -y install clang-tools-extra
 RUN yum -y install zlib-devel
 RUN yum -y install libcurl-devel
 RUN yum -y install python38-devel
-RUN yum -y install pybind11-devel
-RUN yum -y install python3-pybind11
 RUN yum -y install perl-Data-Dumper
 RUN yum -y install flex
 RUN yum -y install bison
@@ -153,6 +151,8 @@ RUN rm /tmp/doxygen-1.9.5.src.tar.gz
 
 RUN yum -y install graphviz
 RUN pip3 install gcovr
+
+RUN pip3 install "pybind11[global]"
 
 # Register new libs installed into /usr/local/lib with linker
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/class.conf

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -145,6 +145,7 @@ RUN yum -y install bison
 RUN wget https://www.doxygen.nl/files/doxygen-1.9.5.src.tar.gz -P /tmp
 RUN cd /tmp; tar xvf /tmp/doxygen-1.9.5.src.tar.gz
 RUN . /etc/profile.d/lmod.sh \
+    && module load cmake \
     && cd /tmp/doxygen-1.9.5 \
     && cmake -G "Unix Makefiles" && make && make install
 RUN rm /tmp/doxygen-1.9.5.src.tar.gz


### PR DESCRIPTION
This PR updates to Ana06/get-changed-files@v2.2.0, which should clear remaining deprecated warnings in github actions.