### PR TITLE
Start to eliminate deprecated code

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,10 +29,10 @@ gcovr-report:
 	    --html-details $(gcovr_dir)/gcovr-report.html
 gcovr-reset:
 	@rm -rf $(gcovr_dir)
-	@rm -f $(find . -name "*.gcda")
+	@find . -name "*.gcda" -exec rm -f {} \;
 
 gcovr-clean: gcovr-reset
-	@rm -f $(find . -name "*.gcno")
+	@find . -name "*.gcno" -exec rm -f {} \;
 
 coverage: gcovr-reset check gcovr-report
 

--- a/configure.ac
+++ b/configure.ac
@@ -231,6 +231,7 @@ AC_PATH_PROG(DOXYGEN, doxygen)
 AC_SUBST(DOXYGEN)
 # -------------------------------------------------------------
 
+
 # -------------------------------------------------------------
 # GSL - look for Gnu Scientific Library
 # -------------------------------------------------------------
@@ -241,6 +242,16 @@ if test x$ENABLE_GSL = xyes; then
    AC_DEFINE([HAVE_GSL])
 fi
 AM_CONDITIONAL(GSL_ENABLED,test x$ENABLE_GSL = xyes)
+
+
+# -------------------------------------------------------------
+# build deprecated capabilities if requested
+# -------------------------------------------------------------
+AH_TEMPLATE([_BUILD_DEPRECATED_], [Build deprecated functionality])
+AC_ARG_ENABLE([build-deprecated],
+         [AS_HELP_STRING([--enable-build-deprecated],[Enable support for deprecated functionality.])],
+	 [AC_DEFINE([_BUILD_DEPRECATED_])],[])
+
 
 dnl --
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -481,6 +481,7 @@ void M2ulPhyS::initVariables() {
 
   alpha = 0.5;
   isSBP = config.isSBP();
+  assert(!isSBP);
 
   // Boundary attributes in present partition
   Array<int> local_attr;
@@ -507,10 +508,12 @@ void M2ulPhyS::initVariables() {
                                         gradUp, gradUpfes, max_char_speed, config.isAxisymmetric());
   }
   A->AddInteriorFaceIntegrator(faceIntegrator);
+#ifdef _BUILD_DEPRECATED_
   if (isSBP) {
     SBPoperator = new SBPintegrator(mixture, fluxClass, intRules, dim, num_equation, alpha);
     A->AddDomainIntegrator(SBPoperator);
   }
+#endif
 
   Aflux = new MixedBilinearForm(dfes, fes);
   domainIntegrator = new DomainIntegrator(fluxClass, intRules, intRuleType, dim, num_equation, config.isAxisymmetric());
