### PR TITLE
Unify approach for constructing classes on device

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -910,41 +910,31 @@ M2ulPhyS::~M2ulPhyS() {
 
 #if defined(_CUDA_) || defined(_HIP_)
   gpu::freeDeviceRiemann<<<1, 1>>>(rsolver);
-  gpu::freeDeviceFluxes<<<1, 1>>>(fluxClass);
-
   tpsGpuFree(rsolver);
+
+  gpu::freeDeviceFluxes<<<1, 1>>>(fluxClass);
   tpsGpuFree(fluxClass);
+
+  gpu::freeDeviceChemistry<<<1, 1>>>(chemistry_);
+  tpsGpuFree(chemistry_);
+
+  gpu::freeDeviceRadiation<<<1, 1>>>(radiation_);
+  tpsGpuFree(radiation_);
+
+  gpu::freeDeviceTransport<<<1, 1>>>(transportPtr);
+  tpsGpuFree(transportPtr);
+
+  gpu::freeDeviceMixture<<<1, 1>>>(d_mixture);
+  tpsGpuFree(d_mixture);
 #else
   delete rsolver;
   delete fluxClass;
-#endif
-
-#if defined(_CUDA_) || defined(_HIP_)
-  gpu::freeDeviceChemistry<<<1, 1>>>(chemistry_);
-  tpsGpuFree(chemistry_);
-#else
   delete chemistry_;
-#endif
-
-#if defined(_CUDA_) || defined(_HIP_)
-  gpu::freeDeviceRadiation<<<1, 1>>>(radiation_);
-  tpsGpuFree(radiation_);
-#else
   delete radiation_;
-#endif
-
-#if defined(_CUDA_) || defined(_HIP_)
-  gpu::freeDeviceTransport<<<1, 1>>>(transportPtr);
-  gpu::freeDeviceMixture<<<1, 1>>>(d_mixture);
-#else
   delete transportPtr;
 #endif
-  delete mixture;
 
-#if defined(_CUDA_) || defined(_HIP_)
-  tpsGpuFree(d_mixture);
-  tpsGpuFree(transportPtr);
-#endif
+  delete mixture;
 
   delete gradUpfes;
   delete vfes;

--- a/src/gpu_constructor.cpp
+++ b/src/gpu_constructor.cpp
@@ -37,6 +37,8 @@
 #include "gpu_constructor.hpp"
 
 namespace gpu {
+
+#if defined(_CUDA_) || defined(_HIP_)
 //---------------------------------------------------
 // Constructors first
 //---------------------------------------------------
@@ -98,4 +100,5 @@ __global__ void freeDeviceRadiation(Radiation *radiation) {
   if (radiation != NULL) radiation->~Radiation();
 }
 
+#endif  // cuda or hip
 }  // namespace gpu

--- a/src/gpu_constructor.cpp
+++ b/src/gpu_constructor.cpp
@@ -42,46 +42,30 @@ __global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs
   mix = new (mix) PerfectMixture(inputs, _dim, nvel);
 }
 
+__global__ void instantiateDeviceDryAirTransport(GasMixture *mixture, const double viscosity_multiplier,
+                                                 const double bulk_viscosity, void *transport) {
+  transport = new (transport) DryAirTransport(mixture, viscosity_multiplier, bulk_viscosity);
+}
+
+__global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const constantTransportData inputs,
+                                                   void *trans) {
+  trans = new (trans) ConstantTransport(mixture, inputs);
+}
+__global__ void instantiateDeviceArgonMinimalTransport(GasMixture *mixture, const ArgonTransportInput inputs,
+                                                       void *trans) {
+  trans = new (trans) ArgonMinimalTransport(mixture, inputs);
+}
+__global__ void instantiateDeviceArgonMixtureTransport(GasMixture *mixture, const ArgonTransportInput inputs,
+                                                       void *trans) {
+  trans = new (trans) ArgonMixtureTransport(mixture, inputs);
+}
+
 __global__ void freeDeviceMixture(GasMixture *mix) { mix->~GasMixture(); }
