### PR TITLE
Modifications to avoid issues reported in #184

### DIFF
--- a/src/radiation.cpp
+++ b/src/radiation.cpp
@@ -32,30 +32,19 @@
 
 #include "radiation.hpp"
 
-using namespace mfem;
-using namespace std;
-
-MFEM_HOST_DEVICE NetEmission::NetEmission(const RadiationInput &inputs) : Radiation() {
+MFEM_HOST_DEVICE NetEmission::NetEmission(const RadiationInput &inputs)
+    : Radiation(), necTable_(LinearTable(inputs.necTableInput)) {
   assert(inputs.model == NET_EMISSION);
-  switch (inputs.necModel) {
-    case TABULATED_NEC: {
-      switch (inputs.necTableInput.order) {
-        case 1: {
-          necTable_ = new LinearTable(inputs.necTableInput);
-        } break;
-        default: {
-          printf("NetEmission: given interpolation order is not supported for TableInterpolator!");
-          assert(false);
-        } break;
-      }
-      break;
-    }
-    default: {
-      printf("NetEmission: given coefficient model is not supported!");
-      assert(false);
-      break;
-    }
-  }
+  assert(inputs.necModel == TABULATED_NEC);
+  assert(inputs.necTableInput.order == 1);
+  // To generalize beyond LinearTable, need to have necTable_ be a
+  // pointer to TableInterpolator and then instantiate the appropriate
+  // class here (e.g., necTable_ = new LinearTable(inputs.necTableInput);).
+  // However, this design causes unexplained problems for the CUDA
+  // version.  See Issue #184.  To avoid this issue, we use the design
+  // here (i.e., necTable_ has type LinearTable).  Since this is the
+  // only option currently supported, this approach is ok.  It will
+  // have to be revisited if other options are added in the future.
 }
 
-MFEM_HOST_DEVICE NetEmission::~NetEmission() { delete necTable_; }
+MFEM_HOST_DEVICE NetEmission::~NetEmission() {}

--- a/src/radiation.hpp
+++ b/src/radiation.hpp
@@ -39,9 +39,6 @@
 #include "table.hpp"
 #include "tps_mfem_wrap.hpp"
 
-using namespace mfem;
-using namespace std;
-
 class Radiation {
  protected:
  public:
@@ -49,11 +46,8 @@ class Radiation {
 
   MFEM_HOST_DEVICE virtual ~Radiation() {}
 
-  // NOTE(kevin): Although this function is clearly overrided and thus must be specified as virtual,
-  //              specifying so causes an nvlink warning for cuda, and a memory fault at runtime.
-  // NOTE(kevin): not sure this is a good naming..
   // Currently has the minimal format required for NEC model.
-  MFEM_HOST_DEVICE double computeEnergySink(const double &T_h) {
+  MFEM_HOST_DEVICE virtual double computeEnergySink(const double &T_h) {
     printf("computeEnergySink not implemented");
     assert(false);
     return 0;
@@ -63,15 +57,16 @@ class Radiation {
 class NetEmission : public Radiation {
  private:
   const double PI_ = PI;
+
   // NOTE(kevin): currently only takes tabulated data.
-  TableInterpolator *necTable_ = NULL;
+  LinearTable necTable_;
 
  public:
   MFEM_HOST_DEVICE NetEmission(const RadiationInput &inputs);
 
-  MFEM_HOST_DEVICE virtual ~NetEmission();
+  MFEM_HOST_DEVICE ~NetEmission();
 
-  MFEM_HOST_DEVICE double computeEnergySink(const double &T_h) { return -4.0 * PI_ * necTable_->eval(T_h); }
+  MFEM_HOST_DEVICE double computeEnergySink(const double &T_h) override { return -4.0 * PI_ * necTable_.eval(T_h); }
 };
 
 #endif  // RADIATION_HPP_


### PR DESCRIPTION
This commit resolves the problems reported in #184.  In particular, we make the computeEnergySink method virtual, which is necessary for the code to work as expected, and eliminate the problems observed in the CUDA branch by changing `necTable_` from `TableInterpolator *` to `LinearTable`.  This also eliminates the `new` in the `NetEmission` ctor, which will be necessary for porting to HIP.

However, the root of the problem described in #184 is still unclear to me, and we will have to revist if we ever want to generalize beyond `LinearTable` here.

Closes #184