@@ -909,7 +912,9 @@ M2ulPhyS::~M2ulPhyS() {
   delete rhsOperator;
   // delete domainIntegrator;
   delete Aflux;  // fails to delete (follow this)
+#ifdef _BUILD_DEPRECATED_
   if (isSBP) delete SBPoperator;
+#endif
   // delete faceIntegrator;
   delete A;  // fails to delete (follow this)
 
@@ -1288,10 +1293,15 @@ void M2ulPhyS::projectInitialSolution() {
 #ifdef HAVE_MASA
     if (config.use_mms_ && config.mmsSaveDetails_) projectExactSolution(0.0, masaU_);
 #endif
+
+#ifdef _BUILD_DEPRECATED_
     if (config.RestartHDFConversion())
       read_restart_files();
     else
       restart_files_hdf5("read");
+#else
+    restart_files_hdf5("read");
+#endif
 
     paraviewColl->SetCycle(iter);
     paraviewColl->SetTime(time);
@@ -1699,6 +1709,7 @@ void M2ulPhyS::initGradUp() {
   }
 }
 
+#ifdef _BUILD_DEPRECATED_
 void M2ulPhyS::write_restart_files() {
   string serialName = "restart_p";
   serialName.append(to_string(order));
@@ -1815,6 +1826,7 @@ void M2ulPhyS::read_restart_files() {
   U->ReadWrite();
   //  if( loadFromAuxSol ) auto dausUp = aux_Up->ReadWrite();
 }
+#endif
 
 void M2ulPhyS::Check_NAN() {
   int local_print = 0;

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -217,7 +217,9 @@ class M2ulPhyS : public TPS::Solver {
   DGNonLinearForm *A;
 
   FaceIntegrator *faceIntegrator;
+#ifdef _BUILD_DEPRECATED_
   SBPintegrator *SBPoperator;
+#endif
 
   MixedBilinearForm *Aflux;
   DomainIntegrator *domainIntegrator;
@@ -324,8 +326,10 @@ class M2ulPhyS : public TPS::Solver {
   void writeHistoryFile();
 
   // i/o routines
+#ifdef _BUILD_DEPRECATED_
   void write_restart_files();
   void read_restart_files();
+#endif
   void read_partitioned_soln_data(hid_t file, string varName, size_t index, double *data);
   void read_serialized_soln_data(hid_t file, string varName, int numDof, int varOffset, double *data, IOFamily &fam);
   void restart_files_hdf5(string mode, string inputFileName = std::string());

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -253,6 +253,7 @@ bool DryAir::StateIsPhysical(const mfem::Vector &state) {
 // Diffusion velocity contributes to the characteristic speed, which mixture cannot handle or know.
 // Compute the maximum characteristic speed.
 double DryAir::ComputeMaxCharSpeed(const Vector &state) {
+#ifdef _BUILD_DEPRECATED_
   const double den = state(0);
   const Vector den_vel(state.GetData() + 1, nvel_);
 
@@ -267,6 +268,9 @@ double DryAir::ComputeMaxCharSpeed(const Vector &state) {
   const double vel = sqrt(den_vel2 / den);
 
   return vel + sound;
+#else
+  return ComputeMaxCharSpeed(state.GetData());
+#endif
 }
 
 MFEM_HOST_DEVICE double DryAir::ComputeMaxCharSpeed(const double *state) const {
@@ -286,6 +290,7 @@ MFEM_HOST_DEVICE double DryAir::ComputeMaxCharSpeed(const double *state) const {
 }
 
 void DryAir::GetConservativesFromPrimitives(const Vector &primit, Vector &conserv) {
+#ifdef _BUILD_DEPRECATED_
   conserv = primit;
 
   double v2 = 0.;
@@ -302,6 +307,9 @@ void DryAir::GetConservativesFromPrimitives(const Vector &primit, Vector &conser
       conserv[nvel_ + 2 + n] *= primit[0];
     }
   }
+#else
+  GetConservativesFromPrimitives(primit.GetData(), conserv.GetData());
+#endif
 }
 
 MFEM_HOST_DEVICE void DryAir::GetConservativesFromPrimitives(const double *primit, double *conserv) {
@@ -324,6 +332,7 @@ MFEM_HOST_DEVICE void DryAir::GetConservativesFromPrimitives(const double *primi
 }
 
 void DryAir::GetPrimitivesFromConservatives(const Vector &conserv, Vector &primit) {
+#ifdef _BUILD_DEPRECATED_
   double T = ComputeTemperature(conserv);
   primit = conserv;
 
@@ -337,6 +346,9 @@ void DryAir::GetPrimitivesFromConservatives(const Vector &conserv, Vector &primi
       primit[nvel_ + 2 + n] /= primit[0];
     }
   }
+#else
+  GetPrimitivesFromConservatives(conserv.GetData(), primit.GetData());
+#endif
 }
 
 MFEM_HOST_DEVICE void DryAir::GetPrimitivesFromConservatives(const double *conserv, double *primit) {

--- a/src/equation_of_state.hpp
+++ b/src/equation_of_state.hpp
@@ -560,12 +560,16 @@ class DryAir : public GasMixture {
 
 // additional functions inlined for speed...
 inline double DryAir::ComputePressure(const Vector &state, double *electronPressure) {
+#ifdef _BUILD_DEPRECATED_
   if (electronPressure != NULL) *electronPressure = 0.0;
   double den_vel2 = 0;
   for (int d = 0; d < nvel_; d++) den_vel2 += state(d + 1) * state(d + 1);
   den_vel2 /= state[0];
 
   return (specific_heat_ratio - 1.0) * (state[1 + nvel_] - 0.5 * den_vel2);
+#else
+  return ComputePressure(state.GetData(), electronPressure);
+#endif
 }
 
 // additional functions inlined for speed...
@@ -579,11 +583,15 @@ MFEM_HOST_DEVICE inline double DryAir::ComputePressure(const double *state, doub
 }
 
 inline double DryAir::ComputeTemperature(const Vector &state) {
+#ifdef _BUILD_DEPRECATED_
   double den_vel2 = 0;
   for (int d = 0; d < nvel_; d++) den_vel2 += state(d + 1) * state(d + 1);
   den_vel2 /= state[0];
 
   return (specific_heat_ratio - 1.0) / gas_constant * (state[1 + nvel_] - 0.5 * den_vel2) / state[0];
+#else
+  return ComputeTemperature(state.GetData());
+#endif
 }
 
 MFEM_HOST_DEVICE inline double DryAir::ComputeTemperature(const double *state) {

--- a/src/face_integrator.cpp
+++ b/src/face_integrator.cpp
@@ -47,12 +47,16 @@ FaceIntegrator::FaceIntegrator(IntegrationRules *_intRules, RiemannSolver *rsolv
       intRules(_intRules),
       useLinear(_useLinear),
       axisymmetric_(axisym) {
+#ifdef _BUILD_DEPRECATED_
   if (useLinear) {
     faceMassMatrix1 = new DenseMatrix[vfes->GetNF() - vfes->GetNBE()];
     faceMassMatrix2 = new DenseMatrix[vfes->GetNF() - vfes->GetNBE()];
     faceMassMatrixComputed = false;
     faceNum = 0;
   }
+#else
+  assert(!useLinear);
+#endif
 
   totDofs = vfes->GetNDofs();
 }
@@ -167,7 +171,11 @@ void FaceIntegrator::AssembleFaceVector(const FiniteElement &el1, const FiniteEl
                                         FaceElementTransformations &Tr, const Vector &elfun, Vector &elvect) {
   if (useLinear) {
     assert(!axisymmetric_);  // axisym not supported in useLinear path
+#ifdef _BUILD_DEPRECATED_
     MassMatrixFaceIntegral(el1, el2, Tr, elfun, elvect);
+#else
+    assert(false);
+#endif
   } else {
     NonLinearFaceIntegration(el1, el2, Tr, elfun, elvect);
   }
@@ -285,6 +293,7 @@ void FaceIntegrator::NonLinearFaceIntegration(const FiniteElement &el1, const Fi
   }
 }
 
+#ifdef _BUILD_DEPRECATED_
 void FaceIntegrator::MassMatrixFaceIntegral(const FiniteElement &el1, const FiniteElement &el2,
                                             FaceElementTransformations &Tr, const Vector &elfun, Vector &elvect) {
   // Compute the term <F.n(u),[w]> on the interior faces.
@@ -430,3 +439,4 @@ void FaceIntegrator::MassMatrixFaceIntegral(const FiniteElement &el1, const Fini
     faceMassMatrixComputed = true;
   }
 }
+#endif

--- a/src/face_integrator.hpp
+++ b/src/face_integrator.hpp
@@ -99,9 +99,10 @@ class FaceIntegrator : public NonlinearFormIntegrator {
 
   void NonLinearFaceIntegration(const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &Tr,
                                 const Vector &elfun, Vector &elvect);
-
+#ifdef _BUILD_DEPRECATED_
   void MassMatrixFaceIntegral(const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &Tr,
                               const Vector &elfun, Vector &elvect);
+#endif
 
  public:
   FaceIntegrator(IntegrationRules *_intRules, RiemannSolver *rsolver_, Fluxes *_fluxClass, ParFiniteElementSpace *_vfes,

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -41,6 +41,7 @@ MFEM_HOST_DEVICE Fluxes::Fluxes(GasMixture *_mixture, Equations _eqSystem, Trans
       axisymmetric_(axisym),
       num_equation(_num_equation) {}
 
+#ifdef _BUILD_DEPRECATED_
 void Fluxes::ComputeTotalFlux(const Vector &state, const DenseMatrix &gradUpi, DenseMatrix &flux) {
   switch (eqSystem) {
     case EULER:
@@ -59,8 +60,10 @@ void Fluxes::ComputeTotalFlux(const Vector &state, const DenseMatrix &gradUpi, D
     } break;
   }
 }
+#endif
 
 void Fluxes::ComputeConvectiveFluxes(const Vector &state, DenseMatrix &flux) {
+#ifdef _BUILD_DEPRECATED_
   double Pe = 0.0;
   const double pres = mixture->ComputePressure(state, &Pe);
   const int numActiveSpecies = mixture->GetNumActiveSpecies();
@@ -89,6 +92,9 @@ void Fluxes::ComputeConvectiveFluxes(const Vector &state, DenseMatrix &flux) {
     for (int d = 0; d < dim; d++) flux(num_equation - 1, d) = electronEnthalpy * state(1 + d);
     // for (int d = 0; d < dim; d++) flux(num_equation - 1, d) = state(num_equation - 1) * state(1 + d) / state(0);
   }
+#else
+  ComputeConvectiveFluxes(state.GetData(), flux.GetData());
+#endif
 }
 
 MFEM_HOST_DEVICE void Fluxes::ComputeConvectiveFluxes(const double *state, double *flux) const {
@@ -130,6 +136,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeConvectiveFluxes(const double *state, doubl
 
 // TODO(kevin): check/complete axisymmetric setting for multi-component flow.
 void Fluxes::ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp, double radius, DenseMatrix &flux) {
+#ifdef _BUILD_DEPRECATED_
   flux = 0.;
   if (eqSystem == EULER) {
     return;
@@ -247,6 +254,9 @@ void Fluxes::ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp
     // however only dim-components are used for flux.
     for (int d = 0; d < dim; d++) flux(nvel + 2 + sp, d) = -state[nvel + 2 + sp] * diffusionVelocity(sp, d);
   }
+#else
+  ComputeViscousFluxes(state.GetData(), gradUp.GetData(), radius, flux.GetData());
+#endif
 }
 
 MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const double *gradUp, double radius,
@@ -624,6 +634,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeBdrViscousFluxes(const double *state, const
   }
 }
 
+#ifdef _BUILD_DEPRECATED_
 void Fluxes::ComputeSplitFlux(const mfem::Vector &state, mfem::DenseMatrix &a_mat, mfem::DenseMatrix &c_mat) {
   const int num_equation = state.Size();
   const int dim = num_equation - 2;
@@ -648,5 +659,6 @@ void Fluxes::ComputeSplitFlux(const mfem::Vector &state, mfem::DenseMatrix &a_ma
     c_mat(num_equation - 1, d) = rhoE /*+p*/;
   }
 }
+#endif
 
 // clang-format on

--- a/src/fluxes.hpp
+++ b/src/fluxes.hpp
@@ -72,7 +72,9 @@ class Fluxes {
 
   Equations GetEquationSystem() { return eqSystem; }
 
+#ifdef _BUILD_DEPRECATED_
   void ComputeTotalFlux(const Vector &state, const DenseMatrix &gradUp, DenseMatrix &flux);
+#endif
 
   void ComputeConvectiveFluxes(const Vector &state, DenseMatrix &flux);
   MFEM_HOST_DEVICE void ComputeConvectiveFluxes(const double *state, double *flux) const;

--- a/src/riemann_solver.cpp
+++ b/src/riemann_solver.cpp
@@ -117,6 +117,7 @@ MFEM_HOST_DEVICE void RiemannSolver::Eval(const double *state1, const double *st
 }
 
 void RiemannSolver::Eval_LF(const Vector &state1, const Vector &state2, const Vector &nor, Vector &flux) {
+#ifdef _BUILD_DEPRECATED_
   // NOTE: nor in general is not a unit normal
   const int dim = nor.Size();
   // const int nvel = (axisymmetric_ ? 3 : dim);
@@ -144,6 +145,9 @@ void RiemannSolver::Eval_LF(const Vector &state1, const Vector &state2, const Ve
   for (int i = 0; i < num_equation; i++) {
     flux(i) = 0.5 * (flux1(i) + flux2(i)) - 0.5 * maxE * (state2(i) - state1(i)) * normag;
   }
+#else
+  Eval_LF(state1.GetData(), state2.GetData(), nor.GetData(), flux.GetData());
+#endif
 }
 
 MFEM_HOST_DEVICE void RiemannSolver::Eval_LF(const double *state1, const double *state2, const double *nor,

--- a/src/run_configuration.cpp
+++ b/src/run_configuration.cpp
@@ -159,6 +159,7 @@ void RunConfiguration::initSpongeData() {
   //   spongeData.szType = SpongeZoneSolution::NONE;
 }
 
+#ifdef _BUILD_DEPRECATED_
 // Note from ks: this method to be deprecated. Superceded by
 // M2ulPhyS::parseSolverOptions2()
 void RunConfiguration::readInputFile(std::string inpuFileName) {
@@ -559,6 +560,7 @@ void RunConfiguration::readInputFile(std::string inpuFileName) {
 
   runFile.close();
 }
+#endif
 
 Array<double> RunConfiguration::GetInletData(int i) {
   int length = 4;

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -258,7 +258,9 @@ class RunConfiguration {
   RunConfiguration();
   ~RunConfiguration();
 
+#ifdef _BUILD_DEPRECATED_
   void readInputFile(std::string inpuFileName);
+#endif
 
   string GetMeshFileName() { return meshFile; }
   string GetOutputName() { return outputFile; }

--- a/src/sbp_integrators.cpp
+++ b/src/sbp_integrators.cpp
@@ -31,6 +31,7 @@
 // -----------------------------------------------------------------------------------el-
 #include "sbp_integrators.hpp"
 
+#ifdef _BUILD_DEPRECATED_
 SBPintegrator::SBPintegrator(GasMixture* _mixture, Fluxes* _fluxClass, IntegrationRules* _intRules, const int _dim,
                              const int _num_equation, double& _alpha)
     : dim(_dim),
@@ -133,3 +134,4 @@ void SBPintegrator::AssembleElementVector(const FiniteElement& el, ElementTransf
     }
   }
 }
+#endif

--- a/src/sbp_integrators.hpp
+++ b/src/sbp_integrators.hpp
@@ -40,6 +40,7 @@
 
 using namespace mfem;
 
+#ifdef _BUILD_DEPRECATED_
 // Volume integrals...DESCRIBE THE OPERATIONS
 class SBPintegrator : public NonlinearFormIntegrator {
  private:
@@ -60,5 +61,6 @@ class SBPintegrator : public NonlinearFormIntegrator {
   virtual void AssembleElementVector(const FiniteElement &el, ElementTransformation &Tr, const Vector &elfun,
                                      Vector &elvect);
 };
+#endif
 
 #endif  // SBP_INTEGRATORS_HPP_

--- a/tps_config.h.in
+++ b/tps_config.h.in
@@ -117,6 +117,9 @@
 /* Version number of package */
 #undef VERSION
 
+/* Build deprecated functionality */
+#undef _BUILD_DEPRECATED_
+
 /* CUDA backend */
 #undef _CUDA_
 


### PR DESCRIPTION
##### Overview
This PR adds a configure flag (`--enable-build-deprecated`, which is off by default) that defines a preprocessor variable (`_BUILD_DEPRECATED_`) which can be used to optionally build code that has been marked as deprecated.  In addition, a few sections have been marked as deprecated.  These are detailed below.

##### Motivation
`tps` has significant chunks of code that do not appear to be used or supported anymore.  Rather than delete these immediately, I prefer to conditionally "delete" them from the build with `#ifdef`.  This enables testing with and without these sections without requiring them to be actually deleted until we are convinced they will never be useful.

##### General Usage
To mark a deprecated section, simply surround it as follows:
```
#ifdef _BUILD_DEPRECATED_
// this code is eliminated from the build
// unless --enable-build-deprecated is passed to configure
#endif
```
In a standard build `_BUILD_DEPRECATED_`  is undefined, so this code is not compiled.  To include it, simply `configure` with `--enable-build-deprecated`.

##### Deprecated Sections
Three types of code section have been marked with `#if _BUILD_DEPRECATED_` in this PR.  These sections are as follows:
* Old read/write functionality, including
  - Read/write for restart files predating the hdf5 restart capability
    - HDF5 restarts were added way back in PR #5.  There aren't any old format restarts around anymore, so no reason to support it.
  - Read of the original input file format
    - The parser was refactored in #88.  We also have a converter utility to map from the old input format to the new, so no reason to continue support for parsing the original format.
* Unused capabilities, including
  - The SBP method
    - To the best of my knowledge, this has never been used and probably does not work.  Seems best to eliminate.
  - The mass-matrix-based approach for the face terms
    - Similarly, not used in practice and never tested.  Don't see a reason to keep.
* Duplicate code
  - Due to the needs of the gpu implementation, we have in places duplicated functions.  This PR reduces this duplication by calling one variant of the function from the other.

Unless someone objects, these sections will be removed in the near future.