+__global__ void freeDeviceTransport(TransportProperties *transport) { transport->~TransportProperties(); }
 
 #if defined(_CUDA_)
 
 // CUDA supports device new/delete
-// __global__ void instantiateDeviceMixture(const WorkingFluid f, const Equations eq_sys,
-//                                          const double viscosity_multiplier, const double bulk_viscosity, int _dim,
-//                                          int nvel, GasMixture **mix) {
-//  // *mix = new DryAir(f, eq_sys, viscosity_multiplier, bulk_viscosity, _dim, nvel);
-//  *mix = new DryAir(inputs, _dim, nvel);
-//}
-// __global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, GasMixture **mix) {
-//   *mix = new DryAir(inputs, _dim, nvel);
-// }
-
-__global__ void instantiateDeviceDryAirTransport(GasMixture *mixture, const double viscosity_multiplier,
-                                                 const double bulk_viscosity, TransportProperties **trans) {
-  *trans = new DryAirTransport(mixture, viscosity_multiplier, bulk_viscosity);
-}
-
-// __global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel,
-//                                                 GasMixture **mix) {
-//   *mix = new PerfectMixture(inputs, _dim, nvel);
-// }
-
-__global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const constantTransportData inputs,
-                                                   TransportProperties **trans) {
-  *trans = new ConstantTransport(mixture, inputs);
-}
-
-__global__ void instantiateDeviceArgonMinimalTransport(GasMixture *mixture, const ArgonTransportInput inputs,
-                                                       TransportProperties **trans) {
-  *trans = new ArgonMinimalTransport(mixture, inputs);
-}
-
-__global__ void instantiateDeviceArgonMixtureTransport(GasMixture *mixture, const ArgonTransportInput inputs,
-                                                       TransportProperties **trans) {
-  *trans = new ArgonMixtureTransport(mixture, inputs);
-}
-
 __global__ void instantiateDeviceFluxes(GasMixture *_mixture, Equations _eqSystem, TransportProperties *_transport,
                                         const int _num_equation, const int _dim, bool axisym, Fluxes **f) {
   *f = new Fluxes(_mixture, _eqSystem, _transport, _num_equation, _dim, axisym);
@@ -100,45 +84,12 @@ __global__ void instantiateDeviceNetEmission(const RadiationInput inputs, Radiat
   *radiation = new NetEmission(inputs);
 }
 
-//__global__ void freeDeviceMixture(GasMixture *mix) { delete mix; }
-__global__ void freeDeviceTransport(TransportProperties *trans) { delete trans; }
 __global__ void freeDeviceFluxes(Fluxes *f) { delete f; }
 __global__ void freeDeviceRiemann(RiemannSolver *r) { delete r; }
 __global__ void freeDeviceChemistry(Chemistry *chem) { delete chem; }
 __global__ void freeDeviceRadiation(Radiation *radiation) { delete radiation; }
 
 #elif defined(_HIP_)
-
-// __global__ void instantiateDeviceMixture(const WorkingFluid f, const Equations eq_sys,
-//                                          const double viscosity_multiplier, const double bulk_viscosity, int _dim,
-//                                          int nvel, void *mix) {
-//  mix = new (mix) DryAir(inputs, _dim, nvel);
-//}
-// __global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, void *mix) {
-//   mix = new (mix) DryAir(inputs, _dim, nvel);
-// }
-
-__global__ void instantiateDeviceDryAirTransport(GasMixture *mixture, const double viscosity_multiplier,
-                                                 const double bulk_viscosity, void *transport) {
-  transport = new (transport) DryAirTransport(mixture, viscosity_multiplier, bulk_viscosity);
-}
-
-// __global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel, void *mix) {
-//   mix = new (mix) PerfectMixture(inputs, _dim, nvel);
-// }
-
-__global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const constantTransportData inputs,
-                                                   void *trans) {
-  trans = new (trans) ConstantTransport(mixture, inputs);
-}
-__global__ void instantiateDeviceArgonMinimalTransport(GasMixture *mixture, const ArgonTransportInput inputs,
-                                                       void *trans) {
-  trans = new (trans) ArgonMinimalTransport(mixture, inputs);
-}
-__global__ void instantiateDeviceArgonMixtureTransport(GasMixture *mixture, const ArgonTransportInput inputs,
-                                                       void *trans) {
-  trans = new (trans) ArgonMixtureTransport(mixture, inputs);
-}
 
 __global__ void instantiateDeviceFluxes(GasMixture *_mixture, Equations _eqSystem, TransportProperties *_transport,
                                         const int _num_equation, const int _dim, bool axisym, void *f) {
@@ -154,11 +105,7 @@ __global__ void instantiateDeviceChemistry(GasMixture *mixture, const ChemistryI
   chem = new (chem) Chemistry(mixture, inputs);
 }
 
-// __global__ void freeDeviceMixture(GasMixture *mix) {
-//   mix->~GasMixture();
-// }
 // explicit destructor call b/c placement new above
-__global__ void freeDeviceTransport(TransportProperties *transport) { transport->~TransportProperties(); }
 __global__ void freeDeviceFluxes(Fluxes *f) { f->~Fluxes(); }
 __global__ void freeDeviceRiemann(RiemannSolver *r) { r->~RiemannSolver(); }
 __global__ void freeDeviceChemistry(Chemistry *chem) { chem->~Chemistry(); }

--- a/src/gpu_constructor.cpp
+++ b/src/gpu_constructor.cpp
@@ -34,6 +34,16 @@
 
 namespace gpu {
 
+__global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, void *mix) {
+  mix = new (mix) DryAir(inputs, _dim, nvel);
+}
+
+__global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel, void *mix) {
+  mix = new (mix) PerfectMixture(inputs, _dim, nvel);
+}
+
+__global__ void freeDeviceMixture(GasMixture *mix) { mix->~GasMixture(); }
+
 #if defined(_CUDA_)
 
 // CUDA supports device new/delete
