### PR TITLE
Power input controls

### DIFF
--- a/src/cycle_avg_joule_coupling.hpp
+++ b/src/cycle_avg_joule_coupling.hpp
@@ -64,8 +64,11 @@ class CycleAvgJouleCoupling : public TPS::Solver {
   int n_em_interp_nodes_;
   int n_flow_interp_nodes_;
 
+  double input_power_;
+
  public:
-  CycleAvgJouleCoupling(MPI_Session &mpi, string &inputFileName, TPS::Tps *tps, int max_out, bool axisym);
+  CycleAvgJouleCoupling(MPI_Session &mpi, string &inputFileName, TPS::Tps *tps, int max_out, bool axisym,
+                        double input_power = -1.);
   ~CycleAvgJouleCoupling();
 
   void initializeInterpolationData();

--- a/src/cycle_avg_joule_coupling.hpp
+++ b/src/cycle_avg_joule_coupling.hpp
@@ -65,10 +65,11 @@ class CycleAvgJouleCoupling : public TPS::Solver {
   int n_flow_interp_nodes_;
 
   double input_power_;
+  double initial_input_power_;
 
  public:
   CycleAvgJouleCoupling(MPI_Session &mpi, string &inputFileName, TPS::Tps *tps, int max_out, bool axisym,
-                        double input_power = -1.);
+                        double input_power = -1., double initial_input_power = -1.);
   ~CycleAvgJouleCoupling();
 
   void initializeInterpolationData();

--- a/src/quasimagnetostatic.hpp
+++ b/src/quasimagnetostatic.hpp
@@ -84,6 +84,8 @@ class QuasiMagnetostaticSolverBase : public TPS::Solver {
 
   virtual double elementJouleHeating(const FiniteElement &el, ElementTransformation &Tr, const Vector &elfun) = 0;
   virtual double totalJouleHeating() = 0;
+
+  void scaleJouleHeating(const double val) { (*joule_heating_) *= val; }
 };
 
 /** Helper class for Joule heating evaluation

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -242,7 +242,9 @@ void Tps::chooseSolver() {
     getInput("solver/axisymmetric", axisym, false);
     double input_power;
     getInput("solver/input-power", input_power, -1.);
-    solver_ = new CycleAvgJouleCoupling(mpi_, iFile_, this, max_out, axisym, input_power);
+    double initial_input_power;
+    getInput("solver/initial-input-power", initial_input_power, input_power);
+    solver_ = new CycleAvgJouleCoupling(mpi_, iFile_, this, max_out, axisym, input_power, initial_input_power);
   } else if (input_solver_type_ == "coupled") {
     isFlowEMCoupledMode_ = true;
     grvy_printf(GRVY_ERROR, "\nSlow your roll.  Solid high-five for whoever implements this coupled solver mode!\n");

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -240,7 +240,9 @@ void Tps::chooseSolver() {
     getRequiredInput("solver/max-outer-iters", max_out);
     bool axisym = false;
     getInput("solver/axisymmetric", axisym, false);
-    solver_ = new CycleAvgJouleCoupling(mpi_, iFile_, this, max_out, axisym);
+    double input_power;
+    getInput("solver/input-power", input_power, -1.);
+    solver_ = new CycleAvgJouleCoupling(mpi_, iFile_, this, max_out, axisym, input_power);
   } else if (input_solver_type_ == "coupled") {
     isFlowEMCoupledMode_ = true;
     grvy_printf(GRVY_ERROR, "\nSlow your roll.  Solid high-five for whoever implements this coupled solver mode!\n");


### PR DESCRIPTION
This PR adds simple logic to control the power deposited in the plasma for a `cycle-avg-joule-coupled` simulation.

Specifically, there are two new input file parameters:
```
solver/input-power
solver/initial-input-power
```
These are only available when `solver/type = cycle-avg-joule-coupled`.  When set, the Joule heating is scaled (uniformly in space) such that the total power deposited in the plasma (`target_power` below) is as follows:
```
delta_power = (input_power_ - initial_input_power_) / max_outer_iters_;
target_power = initial_input_power_ + (outer_iters + 1) * delta_power;
```
This allows the user to linearly ramp between `initial-input-power` and `input-power` over the course of a simulation.  If `input-power` is set but `initial-input-power` is not, then `initial-input-power` is set equal to `input-power` such that the power is simply constant at `input-power`.  If `input-power` is not set then the power level is not controlled.  In that case, the Joule heating is determined by the current, along with the rest of the solution.