@@ -43,19 +53,19 @@ namespace gpu {
 //  // *mix = new DryAir(f, eq_sys, viscosity_multiplier, bulk_viscosity, _dim, nvel);
 //  *mix = new DryAir(inputs, _dim, nvel);
 //}
-__global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, GasMixture **mix) {
-  *mix = new DryAir(inputs, _dim, nvel);
-}
+// __global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, GasMixture **mix) {
+//   *mix = new DryAir(inputs, _dim, nvel);
+// }
 
 __global__ void instantiateDeviceDryAirTransport(GasMixture *mixture, const double viscosity_multiplier,
                                                  const double bulk_viscosity, TransportProperties **trans) {
   *trans = new DryAirTransport(mixture, viscosity_multiplier, bulk_viscosity);
 }
 
-__global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel,
-                                                GasMixture **mix) {
-  *mix = new PerfectMixture(inputs, _dim, nvel);
-}
+// __global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel,
+//                                                 GasMixture **mix) {
+//   *mix = new PerfectMixture(inputs, _dim, nvel);
+// }
 
 __global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const constantTransportData inputs,
                                                    TransportProperties **trans) {
@@ -90,7 +100,7 @@ __global__ void instantiateDeviceNetEmission(const RadiationInput inputs, Radiat
   *radiation = new NetEmission(inputs);
 }
 
-__global__ void freeDeviceMixture(GasMixture *mix) { delete mix; }
+//__global__ void freeDeviceMixture(GasMixture *mix) { delete mix; }
 __global__ void freeDeviceTransport(TransportProperties *trans) { delete trans; }
 __global__ void freeDeviceFluxes(Fluxes *f) { delete f; }
 __global__ void freeDeviceRiemann(RiemannSolver *r) { delete r; }
@@ -104,18 +114,18 @@ __global__ void freeDeviceRadiation(Radiation *radiation) { delete radiation; }
 //                                          int nvel, void *mix) {
 //  mix = new (mix) DryAir(inputs, _dim, nvel);
 //}
-__global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, void *mix) {
-  mix = new (mix) DryAir(inputs, _dim, nvel);
-}
+// __global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, void *mix) {
+//   mix = new (mix) DryAir(inputs, _dim, nvel);
+// }
 
 __global__ void instantiateDeviceDryAirTransport(GasMixture *mixture, const double viscosity_multiplier,
                                                  const double bulk_viscosity, void *transport) {
   transport = new (transport) DryAirTransport(mixture, viscosity_multiplier, bulk_viscosity);
 }
 
-__global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel, void *mix) {
-  mix = new (mix) PerfectMixture(inputs, _dim, nvel);
-}
+// __global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel, void *mix) {
+//   mix = new (mix) PerfectMixture(inputs, _dim, nvel);
+// }
 
 __global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const constantTransportData inputs,
                                                    void *trans) {
@@ -144,9 +154,10 @@ __global__ void instantiateDeviceChemistry(GasMixture *mixture, const ChemistryI
   chem = new (chem) Chemistry(mixture, inputs);
 }
 
-__global__ void freeDeviceMixture(GasMixture *mix) {
-  mix->~GasMixture();
-}  // explicit destructor call b/c placement new above
+// __global__ void freeDeviceMixture(GasMixture *mix) {
+//   mix->~GasMixture();
+// }
+// explicit destructor call b/c placement new above
 __global__ void freeDeviceTransport(TransportProperties *transport) { transport->~TransportProperties(); }
 __global__ void freeDeviceFluxes(Fluxes *f) { f->~Fluxes(); }
 __global__ void freeDeviceRiemann(RiemannSolver *r) { r->~RiemannSolver(); }

--- a/src/gpu_constructor.hpp
+++ b/src/gpu_constructor.hpp
@@ -65,17 +65,34 @@
 #include "transport_properties.hpp"
 #include "utils.hpp"
 
+#if defined(_CUDA_)
+// cuda malloc and free
+#define tpsGpuMalloc(ptr, size) cudaMalloc(ptr, size)
+#define tpsGpuFree(ptr) cudaFree(ptr)
+#elif defined(_HIP)
+// hip malloc and free
+#define tpsGpuMalloc(ptr, size) hipMalloc(ptr, size)
+#define tpsGpuFree(ptr) hipFree(ptr)
+#else
+// these should be unreachable if properly used
+#define tpsGpuMalloc(ptr, size) assert(false)
+#define tpsGpuFree(ptr) assert(false)
+#endif
+
 using namespace mfem;
 using namespace std;
 
 namespace gpu {
+__global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, void *mix);
+__global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel, void *mix);
 
 #if defined(_CUDA_)
 // CUDA supports device new/delete
-__global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, GasMixture **mix);
+//__global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, GasMixture **mix);
 __global__ void instantiateDeviceDryAirTransport(GasMixture *mixture, const double viscosity_multiplier,
                                                  const double bulk_viscosity, TransportProperties **trans);
-__global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel, GasMixture **mix);
+//__global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel, GasMixture
+//**mix);
 __global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const constantTransportData inputs,
                                                    TransportProperties **trans);
 __global__ void instantiateDeviceArgonMinimalTransport(GasMixture *mixture, const ArgonTransportInput inputs,
@@ -104,10 +121,10 @@ __global__ void freeDeviceRadiation(Radiation *radiation);
 // outside of the instantiate functions below with hipMalloc and the
 // use placement new.  Maybe should adopt this approach for CUDA as
 // well, as it seems actually slightly cleaner.
-__global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, void *mix);
+//__global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, void *mix);
 __global__ void instantiateDeviceDryAirTransport(GasMixture *mixture, const double viscosity_multiplier,
                                                  const double bulk_viscosity, void *transport);
-__global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel, void *mix);
+//__global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel, void *mix);
 __global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const constantTransportData inputs,
                                                    void *trans);
 __global__ void instantiateDeviceArgonMinimalTransport(GasMixture *mixture, const ArgonTransportInput inputs,

--- a/src/gpu_constructor.hpp
+++ b/src/gpu_constructor.hpp
@@ -86,19 +86,20 @@ namespace gpu {
 __global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, void *mix);
 __global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel, void *mix);
 
+__global__ void instantiateDeviceDryAirTransport(GasMixture *mixture, const double viscosity_multiplier,
+                                                 const double bulk_viscosity, void *transport);
+__global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const constantTransportData inputs,
+                                                   void *trans);
+__global__ void instantiateDeviceArgonMinimalTransport(GasMixture *mixture, const ArgonTransportInput inputs,
+                                                       void *trans);
+__global__ void instantiateDeviceArgonMixtureTransport(GasMixture *mixture, const ArgonTransportInput inputs,
+                                                       void *trans);
+
+__global__ void freeDeviceMixture(GasMixture *mix);
+__global__ void freeDeviceTransport(TransportProperties *transport);
+
 #if defined(_CUDA_)
 // CUDA supports device new/delete
-//__global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, GasMixture **mix);
-__global__ void instantiateDeviceDryAirTransport(GasMixture *mixture, const double viscosity_multiplier,
-                                                 const double bulk_viscosity, TransportProperties **trans);
-//__global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel, GasMixture
-//**mix);
-__global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const constantTransportData inputs,
-                                                   TransportProperties **trans);
-__global__ void instantiateDeviceArgonMinimalTransport(GasMixture *mixture, const ArgonTransportInput inputs,
-                                                       TransportProperties **trans);
-__global__ void instantiateDeviceArgonMixtureTransport(GasMixture *mixture, const ArgonTransportInput inputs,
-                                                       TransportProperties **trans);
 __global__ void instantiateDeviceFluxes(GasMixture *_mixture, Equations _eqSystem, TransportProperties *_transport,
                                         const int _num_equation, const int _dim, bool axisym, Fluxes **f);
 __global__ void instantiateDeviceRiemann(int _num_equation, GasMixture *_mixture, Equations _eqSystem,
@@ -106,8 +107,6 @@ __global__ void instantiateDeviceRiemann(int _num_equation, GasMixture *_mixture
 __global__ void instantiateDeviceChemistry(GasMixture *mixture, const ChemistryInput inputs, Chemistry **chem);
 __global__ void instantiateDeviceNetEmission(const RadiationInput inputs, Radiation **radiation);
 
-__global__ void freeDeviceMixture(GasMixture *mix);
-__global__ void freeDeviceTransport(TransportProperties *trans);
 __global__ void freeDeviceFluxes(Fluxes *f);
 __global__ void freeDeviceRiemann(RiemannSolver *r);
 __global__ void freeDeviceChemistry(Chemistry *chem);
@@ -121,24 +120,12 @@ __global__ void freeDeviceRadiation(Radiation *radiation);
 // outside of the instantiate functions below with hipMalloc and the
 // use placement new.  Maybe should adopt this approach for CUDA as
 // well, as it seems actually slightly cleaner.
-//__global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, void *mix);
-__global__ void instantiateDeviceDryAirTransport(GasMixture *mixture, const double viscosity_multiplier,
-                                                 const double bulk_viscosity, void *transport);
-//__global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs, int _dim, int nvel, void *mix);
-__global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const constantTransportData inputs,
-                                                   void *trans);
-__global__ void instantiateDeviceArgonMinimalTransport(GasMixture *mixture, const ArgonTransportInput inputs,
-                                                       void *trans);
-__global__ void instantiateDeviceArgonMixtureTransport(GasMixture *mixture, const ArgonTransportInput inputs,
-                                                       void *trans);
 __global__ void instantiateDeviceFluxes(GasMixture *_mixture, Equations _eqSystem, TransportProperties *_transport,
                                         const int _num_equation, const int _dim, bool axisym, void *f);
 __global__ void instantiateDeviceRiemann(int _num_equation, GasMixture *_mixture, Equations _eqSystem,
                                          Fluxes *_fluxClass, bool _useRoe, bool axisym, void *r);
 __global__ void instantiateDeviceChemistry(GasMixture *mixture, const ChemistryInput inputs, void *chem);
 
-__global__ void freeDeviceMixture(GasMixture *mix);
-__global__ void freeDeviceTransport(TransportProperties *transport);
 __global__ void freeDeviceFluxes(Fluxes *f);
 __global__ void freeDeviceRiemann(RiemannSolver *r);
 __global__ void freeDeviceChemistry(Chemistry *chem);

--- a/src/gpu_constructor.hpp
+++ b/src/gpu_constructor.hpp
@@ -86,6 +86,8 @@
 #endif
 
 namespace gpu {
+
+#if defined(_CUDA_) || defined(_HIP_)
 //! Instantiate DryAir object on the device with placement new
 __global__ void instantiateDeviceDryAir(const DryAirInput inputs, int _dim, int nvel, void *mix);
 
@@ -140,6 +142,7 @@ __global__ void freeDeviceChemistry(Chemistry *chem);
 //! Explicit call to Radiation destructor on the device
 __global__ void freeDeviceRadiation(Radiation *radiation);
 
+#endif  // cuda or hip
 }  // namespace gpu
 
 #endif  // GPU_CONSTRUCTOR_HPP_

--- a/src/gpu_constructor.hpp
+++ b/src/gpu_constructor.hpp
@@ -75,7 +75,7 @@
 // cuda malloc and free
 #define tpsGpuMalloc(ptr, size) cudaMalloc(ptr, size)
 #define tpsGpuFree(ptr) cudaFree(ptr)
-#elif defined(_HIP)
+#elif defined(_HIP_)
 // hip malloc and free
 #define tpsGpuMalloc(ptr, size) hipMalloc(ptr, size)
 #define tpsGpuFree(ptr) hipFree(ptr)

--- a/src/gpu_constructor.hpp
+++ b/src/gpu_constructor.hpp
@@ -94,21 +94,20 @@ __global__ void instantiateDeviceArgonMinimalTransport(GasMixture *mixture, cons
                                                        void *trans);
 __global__ void instantiateDeviceArgonMixtureTransport(GasMixture *mixture, const ArgonTransportInput inputs,
                                                        void *trans);
-
+__global__ void instantiateDeviceFluxes(GasMixture *_mixture, Equations _eqSystem, TransportProperties *_transport,
+                                        const int _num_equation, const int _dim, bool axisym, void *f);
+__global__ void instantiateDeviceRiemann(int _num_equation, GasMixture *_mixture, Equations _eqSystem,
+                                         Fluxes *_fluxClass, bool _useRoe, bool axisym, void *r);
 __global__ void freeDeviceMixture(GasMixture *mix);
 __global__ void freeDeviceTransport(TransportProperties *transport);
+__global__ void freeDeviceFluxes(Fluxes *f);
+__global__ void freeDeviceRiemann(RiemannSolver *r);
 
 #if defined(_CUDA_)
 // CUDA supports device new/delete
-__global__ void instantiateDeviceFluxes(GasMixture *_mixture, Equations _eqSystem, TransportProperties *_transport,
-                                        const int _num_equation, const int _dim, bool axisym, Fluxes **f);
-__global__ void instantiateDeviceRiemann(int _num_equation, GasMixture *_mixture, Equations _eqSystem,
-                                         Fluxes *_fluxClass, bool _useRoe, bool axisym, RiemannSolver **r);
 __global__ void instantiateDeviceChemistry(GasMixture *mixture, const ChemistryInput inputs, Chemistry **chem);
 __global__ void instantiateDeviceNetEmission(const RadiationInput inputs, Radiation **radiation);
 
-__global__ void freeDeviceFluxes(Fluxes *f);
-__global__ void freeDeviceRiemann(RiemannSolver *r);
 __global__ void freeDeviceChemistry(Chemistry *chem);
 __global__ void freeDeviceRadiation(Radiation *radiation);
 #elif defined(_HIP_)
@@ -120,14 +119,8 @@ __global__ void freeDeviceRadiation(Radiation *radiation);
 // outside of the instantiate functions below with hipMalloc and the
 // use placement new.  Maybe should adopt this approach for CUDA as
 // well, as it seems actually slightly cleaner.
-__global__ void instantiateDeviceFluxes(GasMixture *_mixture, Equations _eqSystem, TransportProperties *_transport,
-                                        const int _num_equation, const int _dim, bool axisym, void *f);
-__global__ void instantiateDeviceRiemann(int _num_equation, GasMixture *_mixture, Equations _eqSystem,
-                                         Fluxes *_fluxClass, bool _useRoe, bool axisym, void *r);
 __global__ void instantiateDeviceChemistry(GasMixture *mixture, const ChemistryInput inputs, void *chem);
 
-__global__ void freeDeviceFluxes(Fluxes *f);
-__global__ void freeDeviceRiemann(RiemannSolver *r);
 __global__ void freeDeviceChemistry(Chemistry *chem);
 #endif
 

--- a/src/gpu_constructor.hpp
+++ b/src/gpu_constructor.hpp
@@ -98,18 +98,18 @@ __global__ void instantiateDeviceFluxes(GasMixture *_mixture, Equations _eqSyste
                                         const int _num_equation, const int _dim, bool axisym, void *f);
 __global__ void instantiateDeviceRiemann(int _num_equation, GasMixture *_mixture, Equations _eqSystem,
                                          Fluxes *_fluxClass, bool _useRoe, bool axisym, void *r);
+__global__ void instantiateDeviceChemistry(GasMixture *mixture, const ChemistryInput inputs, void *chem);
+__global__ void instantiateDeviceNetEmission(const RadiationInput inputs, void *radiation);
+
 __global__ void freeDeviceMixture(GasMixture *mix);
 __global__ void freeDeviceTransport(TransportProperties *transport);
 __global__ void freeDeviceFluxes(Fluxes *f);
 __global__ void freeDeviceRiemann(RiemannSolver *r);
+__global__ void freeDeviceChemistry(Chemistry *chem);
+__global__ void freeDeviceRadiation(Radiation *radiation);
 
 #if defined(_CUDA_)
 // CUDA supports device new/delete
-__global__ void instantiateDeviceChemistry(GasMixture *mixture, const ChemistryInput inputs, Chemistry **chem);
-__global__ void instantiateDeviceNetEmission(const RadiationInput inputs, Radiation **radiation);
-
-__global__ void freeDeviceChemistry(Chemistry *chem);
-__global__ void freeDeviceRadiation(Radiation *radiation);
 #elif defined(_HIP_)
 // HIP doesn't support device new/delete.  There is
 // (experimental?... requires -D__HIP_ENABLE_DEVICE_MALLOC__) support
@@ -119,9 +119,6 @@ __global__ void freeDeviceRadiation(Radiation *radiation);
 // outside of the instantiate functions below with hipMalloc and the
 // use placement new.  Maybe should adopt this approach for CUDA as
 // well, as it seems actually slightly cleaner.
-__global__ void instantiateDeviceChemistry(GasMixture *mixture, const ChemistryInput inputs, void *chem);
-
-__global__ void freeDeviceChemistry(Chemistry *chem);
 #endif
 
 // NOTE(kevin): Do not use it. For some unknown reason, this wrapper causes a memory issue, at a random place far after


### PR DESCRIPTION
Prior to this PR, `tps` used device-side `new` to instantiate polymorphic classes on the gpu for cuda and placement `new` for hip.  This resulted from the fact that the cuda implementation was done first and then had to be adjusted to hip, which, at least at that time, [did not support device-side new](https://rocmdocs.amd.com/en/latest/FAQ/FAQ_HIP.html#what-is-not-supported).  (NB: It seems that device-side `malloc` [is supported now](https://docs.amd.com/bundle/HIP-Programming-Guide-v5.4/page/Programming_with_HIP.html), although I'm not clear on device-side `new`.)

Regardless, the code has been refactored to unify the cuda and hip approaches.  We take the approach where the host allocates memory on the device using `cudaMalloc` or `hipMalloc` and then placement new is used to construct objects in that memory on the device. 