### PR TITLE
Clean up precomputed data used in _GPU_ path

### DIFF
--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -40,9 +40,9 @@
 BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes,
                            IntegrationRules *_intRules, RiemannSolver *rsolver_, double &_dt, GasMixture *_mixture,
                            GasMixture *d_mixture, Fluxes *_fluxClass, ParGridFunction *_Up, ParGridFunction *_gradUp,
-                           boundaryFaceIntegrationData &boundary_face_data, const int _dim, const int _num_equation,
-                           double &_max_char_speed, RunConfiguration &_runFile, Array<int> &local_attr,
-                           const int &_maxIntPoints, const int &_maxDofs)
+                           const boundaryFaceIntegrationData &boundary_face_data, const int _dim,
+                           const int _num_equation, double &_max_char_speed, RunConfiguration &_runFile,
+                           Array<int> &local_attr, const int &_maxIntPoints, const int &_maxDofs)
     : groupsMPI(_groupsMPI),
       config(_runFile),
       rsolver(rsolver_),

--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -247,23 +247,24 @@ void BCintegrator::updateBCMean(ParGridFunction *Up) {
   }
 }
 
-void BCintegrator::integrateBCs(Vector &y, const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds) {
+void BCintegrator::integrateBCs(Vector &y, const Vector &x, const Array<int> &elem_dofs_list,
+                                const Array<int> &posDofIds) {
   for (auto bc = inletBCmap.begin(); bc != inletBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
-                              x, nodesIDs, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, maxIntPoints,
-                              maxDofs);
+                              x, elem_dofs_list, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC,
+                              maxIntPoints, maxDofs);
   }
 
   for (auto bc = outletBCmap.begin(); bc != outletBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
-                              x, nodesIDs, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, maxIntPoints,
-                              maxDofs);
+                              x, elem_dofs_list, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC,
+                              maxIntPoints, maxDofs);
   }
 
   for (auto bc = wallBCmap.begin(); bc != wallBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
-                              x, nodesIDs, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, maxIntPoints,
-                              maxDofs);
+                              x, elem_dofs_list, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC,
+                              maxIntPoints, maxDofs);
   }
 }
 

--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -113,7 +113,7 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
 
       wallBCmap[patchType.first] = new WallBC(rsolver, mixture, d_mixture, _runFile.GetEquationSystem(), fluxClass,
                                               vfes, intRules, _dt, dim, num_equation, patchType.first, patchType.second,
-                                              wallData, boundary_face_data_.intPointsElIDBC, _maxIntPoints, config.isAxisymmetric());
+                                              wallData, boundary_face_data_, _maxIntPoints, config.isAxisymmetric());
     }
   }
 

--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -247,23 +247,22 @@ void BCintegrator::updateBCMean(ParGridFunction *Up) {
   }
 }
 
-void BCintegrator::integrateBCs(Vector &y, const Vector &x, const Array<int> &elem_dofs_list,
-                                const Array<int> &posDofIds) {
+void BCintegrator::integrateBCs(Vector &y, const Vector &x,  const elementIndexingData &elem_index_data) {
   for (auto bc = inletBCmap.begin(); bc != inletBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
-                              x, elem_dofs_list, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC,
+                              x, elem_index_data, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC,
                               maxIntPoints, maxDofs);
   }
 
   for (auto bc = outletBCmap.begin(); bc != outletBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
-                              x, elem_dofs_list, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC,
+                              x, elem_index_data, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC,
                               maxIntPoints, maxDofs);
   }
 
   for (auto bc = wallBCmap.begin(); bc != wallBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
-                              x, elem_dofs_list, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC,
+                              x, elem_index_data, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC,
                               maxIntPoints, maxDofs);
   }
 }

--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -40,7 +40,7 @@
 BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes,
                            IntegrationRules *_intRules, RiemannSolver *rsolver_, double &_dt, GasMixture *_mixture,
                            GasMixture *d_mixture, Fluxes *_fluxClass, ParGridFunction *_Up, ParGridFunction *_gradUp,
-                           Vector &_shapesBC, Vector &_normalsWBC, Array<int> &_intPointsElIDBC, const int _dim,
+                           boundaryFaceIntegrationData &boundary_face_data, const int _dim,
                            const int _num_equation, double &_max_char_speed, RunConfiguration &_runFile,
                            Array<int> &local_attr, const int &_maxIntPoints, const int &_maxDofs)
     : groupsMPI(_groupsMPI),
@@ -54,9 +54,7 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
       vfes(_vfes),
       Up(_Up),
       gradUp(_gradUp),
-      shapesBC(_shapesBC),
-      normalsWBC(_normalsWBC),
-      intPointsElIDBC(_intPointsElIDBC),
+      boundary_face_data_(boundary_face_data),
       dim(_dim),
       num_equation(_num_equation),
       maxIntPoints(_maxIntPoints),
@@ -115,7 +113,7 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
 
       wallBCmap[patchType.first] = new WallBC(rsolver, mixture, d_mixture, _runFile.GetEquationSystem(), fluxClass,
                                               vfes, intRules, _dt, dim, num_equation, patchType.first, patchType.second,
-                                              wallData, intPointsElIDBC, _maxIntPoints, config.isAxisymmetric());
+                                              wallData, boundary_face_data_.intPointsElIDBC, _maxIntPoints, config.isAxisymmetric());
     }
   }
 
@@ -250,19 +248,19 @@ void BCintegrator::updateBCMean(ParGridFunction *Up) {
 void BCintegrator::integrateBCs(Vector &y, const Vector &x,  const elementIndexingData &elem_index_data) {
   for (auto bc = inletBCmap.begin(); bc != inletBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
-                              x, elem_index_data, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC,
+                              x, elem_index_data, Up, gradUp, boundary_face_data_,
                               maxIntPoints, maxDofs);
   }
 
   for (auto bc = outletBCmap.begin(); bc != outletBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
-                              x, elem_index_data, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC,
+                              x, elem_index_data, Up, gradUp, boundary_face_data_,
                               maxIntPoints, maxDofs);
   }
 
   for (auto bc = wallBCmap.begin(); bc != wallBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
-                              x, elem_index_data, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC,
+                              x, elem_index_data, Up, gradUp, boundary_face_data_,
                               maxIntPoints, maxDofs);
   }
 }

--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -40,9 +40,9 @@
 BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes,
                            IntegrationRules *_intRules, RiemannSolver *rsolver_, double &_dt, GasMixture *_mixture,
                            GasMixture *d_mixture, Fluxes *_fluxClass, ParGridFunction *_Up, ParGridFunction *_gradUp,
-                           boundaryFaceIntegrationData &boundary_face_data, const int _dim,
-                           const int _num_equation, double &_max_char_speed, RunConfiguration &_runFile,
-                           Array<int> &local_attr, const int &_maxIntPoints, const int &_maxDofs)
+                           boundaryFaceIntegrationData &boundary_face_data, const int _dim, const int _num_equation,
+                           double &_max_char_speed, RunConfiguration &_runFile, Array<int> &local_attr,
+                           const int &_maxIntPoints, const int &_maxDofs)
     : groupsMPI(_groupsMPI),
       config(_runFile),
       rsolver(rsolver_),
@@ -245,23 +245,20 @@ void BCintegrator::updateBCMean(ParGridFunction *Up) {
   }
 }
 
-void BCintegrator::integrateBCs(Vector &y, const Vector &x,  const elementIndexingData &elem_index_data) {
+void BCintegrator::integrateBCs(Vector &y, const Vector &x, const elementIndexingData &elem_index_data) {
   for (auto bc = inletBCmap.begin(); bc != inletBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
-                              x, elem_index_data, Up, gradUp, boundary_face_data_,
-                              maxIntPoints, maxDofs);
+                              x, elem_index_data, Up, gradUp, boundary_face_data_, maxIntPoints, maxDofs);
   }
 
   for (auto bc = outletBCmap.begin(); bc != outletBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
-                              x, elem_index_data, Up, gradUp, boundary_face_data_,
-                              maxIntPoints, maxDofs);
+                              x, elem_index_data, Up, gradUp, boundary_face_data_, maxIntPoints, maxDofs);
   }
 
   for (auto bc = wallBCmap.begin(); bc != wallBCmap.end(); bc++) {
     bc->second->integrationBC(y,  // output
-                              x, elem_index_data, Up, gradUp, boundary_face_data_,
-                              maxIntPoints, maxDofs);
+                              x, elem_index_data, Up, gradUp, boundary_face_data_, maxIntPoints, maxDofs);
   }
 }
 

--- a/src/BCintegrator.hpp
+++ b/src/BCintegrator.hpp
@@ -69,9 +69,7 @@ class BCintegrator : public NonlinearFormIntegrator {
 
   ParGridFunction *gradUp;
 
-  Vector &shapesBC;
-  Vector &normalsWBC;
-  Array<int> &intPointsElIDBC;
+  boundaryFaceIntegrationData &boundary_face_data_;
 
   const int dim;
   const int num_equation;
@@ -90,8 +88,8 @@ class BCintegrator : public NonlinearFormIntegrator {
  public:
   BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules,
                RiemannSolver *rsolver_, double &_dt, GasMixture *mixture, GasMixture *d_mixture, Fluxes *_fluxClass,
-               ParGridFunction *_Up, ParGridFunction *_gradUp, Vector &_shapesBC, Vector &_normalsWBC,
-               Array<int> &_intPointsElIDBC, const int _dim, const int _num_equation, double &_max_char_speed,
+               ParGridFunction *_Up, ParGridFunction *_gradUp, boundaryFaceIntegrationData &boundary_face_data,
+               const int _dim, const int _num_equation, double &_max_char_speed,
                RunConfiguration &_runFile, Array<int> &local_bdr_attr, const int &_maxIntPoints, const int &_maxDofs);
   ~BCintegrator();
 

--- a/src/BCintegrator.hpp
+++ b/src/BCintegrator.hpp
@@ -100,7 +100,7 @@ class BCintegrator : public NonlinearFormIntegrator {
   void initBCs();
 
   void updateBCMean(ParGridFunction *Up);
-  void integrateBCs(Vector &y, const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds);
+  void integrateBCs(Vector &y, const Vector &x, const elementIndexingData &elem_index_data);
 
   // GPU functions
   static void retrieveGradientsData_gpu(ParGridFunction *gradUp, DenseTensor &elGradUp, Array<int> &vdofs,

--- a/src/BCintegrator.hpp
+++ b/src/BCintegrator.hpp
@@ -100,7 +100,7 @@ class BCintegrator : public NonlinearFormIntegrator {
   void initBCs();
 
   void updateBCMean(ParGridFunction *Up);
-  void integrateBCs(Vector &y, const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds);
+  void integrateBCs(Vector &y, const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds);
 
   // GPU functions
   static void retrieveGradientsData_gpu(ParGridFunction *gradUp, DenseTensor &elGradUp, Array<int> &vdofs,

--- a/src/BCintegrator.hpp
+++ b/src/BCintegrator.hpp
@@ -69,7 +69,7 @@ class BCintegrator : public NonlinearFormIntegrator {
 
   ParGridFunction *gradUp;
 
-  boundaryFaceIntegrationData &boundary_face_data_;
+  const boundaryFaceIntegrationData &boundary_face_data_;
 
   const int dim;
   const int num_equation;
@@ -88,7 +88,7 @@ class BCintegrator : public NonlinearFormIntegrator {
  public:
   BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules,
                RiemannSolver *rsolver_, double &_dt, GasMixture *mixture, GasMixture *d_mixture, Fluxes *_fluxClass,
-               ParGridFunction *_Up, ParGridFunction *_gradUp, boundaryFaceIntegrationData &boundary_face_data,
+               ParGridFunction *_Up, ParGridFunction *_gradUp, const boundaryFaceIntegrationData &boundary_face_data,
                const int _dim, const int _num_equation, double &_max_char_speed, RunConfiguration &_runFile,
                Array<int> &local_bdr_attr, const int &_maxIntPoints, const int &_maxDofs);
   ~BCintegrator();

--- a/src/BCintegrator.hpp
+++ b/src/BCintegrator.hpp
@@ -89,8 +89,8 @@ class BCintegrator : public NonlinearFormIntegrator {
   BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules,
                RiemannSolver *rsolver_, double &_dt, GasMixture *mixture, GasMixture *d_mixture, Fluxes *_fluxClass,
                ParGridFunction *_Up, ParGridFunction *_gradUp, boundaryFaceIntegrationData &boundary_face_data,
-               const int _dim, const int _num_equation, double &_max_char_speed,
-               RunConfiguration &_runFile, Array<int> &local_bdr_attr, const int &_maxIntPoints, const int &_maxDofs);
+               const int _dim, const int _num_equation, double &_max_char_speed, RunConfiguration &_runFile,
+               Array<int> &local_bdr_attr, const int &_maxIntPoints, const int &_maxDofs);
   ~BCintegrator();
 
   virtual void AssembleFaceVector(const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &Tr,

--- a/src/BoundaryCondition.hpp
+++ b/src/BoundaryCondition.hpp
@@ -92,9 +92,9 @@ class BoundaryCondition {
 
   virtual void integrationBC(Vector &y,        // output
                              const Vector &x,  // conservative vars (input)
-                             const elementIndexingData &elem_index_data, ParGridFunction *Up,
-                             ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
-                             const int &maxIntPoints, const int &maxDofs) = 0;
+                             const elementIndexingData &elem_index_data, ParGridFunction *Up, ParGridFunction *gradUp,
+                             boundaryFaceIntegrationData &boundary_face_data, const int &maxIntPoints,
+                             const int &maxDofs) = 0;
 
   static void copyValues(const Vector &orig, Vector &target, const double &mult);
 };

--- a/src/BoundaryCondition.hpp
+++ b/src/BoundaryCondition.hpp
@@ -93,7 +93,7 @@ class BoundaryCondition {
   virtual void integrationBC(Vector &y,        // output
                              const Vector &x,  // conservative vars (input)
                              const elementIndexingData &elem_index_data, ParGridFunction *Up, ParGridFunction *gradUp,
-                             boundaryFaceIntegrationData &boundary_face_data, const int &maxIntPoints,
+                             const boundaryFaceIntegrationData &boundary_face_data, const int &maxIntPoints,
                              const int &maxDofs) = 0;
 
   static void copyValues(const Vector &orig, Vector &target, const double &mult);

--- a/src/BoundaryCondition.hpp
+++ b/src/BoundaryCondition.hpp
@@ -93,7 +93,7 @@ class BoundaryCondition {
   virtual void integrationBC(Vector &y,        // output
                              const Vector &x,  // conservative vars (input)
                              const elementIndexingData &elem_index_data, ParGridFunction *Up,
-                             ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
+                             ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
                              const int &maxIntPoints, const int &maxDofs) = 0;
 
   static void copyValues(const Vector &orig, Vector &target, const double &mult);

--- a/src/BoundaryCondition.hpp
+++ b/src/BoundaryCondition.hpp
@@ -92,7 +92,7 @@ class BoundaryCondition {
 
   virtual void integrationBC(Vector &y,        // output
                              const Vector &x,  // conservative vars (input)
-                             const Array<int> &elem_dofs_list, const Array<int> &posDofIds, ParGridFunction *Up,
+                             const elementIndexingData &elem_index_data, ParGridFunction *Up,
                              ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
                              const int &maxIntPoints, const int &maxDofs) = 0;
 

--- a/src/BoundaryCondition.hpp
+++ b/src/BoundaryCondition.hpp
@@ -92,7 +92,7 @@ class BoundaryCondition {
 
   virtual void integrationBC(Vector &y,        // output
                              const Vector &x,  // conservative vars (input)
-                             const Array<int> &nodesIDs, const Array<int> &posDofIds, ParGridFunction *Up,
+                             const Array<int> &elem_dofs_list, const Array<int> &posDofIds, ParGridFunction *Up,
                              ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
                              const int &maxIntPoints, const int &maxDofs) = 0;
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -880,7 +880,7 @@ void M2ulPhyS::initIndirectionArrays() {
   // Shared faces (i.e., interior faces at boundary of decomposition,
   // such that element1 and element2 live on different mpi ranks)
   //-----------------------------------------------------------------
-  sharedFaceIntegrationData &parallelData = gpuArrays.shared_face_data;
+  sharedFaceIntegrationData &shared_face_data = gpuArrays.shared_face_data;
 
   // NB: mesh from above is out of scope
   ParMesh *mesh = fes->GetParMesh();
@@ -892,43 +892,43 @@ void M2ulPhyS::initIndirectionArrays() {
   gradUpfes->ExchangeFaceNbrData();
 
   if (Nshared > 0) {
-    parallelData.elem2_dofs.SetSize(Nshared * num_equation * maxDofs);
-    parallelData.elem2_grad_dofs.SetSize(Nshared * num_equation * maxDofs * dim);
+    shared_face_data.elem2_dofs.SetSize(Nshared * num_equation * maxDofs);
+    shared_face_data.elem2_grad_dofs.SetSize(Nshared * num_equation * maxDofs * dim);
 
-    parallelData.elem2_dofs = 0;
-    parallelData.elem2_grad_dofs = 0;
+    shared_face_data.elem2_dofs = 0;
+    shared_face_data.elem2_grad_dofs = 0;
 
-    auto h_elem2_dofs = parallelData.elem2_dofs.HostReadWrite();
-    auto h_elem2_grad_dofs = parallelData.elem2_grad_dofs.HostReadWrite();
+    auto h_elem2_dofs = shared_face_data.elem2_dofs.HostReadWrite();
+    auto h_elem2_grad_dofs = shared_face_data.elem2_grad_dofs.HostReadWrite();
 
-    parallelData.el1_shape.UseDevice(true);
-    parallelData.el2_shape.UseDevice(true);
-    parallelData.quad_weight.UseDevice(true);
-    parallelData.normal.UseDevice(true);
+    shared_face_data.el1_shape.UseDevice(true);
+    shared_face_data.el2_shape.UseDevice(true);
+    shared_face_data.quad_weight.UseDevice(true);
+    shared_face_data.normal.UseDevice(true);
 
-    parallelData.el1_shape.SetSize(Nshared * maxIntPoints * maxDofs);
-    parallelData.el2_shape.SetSize(Nshared * maxIntPoints * maxDofs);
-    parallelData.quad_weight.SetSize(Nshared * maxIntPoints);
-    parallelData.normal.SetSize(Nshared * maxIntPoints * dim);
-    parallelData.el1.SetSize(Nshared);
-    parallelData.num_quad.SetSize(Nshared);
-    parallelData.num_dof2.SetSize(Nshared);
+    shared_face_data.el1_shape.SetSize(Nshared * maxIntPoints * maxDofs);
+    shared_face_data.el2_shape.SetSize(Nshared * maxIntPoints * maxDofs);
+    shared_face_data.quad_weight.SetSize(Nshared * maxIntPoints);
+    shared_face_data.normal.SetSize(Nshared * maxIntPoints * dim);
+    shared_face_data.el1.SetSize(Nshared);
+    shared_face_data.num_quad.SetSize(Nshared);
+    shared_face_data.num_dof2.SetSize(Nshared);
 
-    parallelData.el1_shape = 0.;
-    parallelData.el2_shape = 0.;
-    parallelData.quad_weight = 0.;
-    parallelData.normal = 0.;
-    parallelData.el1 = 0;
-    parallelData.num_quad = 0;
-    parallelData.num_dof2 = 0;
+    shared_face_data.el1_shape = 0.;
+    shared_face_data.el2_shape = 0.;
+    shared_face_data.quad_weight = 0.;
+    shared_face_data.normal = 0.;
+    shared_face_data.el1 = 0;
+    shared_face_data.num_quad = 0;
+    shared_face_data.num_dof2 = 0;
 
-    auto h_shape1 = parallelData.el1_shape.HostWrite();
-    auto h_shape2 = parallelData.el2_shape.HostWrite();
-    auto h_face_quad_weight = parallelData.quad_weight.HostWrite();
-    auto h_face_normal = parallelData.normal.HostWrite();
-    auto h_face_el1 = parallelData.el1.HostWrite();
-    auto h_face_num_quad = parallelData.num_quad.HostWrite();
-    auto h_face_num_dof2 = parallelData.num_dof2.HostWrite();
+    auto h_shape1 = shared_face_data.el1_shape.HostWrite();
+    auto h_shape2 = shared_face_data.el2_shape.HostWrite();
+    auto h_face_quad_weight = shared_face_data.quad_weight.HostWrite();
+    auto h_face_normal = shared_face_data.normal.HostWrite();
+    auto h_face_el1 = shared_face_data.el1.HostWrite();
+    auto h_face_num_quad = shared_face_data.num_quad.HostWrite();
+    auto h_face_num_dof2 = shared_face_data.num_dof2.HostWrite();
 
     std::vector<int> unicElems;
     unicElems.clear();
@@ -1010,12 +1010,12 @@ void M2ulPhyS::initIndirectionArrays() {
       }
     }
 
-    parallelData.shared_elements_to_shared_faces.SetSize(7 * unicElems.size());
-    parallelData.shared_elements_to_shared_faces = -1;
-    auto h_shared_elements_to_shared_faces = parallelData.shared_elements_to_shared_faces.HostWrite();
+    shared_face_data.shared_elements_to_shared_faces.SetSize(7 * unicElems.size());
+    shared_face_data.shared_elements_to_shared_faces = -1;
+    auto h_shared_elements_to_shared_faces = shared_face_data.shared_elements_to_shared_faces.HostWrite();
     for (size_t el = 0; el < unicElems.size(); el++) {
       const int eli = unicElems[el];
-      for (int f = 0; f < parallelData.el1.Size(); f++) {
+      for (int f = 0; f < shared_face_data.el1.Size(); f++) {
         if (eli == h_face_el1[f]) {
           h_shared_elements_to_shared_faces[0 + 7 * el] = h_face_el1[f];
           int numFace = h_shared_elements_to_shared_faces[1 + 7 * el];

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -779,6 +779,8 @@ void M2ulPhyS::initIndirectionArrays() {
 
   //  BC  integration arrays
   if (fes->GetNBE() > 0) {
+    // This is supposed to be number of boundary faces, and for
+    // non-periodic cases it is.  See #199 for more info.
     const int NumBCelems = fes->GetNBE();
 
     bdry_face_data.face_shape.UseDevice(true);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -603,10 +603,6 @@ void M2ulPhyS::initIndirectionArrays() {
   elementIndexingData &elem_data = gpuArrays.element_indexing_data;
   interiorFaceIntegrationData &face_data = gpuArrays.interior_face_data;
 
-  elem_data.posDofIds.SetSize(2 * vfes->GetNE());
-  elem_data.posDofIds = 0;
-  auto hposDofIds = elem_data.posDofIds.HostWrite();
-
   elem_data.element_dof_offset.SetSize(vfes->GetNE());
   elem_data.element_dof_offset = -1;  // invalid
   auto h_element_dof_offset = elem_data.element_dof_offset.HostWrite();
@@ -622,10 +618,7 @@ void M2ulPhyS::initIndirectionArrays() {
     const int dof = vfes->GetFE(i)->GetDof();
 
     // get the nodes IDs
-    hposDofIds[2 * i] = tempNodes.size();
     h_element_dof_offset[i] = tempNodes.size();
-
-    hposDofIds[2 * i + 1] = dof;
     h_element_dof_number[i] = dof;
 
     Array<int> dofs;
@@ -643,10 +636,10 @@ void M2ulPhyS::initIndirectionArrays() {
   // count number of each type of element
   std::vector<int> tempNumElems;
   tempNumElems.clear();
-  int dof1 = hposDofIds[1];
+  int dof1 = h_element_dof_number[0];
   int typeElems = 0;
-  for (int el = 0; el < elem_data.posDofIds.Size() / 2; el++) {
-    int dofi = hposDofIds[2 * el + 1];
+  for (int el = 0; el < elem_data.element_dof_number.Size(); el++) {
+    int dofi = h_element_dof_number[el];
     if (dofi == dof1) {
       typeElems++;
     } else {

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -653,10 +653,10 @@ void M2ulPhyS::initIndirectionArrays() {
     }
   }
   tempNumElems.push_back(typeElems);
-  elem_data.numElems.SetSize(tempNumElems.size());
-  elem_data.numElems = 0;
-  auto hnumElems = elem_data.numElems.HostWrite();
-  for (int i = 0; i < (int)tempNumElems.size(); i++) hnumElems[i] = tempNumElems[i];
+  elem_data.num_elems_of_type.SetSize(tempNumElems.size());
+  elem_data.num_elems_of_type = 0;
+  auto h_num_elems_of_type = elem_data.num_elems_of_type.HostWrite();
+  for (int i = 0; i < (int)tempNumElems.size(); i++) h_num_elems_of_type[i] = tempNumElems[i];
 
   //-----------------------------------------------------------------
   // Interior faces
@@ -667,9 +667,9 @@ void M2ulPhyS::initIndirectionArrays() {
     //     const int maxIntPoints = 49; // corresponding to square face with p=5
     //     const int maxDofs = 216; //HEX with p=5
 
-    face_data.elemFaces.SetSize(7 * vfes->GetNE());
-    face_data.elemFaces = 0;
-    auto helemFaces = face_data.elemFaces.HostWrite();
+    face_data.element_to_faces.SetSize(7 * vfes->GetNE());
+    face_data.element_to_faces = 0;
+    auto h_element_to_faces = face_data.element_to_faces.HostWrite();
 
     std::vector<double> shapes2, shapes1;
     shapes1.clear();
@@ -716,17 +716,17 @@ void M2ulPhyS::initIndirectionArrays() {
         fes->GetElementVDofs(tr->Elem2No, vdofs2);
 
         {
-          int nf = helemFaces[7 * tr->Elem1No];
+          int nf = h_element_to_faces[7 * tr->Elem1No];
           if (nf < 0) nf = 0;
-          helemFaces[7 * tr->Elem1No + nf + 1] = face;
+          h_element_to_faces[7 * tr->Elem1No + nf + 1] = face;
           nf++;
-          helemFaces[7 * tr->Elem1No] = nf;
+          h_element_to_faces[7 * tr->Elem1No] = nf;
 
-          nf = helemFaces[7 * tr->Elem2No];
+          nf = h_element_to_faces[7 * tr->Elem2No];
           if (nf < 0) nf = 0;
-          helemFaces[7 * tr->Elem2No + nf + 1] = face;
+          h_element_to_faces[7 * tr->Elem2No + nf + 1] = face;
           nf++;
-          helemFaces[7 * tr->Elem2No] = nf;
+          h_element_to_faces[7 * tr->Elem2No] = nf;
         }
 
         const FiniteElement *fe1 = fes->GetFE(tr->Elem1No);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -550,7 +550,7 @@ void M2ulPhyS::initVariables() {
 #else
       gradUpfes,
 #endif
-      intRules, dim, num_equation, gpuArrays, maxIntPoints, maxDofs);
+      intRules, dim, num_equation);
   gradUp_A->AddInteriorFaceIntegrator(new GradFaceIntegrator(intRules, dim, num_equation));
 
   rhsOperator = new RHSoperator(iter, dim, num_equation, order, eqSystem, max_char_speed, intRules, intRuleType,

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1010,19 +1010,19 @@ void M2ulPhyS::initIndirectionArrays() {
       }
     }
 
-    parallelData.sharedElemsFaces.SetSize(7 * unicElems.size());
-    parallelData.sharedElemsFaces = -1;
-    auto hsharedElemsFaces = parallelData.sharedElemsFaces.HostWrite();
+    parallelData.shared_elements_to_shared_faces.SetSize(7 * unicElems.size());
+    parallelData.shared_elements_to_shared_faces = -1;
+    auto h_shared_elements_to_shared_faces = parallelData.shared_elements_to_shared_faces.HostWrite();
     for (size_t el = 0; el < unicElems.size(); el++) {
       const int eli = unicElems[el];
       for (int f = 0; f < parallelData.face_el1.Size(); f++) {
         if (eli == h_face_el1[f]) {
-          hsharedElemsFaces[0 + 7 * el] = h_face_el1[f];
-          int numFace = hsharedElemsFaces[1 + 7 * el];
+          h_shared_elements_to_shared_faces[0 + 7 * el] = h_face_el1[f];
+          int numFace = h_shared_elements_to_shared_faces[1 + 7 * el];
           if (numFace == -1) numFace = 0;
           numFace++;
-          hsharedElemsFaces[1 + numFace + 7 * el] = f;
-          hsharedElemsFaces[1 + 7 * el] = numFace;
+          h_shared_elements_to_shared_faces[1 + numFace + 7 * el] = f;
+          h_shared_elements_to_shared_faces[1 + 7 * el] = numFace;
         }
       }
     }

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -796,9 +796,13 @@ void M2ulPhyS::initIndirectionArrays() {
     bdry_face_data.face_quad_weight = 0.;
     auto h_face_quad_weight = bdry_face_data.face_quad_weight.HostWrite();
 
-    bdry_face_data.intPointsElIDBC.SetSize(NumBCelems * 2);
-    bdry_face_data.intPointsElIDBC = 0;
-    auto hintPointsElIDBC = bdry_face_data.intPointsElIDBC.HostWrite();
+    bdry_face_data.face_el.SetSize(NumBCelems);
+    bdry_face_data.face_el = 0;
+    auto h_face_el = bdry_face_data.face_el.HostWrite();
+
+    bdry_face_data.face_num_quad.SetSize(NumBCelems);
+    bdry_face_data.face_num_quad = 0;
+    auto h_face_num_quad = bdry_face_data.face_num_quad.HostWrite();
 
     const FiniteElement *fe;
     FaceElementTransformations *tr;
@@ -821,8 +825,8 @@ void M2ulPhyS::initIndirectionArrays() {
         }
         const IntegrationRule *ir = &intRules->Get(tr->GetGeometryType(), intorder);
 
-        hintPointsElIDBC[2 * f] = ir->GetNPoints();
-        hintPointsElIDBC[2 * f + 1] = tr->Elem1No;
+        h_face_el[f] = tr->Elem1No;
+        h_face_num_quad[f] = ir->GetNPoints();
 
         for (int q = 0; q < ir->GetNPoints(); q++) {
           const IntegrationPoint &ip = ir->IntPoint(q);
@@ -855,8 +859,11 @@ void M2ulPhyS::initIndirectionArrays() {
     bdry_face_data.face_quad_weight.SetSize(1);
     bdry_face_data.face_quad_weight = 0.;
 
-    bdry_face_data.intPointsElIDBC.SetSize(1);
-    bdry_face_data.intPointsElIDBC = 0.;
+    bdry_face_data.face_el.SetSize(1);
+    bdry_face_data.face_el = -1;
+
+    bdry_face_data.face_num_quad.SetSize(1);
+    bdry_face_data.face_num_quad = 0;
   }
 }
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -490,8 +490,8 @@ void M2ulPhyS::initVariables() {
   bcIntegrator = NULL;
   if (local_attr.Size() > 0) {
     bcIntegrator = new BCintegrator(groupsMPI, mesh, vfes, intRules, rsolver, dt, mixture, d_mixture, fluxClass, Up,
-                                    gradUp, gpuArrays.boundary_face_data, dim, num_equation, max_char_speed,
-                                    config, local_attr, maxIntPoints, maxDofs);
+                                    gradUp, gpuArrays.boundary_face_data, dim, num_equation, max_char_speed, config,
+                                    local_attr, maxIntPoints, maxDofs);
   }
 
   // A->SetAssemblyLevel(AssemblyLevel::PARTIAL);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -892,14 +892,14 @@ void M2ulPhyS::initIndirectionArrays() {
   gradUpfes->ExchangeFaceNbrData();
 
   if (Nshared > 0) {
-    parallelData.sharedVdofs.SetSize(Nshared * num_equation * maxDofs);
-    parallelData.sharedVdofsGradUp.SetSize(Nshared * num_equation * maxDofs * dim);
+    parallelData.elem2_dofs.SetSize(Nshared * num_equation * maxDofs);
+    parallelData.elem2_grad_dofs.SetSize(Nshared * num_equation * maxDofs * dim);
 
-    parallelData.sharedVdofs = 0;
-    parallelData.sharedVdofsGradUp = 0;
+    parallelData.elem2_dofs = 0;
+    parallelData.elem2_grad_dofs = 0;
 
-    auto hsharedVdofs = parallelData.sharedVdofs.HostReadWrite();
-    auto hsharedVdofsGrads = parallelData.sharedVdofsGradUp.HostReadWrite();
+    auto h_elem2_dofs = parallelData.elem2_dofs.HostReadWrite();
+    auto h_elem2_grad_dofs = parallelData.elem2_grad_dofs.HostReadWrite();
 
     parallelData.face_el1_shape.UseDevice(true);
     parallelData.face_el2_shape.UseDevice(true);
@@ -950,10 +950,10 @@ void M2ulPhyS::initIndirectionArrays() {
 
       for (int n = 0; n < dof2; n++) {
         for (int eq = 0; eq < num_equation; eq++) {
-          hsharedVdofs[n + eq * maxDofs + i * num_equation * maxDofs] = vdofs2[n + eq * dof2];
+          h_elem2_dofs[n + eq * maxDofs + i * num_equation * maxDofs] = vdofs2[n + eq * dof2];
           for (int d = 0; d < dim; d++) {
             int index = n + eq * maxDofs + d * num_equation * maxDofs + i * dim * num_equation * maxDofs;
-            hsharedVdofsGrads[index] = vdofsGrad[n + eq * dof2 + d * num_equation * dof2];
+            h_elem2_grad_dofs[index] = vdofsGrad[n + eq * dof2 + d * num_equation * dof2];
           }
         }
       }
@@ -1026,17 +1026,7 @@ void M2ulPhyS::initIndirectionArrays() {
         }
       }
     }
-  } else {
-    parallelData.sharedVdofs.SetSize(1);
-    parallelData.sharedVdofsGradUp.SetSize(1);
-    parallelData.sharedElemsFaces.SetSize(1);
   }
-
-#ifdef _GPU_
-  auto dsharedVdofs = parallelData.sharedVdofs.ReadWrite();
-  auto dsharedVdofsGradUp = parallelData.sharedVdofsGradUp.ReadWrite();
-  auto dsharedElemsFaces = parallelData.sharedElemsFaces.ReadWrite();
-#endif
 }
 
 M2ulPhyS::~M2ulPhyS() {

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -880,7 +880,7 @@ void M2ulPhyS::initIndirectionArrays() {
   // Shared faces (i.e., interior faces at boundary of decomposition,
   // such that element1 and element2 live on different mpi ranks)
   //-----------------------------------------------------------------
-  parallelFacesIntegrationArrays &parallelData = gpuArrays.shared_face_data;
+  sharedFaceIntegrationData &parallelData = gpuArrays.shared_face_data;
 
   // NB: mesh from above is out of scope
   ParMesh *mesh = fes->GetParMesh();

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -681,19 +681,19 @@ void M2ulPhyS::initIndirectionArrays() {
     gpuArrays.face_el1_shape.UseDevice(true);
     gpuArrays.face_el1_shape.SetSize(maxDofs * maxIntPoints * mesh->GetNumFaces());
 
+    gpuArrays.face_el2_shape.UseDevice(true);
+    gpuArrays.face_el2_shape.SetSize(maxDofs * maxIntPoints * mesh->GetNumFaces());
+
     gpuArrays.face_quad_weight.UseDevice(true);
     gpuArrays.face_quad_weight.SetSize(maxIntPoints * mesh->GetNumFaces());
 
     gpuArrays.face_normal.UseDevice(true);
     gpuArrays.face_normal.SetSize(dim * maxIntPoints * mesh->GetNumFaces());
 
-    gpuArrays.shape2.UseDevice(true);
-    gpuArrays.shape2.SetSize(maxDofs * maxIntPoints * mesh->GetNumFaces());
-
     auto hshape1 = gpuArrays.face_el1_shape.HostWrite();
+    auto hshape2 = gpuArrays.face_el2_shape.HostWrite();
     auto hweight = gpuArrays.face_quad_weight.HostWrite();
     auto hnormal = gpuArrays.face_normal.HostWrite();
-    auto hshape2 = gpuArrays.shape2.HostWrite();
 
     for (int face = 0; face < mesh->GetNumFaces(); face++) {
       FaceElementTransformations *tr;
@@ -753,9 +753,12 @@ void M2ulPhyS::initIndirectionArrays() {
           for (int j = 0; j < dof1; j++) {
             hshape1[face * maxDofs * maxIntPoints + k * maxDofs + j] = shape1i[j];
           }
-          for (int j = 0; j < dof2; j++) hshape2[face * maxDofs * maxIntPoints + j + k * maxDofs] = shape2i[j];
+          for (int j = 0; j < dof2; j++) {
+            hshape2[face * maxDofs * maxIntPoints + k * maxDofs + j] = shape2i[j];
+          }
 
           hweight[face * maxIntPoints + k] = ip.weight;
+
           // normals (multiplied by determinant of jacobian
           Vector nor;
           nor.UseDevice(false);
@@ -900,8 +903,6 @@ void M2ulPhyS::initIndirectionArrays() {
 #ifdef _GPU_
   auto dnumElems = gpuArrays.numElems.Read();
   auto dposDofIds = gpuArrays.posDofIds.Read();
-
-  auto dshape2 = gpuArrays.shape2.Read();
 
   auto delemFaces = gpuArrays.elemFaces.Read();
   auto delems12Q = gpuArrays.elems12Q.Read();

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -786,10 +786,15 @@ void M2ulPhyS::initIndirectionArrays() {
     bdry_face_data.face_shape = 0.;
     auto hshapesBC = bdry_face_data.face_shape.HostWrite();
 
-    bdry_face_data.normalsWBC.UseDevice(true);
-    bdry_face_data.normalsWBC.SetSize(NumBCelems * maxIntPoints * (dim + 1));
-    bdry_face_data.normalsWBC = 0.;
-    auto hnormalsWBC = bdry_face_data.normalsWBC.HostWrite();
+    bdry_face_data.face_normal.UseDevice(true);
+    bdry_face_data.face_normal.SetSize(NumBCelems * maxIntPoints * dim);
+    bdry_face_data.face_normal = 0.;
+    auto h_face_normal = bdry_face_data.face_normal.HostWrite();
+
+    bdry_face_data.face_quad_weight.UseDevice(true);
+    bdry_face_data.face_quad_weight.SetSize(NumBCelems * maxIntPoints);
+    bdry_face_data.face_quad_weight = 0.;
+    auto h_face_quad_weight = bdry_face_data.face_quad_weight.HostWrite();
 
     bdry_face_data.intPointsElIDBC.SetSize(NumBCelems * 2);
     bdry_face_data.intPointsElIDBC = 0;
@@ -826,8 +831,11 @@ void M2ulPhyS::initIndirectionArrays() {
           nor.UseDevice(false);
           nor.SetSize(dim);
           CalcOrtho(tr->Jacobian(), nor);
-          hnormalsWBC[dim + q * (dim + 1) + f * maxIntPoints * (dim + 1)] = ip.weight;
-          for (int d = 0; d < dim; d++) hnormalsWBC[d + q * (dim + 1) + f * maxIntPoints * (dim + 1)] = nor[d];
+          h_face_quad_weight[f * maxIntPoints + q] = ip.weight;
+
+          for (int d = 0; d < dim; d++) {
+            h_face_normal[f * maxIntPoints * dim + q * dim + d] = nor[d];
+          }
 
           Vector shape1;
           shape1.UseDevice(false);
@@ -841,8 +849,11 @@ void M2ulPhyS::initIndirectionArrays() {
     bdry_face_data.face_shape.SetSize(1);
     bdry_face_data.face_shape = 0.;
 
-    bdry_face_data.normalsWBC.SetSize(1);
-    bdry_face_data.normalsWBC = 0.;
+    bdry_face_data.face_normal.SetSize(1);
+    bdry_face_data.face_normal = 0.;
+
+    bdry_face_data.face_quad_weight.SetSize(1);
+    bdry_face_data.face_quad_weight = 0.;
 
     bdry_face_data.intPointsElIDBC.SetSize(1);
     bdry_face_data.intPointsElIDBC = 0.;

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -607,13 +607,13 @@ void M2ulPhyS::initIndirectionArrays() {
   //-----------------------------------------------------------------
   // Element data
   //-----------------------------------------------------------------
-  elem_data.element_dof_offset.SetSize(vfes->GetNE());
-  elem_data.element_dof_offset = -1;  // invalid
-  auto h_element_dof_offset = elem_data.element_dof_offset.HostWrite();
+  elem_data.dof_offset.SetSize(vfes->GetNE());
+  elem_data.dof_offset = -1;  // invalid
+  auto h_dof_offset = elem_data.dof_offset.HostWrite();
 
-  elem_data.element_dof_number.SetSize(vfes->GetNE());
-  elem_data.element_dof_number = -1;  // invalid
-  auto h_element_dof_number = elem_data.element_dof_number.HostWrite();
+  elem_data.dof_number.SetSize(vfes->GetNE());
+  elem_data.dof_number = -1;  // invalid
+  auto h_dof_number = elem_data.dof_number.HostWrite();
 
   std::vector<int> tempNodes;
   tempNodes.clear();
@@ -622,28 +622,28 @@ void M2ulPhyS::initIndirectionArrays() {
     const int dof = vfes->GetFE(i)->GetDof();
 
     // get the nodes IDs
-    h_element_dof_offset[i] = tempNodes.size();
-    h_element_dof_number[i] = dof;
+    h_dof_offset[i] = tempNodes.size();
+    h_dof_number[i] = dof;
 
     Array<int> dofs;
     vfes->GetElementVDofs(i, dofs);
     for (int n = 0; n < dof; n++) tempNodes.push_back(dofs[n]);
   }
 
-  elem_data.element_dofs_list.SetSize(tempNodes.size());
-  elem_data.element_dofs_list = 0;
-  auto h_element_dofs_list = elem_data.element_dofs_list.HostWrite();
-  for (int i = 0; i < elem_data.element_dofs_list.Size(); i++) {
-    h_element_dofs_list[i] = tempNodes[i];
+  elem_data.dofs_list.SetSize(tempNodes.size());
+  elem_data.dofs_list = 0;
+  auto h_dofs_list = elem_data.dofs_list.HostWrite();
+  for (int i = 0; i < elem_data.dofs_list.Size(); i++) {
+    h_dofs_list[i] = tempNodes[i];
   }
 
   // count number of each type of element
   std::vector<int> tempNumElems;
   tempNumElems.clear();
-  int dof1 = h_element_dof_number[0];
+  int dof1 = h_dof_number[0];
   int typeElems = 0;
-  for (int el = 0; el < elem_data.element_dof_number.Size(); el++) {
-    int dofi = h_element_dof_number[el];
+  for (int el = 0; el < elem_data.dof_number.Size(); el++) {
+    int dofi = h_dof_number[el];
     if (dofi == dof1) {
       typeElems++;
     } else {
@@ -677,34 +677,34 @@ void M2ulPhyS::initIndirectionArrays() {
 
     Mesh *mesh = vfes->GetMesh();
 
-    face_data.face_el1.SetSize(mesh->GetNumFaces());
-    face_data.face_el1 = 0;
-    auto h_face_el1 = face_data.face_el1.HostWrite();
+    face_data.el1.SetSize(mesh->GetNumFaces());
+    face_data.el1 = 0;
+    auto h_face_el1 = face_data.el1.HostWrite();
 
-    face_data.face_el2.SetSize(mesh->GetNumFaces());
-    face_data.face_el2 = 0;
-    auto h_face_el2 = face_data.face_el2.HostWrite();
+    face_data.el2.SetSize(mesh->GetNumFaces());
+    face_data.el2 = 0;
+    auto h_face_el2 = face_data.el2.HostWrite();
 
-    face_data.face_num_quad.SetSize(mesh->GetNumFaces());
-    face_data.face_num_quad = 0;
-    auto h_face_num_quad = face_data.face_num_quad.HostWrite();
+    face_data.num_quad.SetSize(mesh->GetNumFaces());
+    face_data.num_quad = 0;
+    auto h_face_num_quad = face_data.num_quad.HostWrite();
 
-    face_data.face_el1_shape.UseDevice(true);
-    face_data.face_el1_shape.SetSize(maxDofs * maxIntPoints * mesh->GetNumFaces());
+    face_data.el1_shape.UseDevice(true);
+    face_data.el1_shape.SetSize(maxDofs * maxIntPoints * mesh->GetNumFaces());
 
-    face_data.face_el2_shape.UseDevice(true);
-    face_data.face_el2_shape.SetSize(maxDofs * maxIntPoints * mesh->GetNumFaces());
+    face_data.el2_shape.UseDevice(true);
+    face_data.el2_shape.SetSize(maxDofs * maxIntPoints * mesh->GetNumFaces());
 
-    face_data.face_quad_weight.UseDevice(true);
-    face_data.face_quad_weight.SetSize(maxIntPoints * mesh->GetNumFaces());
+    face_data.quad_weight.UseDevice(true);
+    face_data.quad_weight.SetSize(maxIntPoints * mesh->GetNumFaces());
 
-    face_data.face_normal.UseDevice(true);
-    face_data.face_normal.SetSize(dim * maxIntPoints * mesh->GetNumFaces());
+    face_data.normal.UseDevice(true);
+    face_data.normal.SetSize(dim * maxIntPoints * mesh->GetNumFaces());
 
-    auto hshape1 = face_data.face_el1_shape.HostWrite();
-    auto hshape2 = face_data.face_el2_shape.HostWrite();
-    auto hweight = face_data.face_quad_weight.HostWrite();
-    auto hnormal = face_data.face_normal.HostWrite();
+    auto hshape1 = face_data.el1_shape.HostWrite();
+    auto hshape2 = face_data.el2_shape.HostWrite();
+    auto hweight = face_data.quad_weight.HostWrite();
+    auto hnormal = face_data.normal.HostWrite();
 
     for (int face = 0; face < mesh->GetNumFaces(); face++) {
       FaceElementTransformations *tr;
@@ -791,28 +791,28 @@ void M2ulPhyS::initIndirectionArrays() {
     // non-periodic cases it is.  See #199 for more info.
     const int NumBCelems = fes->GetNBE();
 
-    bdry_face_data.face_shape.UseDevice(true);
-    bdry_face_data.face_shape.SetSize(NumBCelems * maxIntPoints * maxDofs);
-    bdry_face_data.face_shape = 0.;
-    auto hshapesBC = bdry_face_data.face_shape.HostWrite();
+    bdry_face_data.shape.UseDevice(true);
+    bdry_face_data.shape.SetSize(NumBCelems * maxIntPoints * maxDofs);
+    bdry_face_data.shape = 0.;
+    auto hshapesBC = bdry_face_data.shape.HostWrite();
 
-    bdry_face_data.face_normal.UseDevice(true);
-    bdry_face_data.face_normal.SetSize(NumBCelems * maxIntPoints * dim);
-    bdry_face_data.face_normal = 0.;
-    auto h_face_normal = bdry_face_data.face_normal.HostWrite();
+    bdry_face_data.normal.UseDevice(true);
+    bdry_face_data.normal.SetSize(NumBCelems * maxIntPoints * dim);
+    bdry_face_data.normal = 0.;
+    auto h_face_normal = bdry_face_data.normal.HostWrite();
 
-    bdry_face_data.face_quad_weight.UseDevice(true);
-    bdry_face_data.face_quad_weight.SetSize(NumBCelems * maxIntPoints);
-    bdry_face_data.face_quad_weight = 0.;
-    auto h_face_quad_weight = bdry_face_data.face_quad_weight.HostWrite();
+    bdry_face_data.quad_weight.UseDevice(true);
+    bdry_face_data.quad_weight.SetSize(NumBCelems * maxIntPoints);
+    bdry_face_data.quad_weight = 0.;
+    auto h_face_quad_weight = bdry_face_data.quad_weight.HostWrite();
 
-    bdry_face_data.face_el.SetSize(NumBCelems);
-    bdry_face_data.face_el = 0;
-    auto h_face_el = bdry_face_data.face_el.HostWrite();
+    bdry_face_data.el.SetSize(NumBCelems);
+    bdry_face_data.el = 0;
+    auto h_face_el = bdry_face_data.el.HostWrite();
 
-    bdry_face_data.face_num_quad.SetSize(NumBCelems);
-    bdry_face_data.face_num_quad = 0;
-    auto h_face_num_quad = bdry_face_data.face_num_quad.HostWrite();
+    bdry_face_data.num_quad.SetSize(NumBCelems);
+    bdry_face_data.num_quad = 0;
+    auto h_face_num_quad = bdry_face_data.num_quad.HostWrite();
 
     const FiniteElement *fe;
     FaceElementTransformations *tr;
@@ -860,20 +860,20 @@ void M2ulPhyS::initIndirectionArrays() {
       }
     }
   } else {
-    bdry_face_data.face_shape.SetSize(1);
-    bdry_face_data.face_shape = 0.;
+    bdry_face_data.shape.SetSize(1);
+    bdry_face_data.shape = 0.;
 
-    bdry_face_data.face_normal.SetSize(1);
-    bdry_face_data.face_normal = 0.;
+    bdry_face_data.normal.SetSize(1);
+    bdry_face_data.normal = 0.;
 
-    bdry_face_data.face_quad_weight.SetSize(1);
-    bdry_face_data.face_quad_weight = 0.;
+    bdry_face_data.quad_weight.SetSize(1);
+    bdry_face_data.quad_weight = 0.;
 
-    bdry_face_data.face_el.SetSize(1);
-    bdry_face_data.face_el = -1;
+    bdry_face_data.el.SetSize(1);
+    bdry_face_data.el = -1;
 
-    bdry_face_data.face_num_quad.SetSize(1);
-    bdry_face_data.face_num_quad = 0;
+    bdry_face_data.num_quad.SetSize(1);
+    bdry_face_data.num_quad = 0;
   }
 
   //-----------------------------------------------------------------
@@ -901,34 +901,34 @@ void M2ulPhyS::initIndirectionArrays() {
     auto h_elem2_dofs = parallelData.elem2_dofs.HostReadWrite();
     auto h_elem2_grad_dofs = parallelData.elem2_grad_dofs.HostReadWrite();
 
-    parallelData.face_el1_shape.UseDevice(true);
-    parallelData.face_el2_shape.UseDevice(true);
-    parallelData.face_quad_weight.UseDevice(true);
-    parallelData.face_normal.UseDevice(true);
+    parallelData.el1_shape.UseDevice(true);
+    parallelData.el2_shape.UseDevice(true);
+    parallelData.quad_weight.UseDevice(true);
+    parallelData.normal.UseDevice(true);
 
-    parallelData.face_el1_shape.SetSize(Nshared * maxIntPoints * maxDofs);
-    parallelData.face_el2_shape.SetSize(Nshared * maxIntPoints * maxDofs);
-    parallelData.face_quad_weight.SetSize(Nshared * maxIntPoints);
-    parallelData.face_normal.SetSize(Nshared * maxIntPoints * dim);
-    parallelData.face_el1.SetSize(Nshared);
-    parallelData.face_num_quad.SetSize(Nshared);
-    parallelData.face_num_dof2.SetSize(Nshared);
+    parallelData.el1_shape.SetSize(Nshared * maxIntPoints * maxDofs);
+    parallelData.el2_shape.SetSize(Nshared * maxIntPoints * maxDofs);
+    parallelData.quad_weight.SetSize(Nshared * maxIntPoints);
+    parallelData.normal.SetSize(Nshared * maxIntPoints * dim);
+    parallelData.el1.SetSize(Nshared);
+    parallelData.num_quad.SetSize(Nshared);
+    parallelData.num_dof2.SetSize(Nshared);
 
-    parallelData.face_el1_shape = 0.;
-    parallelData.face_el2_shape = 0.;
-    parallelData.face_quad_weight = 0.;
-    parallelData.face_normal = 0.;
-    parallelData.face_el1 = 0;
-    parallelData.face_num_quad = 0;
-    parallelData.face_num_dof2 = 0;
+    parallelData.el1_shape = 0.;
+    parallelData.el2_shape = 0.;
+    parallelData.quad_weight = 0.;
+    parallelData.normal = 0.;
+    parallelData.el1 = 0;
+    parallelData.num_quad = 0;
+    parallelData.num_dof2 = 0;
 
-    auto h_shape1 = parallelData.face_el1_shape.HostWrite();
-    auto h_shape2 = parallelData.face_el2_shape.HostWrite();
-    auto h_face_quad_weight = parallelData.face_quad_weight.HostWrite();
-    auto h_face_normal = parallelData.face_normal.HostWrite();
-    auto h_face_el1 = parallelData.face_el1.HostWrite();
-    auto h_face_num_quad = parallelData.face_num_quad.HostWrite();
-    auto h_face_num_dof2 = parallelData.face_num_dof2.HostWrite();
+    auto h_shape1 = parallelData.el1_shape.HostWrite();
+    auto h_shape2 = parallelData.el2_shape.HostWrite();
+    auto h_face_quad_weight = parallelData.quad_weight.HostWrite();
+    auto h_face_normal = parallelData.normal.HostWrite();
+    auto h_face_el1 = parallelData.el1.HostWrite();
+    auto h_face_num_quad = parallelData.num_quad.HostWrite();
+    auto h_face_num_dof2 = parallelData.num_dof2.HostWrite();
 
     std::vector<int> unicElems;
     unicElems.clear();
@@ -1015,7 +1015,7 @@ void M2ulPhyS::initIndirectionArrays() {
     auto h_shared_elements_to_shared_faces = parallelData.shared_elements_to_shared_faces.HostWrite();
     for (size_t el = 0; el < unicElems.size(); el++) {
       const int eli = unicElems[el];
-      for (int f = 0; f < parallelData.face_el1.Size(); f++) {
+      for (int f = 0; f < parallelData.el1.Size(); f++) {
         if (eli == h_face_el1[f]) {
           h_shared_elements_to_shared_faces[0 + 7 * el] = h_face_el1[f];
           int numFace = h_shared_elements_to_shared_faces[1 + 7 * el];

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -492,14 +492,14 @@ void M2ulPhyS::initVariables() {
   bcIntegrator = NULL;
   if (local_attr.Size() > 0) {
     bcIntegrator = new BCintegrator(groupsMPI, mesh, vfes, intRules, rsolver, dt, mixture, d_mixture, fluxClass, Up,
-                                    gradUp, gpuArrays.boundary_face_data, dim, num_equation, max_char_speed, config,
+                                    gradUp, gpu_precomputed_data_.boundary_face_data, dim, num_equation, max_char_speed, config,
                                     local_attr, maxIntPoints, maxDofs);
   }
 
   // A->SetAssemblyLevel(AssemblyLevel::PARTIAL);
 
   A = new DGNonLinearForm(rsolver, fluxClass, vfes, gradUpfes, gradUp, bcIntegrator, intRules, dim, num_equation,
-                          mixture, gpuArrays, maxIntPoints, maxDofs);
+                          mixture, gpu_precomputed_data_, maxIntPoints, maxDofs);
   if (local_attr.Size() > 0) A->AddBdrFaceIntegrator(bcIntegrator);
 
   {
@@ -556,7 +556,7 @@ void M2ulPhyS::initVariables() {
   gradUp_A->AddInteriorFaceIntegrator(new GradFaceIntegrator(intRules, dim, num_equation));
 
   rhsOperator = new RHSoperator(iter, dim, num_equation, order, eqSystem, max_char_speed, intRules, intRuleType,
-                                fluxClass, mixture, d_mixture, chemistry_, transportPtr, radiation_, vfes, gpuArrays,
+                                fluxClass, mixture, d_mixture, chemistry_, transportPtr, radiation_, vfes, gpu_precomputed_data_,
                                 maxIntPoints, maxDofs, A, Aflux, mesh, spaceVaryViscMult, U, Up, gradUp, gradUpfes,
                                 gradUp_A, bcIntegrator, isSBP, alpha, config, plasma_conductivity_, joule_heating_);
 
@@ -605,7 +605,7 @@ void M2ulPhyS::initIndirectionArrays() {
   //-----------------------------------------------------------------
   // Element data
   //-----------------------------------------------------------------
-  elementIndexingData &elem_data = gpuArrays.element_indexing_data;
+  elementIndexingData &elem_data = gpu_precomputed_data_.element_indexing_data;
 
   elem_data.dof_offset.SetSize(vfes->GetNE());
   elem_data.dof_offset = -1;  // invalid
@@ -661,7 +661,7 @@ void M2ulPhyS::initIndirectionArrays() {
   //-----------------------------------------------------------------
   // Interior faces
   //-----------------------------------------------------------------
-  interiorFaceIntegrationData &face_data = gpuArrays.interior_face_data;
+  interiorFaceIntegrationData &face_data = gpu_precomputed_data_.interior_face_data;
 
   face_data.element_to_faces.SetSize(7 * vfes->GetNE());
   face_data.element_to_faces = 0;
@@ -781,7 +781,7 @@ void M2ulPhyS::initIndirectionArrays() {
   //-----------------------------------------------------------------
   // Boundary faces
   //-----------------------------------------------------------------
-  boundaryFaceIntegrationData &bdry_face_data = gpuArrays.boundary_face_data;
+  boundaryFaceIntegrationData &bdry_face_data = gpu_precomputed_data_.boundary_face_data;
 
   // This is supposed to be number of boundary faces, and for
   // non-periodic cases it is.  See #199 for more info.
@@ -862,7 +862,7 @@ void M2ulPhyS::initIndirectionArrays() {
   // Shared faces (i.e., interior faces at boundary of decomposition,
   // such that element1 and element2 live on different mpi ranks)
   //-----------------------------------------------------------------
-  sharedFaceIntegrationData &shared_face_data = gpuArrays.shared_face_data;
+  sharedFaceIntegrationData &shared_face_data = gpu_precomputed_data_.shared_face_data;
 
   mesh->ExchangeFaceNbrNodes();
   mesh->ExchangeFaceNbrData();

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -674,9 +674,17 @@ void M2ulPhyS::initIndirectionArrays() {
 
     Mesh *mesh = vfes->GetMesh();
 
-    gpuArrays.elems12Q.SetSize(3 * mesh->GetNumFaces());
-    gpuArrays.elems12Q = 0;
-    auto helems12Q = gpuArrays.elems12Q.HostWrite();
+    gpuArrays.face_el1.SetSize(mesh->GetNumFaces());
+    gpuArrays.face_el1 = 0;
+    auto h_face_el1 = gpuArrays.face_el1.HostWrite();
+
+    gpuArrays.face_el2.SetSize(mesh->GetNumFaces());
+    gpuArrays.face_el2 = 0;
+    auto h_face_el2 = gpuArrays.face_el2.HostWrite();
+
+    gpuArrays.face_num_quad.SetSize(mesh->GetNumFaces());
+    gpuArrays.face_num_quad = 0;
+    auto h_face_num_quad = gpuArrays.face_num_quad.HostWrite();
 
     gpuArrays.face_el1_shape.UseDevice(true);
     gpuArrays.face_el1_shape.SetSize(maxDofs * maxIntPoints * mesh->GetNumFaces());
@@ -735,9 +743,9 @@ void M2ulPhyS::initIndirectionArrays() {
         }
         const IntegrationRule *ir = &intRules->Get(tr->GetGeometryType(), intorder);
 
-        helems12Q[3 * face] = tr->Elem1No;
-        helems12Q[3 * face + 1] = tr->Elem2No;
-        helems12Q[3 * face + 2] = ir->GetNPoints();
+        h_face_el1[face] = tr->Elem1No;
+        h_face_el2[face] = tr->Elem2No;
+        h_face_num_quad[face] = ir->GetNPoints();
 
         Vector shape1i, shape2i;
         shape1i.UseDevice(false);
@@ -905,7 +913,6 @@ void M2ulPhyS::initIndirectionArrays() {
   auto dposDofIds = gpuArrays.posDofIds.Read();
 
   auto delemFaces = gpuArrays.elemFaces.Read();
-  auto delems12Q = gpuArrays.elems12Q.Read();
 
   auto dshapesBC = shapesBC.Read();
   auto dnormalsBC = normalsWBC.Read();

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -83,18 +83,6 @@ M2ulPhyS::M2ulPhyS(MPI_Session &_mpi, string &inputFileName, TPS::Tps *tps) : mp
   // set default solver state
   exit_status_ = NORMAL;
 
-  // This example depends on this ordering of the space.
-  // MFEM_ASSERT(fes.GetOrdering() == Ordering::byNODES, "");
-#ifdef _GPU_
-  // write to GPU global memory
-  gradUp->ReadWrite();
-  U->ReadWrite();
-  Up->ReadWrite();
-  auto vgradUp = gradUp->ReadWrite();
-  auto v_U = U->ReadWrite();
-  auto vUp = Up->ReadWrite();
-#endif  // _GPU_
-
   // remove DIE file if present
   if (rank0_) {
     if (file_exists("DIE")) {

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -630,11 +630,6 @@ void M2ulPhyS::initIndirectionArrays() {
     for (int n = 0; n < dof; n++) tempNodes.push_back(dofs[n]);
   }
 
-  gpuArrays.nodesIDs.SetSize(tempNodes.size());
-  gpuArrays.nodesIDs = 0;
-  auto hnodesIDs = gpuArrays.nodesIDs.HostWrite();
-  for (int i = 0; i < gpuArrays.nodesIDs.Size(); i++) hnodesIDs[i] = tempNodes[i];
-
   gpuArrays.element_dofs_list.SetSize(tempNodes.size());
   gpuArrays.element_dofs_list = 0;
   auto h_element_dofs_list = gpuArrays.element_dofs_list.HostWrite();
@@ -893,7 +888,6 @@ void M2ulPhyS::initIndirectionArrays() {
   }
 
 #ifdef _GPU_
-  auto dnodesID = gpuArrays.nodesIDs.Read();
   auto dnumElems = gpuArrays.numElems.Read();
   auto dposDofIds = gpuArrays.posDofIds.Read();
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -781,10 +781,10 @@ void M2ulPhyS::initIndirectionArrays() {
   if (fes->GetNBE() > 0) {
     const int NumBCelems = fes->GetNBE();
 
-    bdry_face_data.shapesBC.UseDevice(true);
-    bdry_face_data.shapesBC.SetSize(NumBCelems * maxIntPoints * maxDofs);
-    bdry_face_data.shapesBC = 0.;
-    auto hshapesBC = bdry_face_data.shapesBC.HostWrite();
+    bdry_face_data.face_shape.UseDevice(true);
+    bdry_face_data.face_shape.SetSize(NumBCelems * maxIntPoints * maxDofs);
+    bdry_face_data.face_shape = 0.;
+    auto hshapesBC = bdry_face_data.face_shape.HostWrite();
 
     bdry_face_data.normalsWBC.UseDevice(true);
     bdry_face_data.normalsWBC.SetSize(NumBCelems * maxIntPoints * (dim + 1));
@@ -838,8 +838,8 @@ void M2ulPhyS::initIndirectionArrays() {
       }
     }
   } else {
-    bdry_face_data.shapesBC.SetSize(1);
-    bdry_face_data.shapesBC = 0.;
+    bdry_face_data.face_shape.SetSize(1);
+    bdry_face_data.face_shape = 0.;
 
     bdry_face_data.normalsWBC.SetSize(1);
     bdry_face_data.normalsWBC = 0.;

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -604,6 +604,14 @@ void M2ulPhyS::initIndirectionArrays() {
   gpuArrays.posDofIds = 0;
   auto hposDofIds = gpuArrays.posDofIds.HostWrite();
 
+  gpuArrays.element_dof_offset.SetSize(vfes->GetNE());
+  gpuArrays.element_dof_offset = -1;  // invalid
+  auto h_element_dof_offset = gpuArrays.element_dof_offset.HostWrite();
+
+  gpuArrays.element_dof_number.SetSize(vfes->GetNE());
+  gpuArrays.element_dof_number = -1;  // invalid
+  auto h_element_dof_number = gpuArrays.element_dof_number.HostWrite();
+
   std::vector<int> tempNodes;
   tempNodes.clear();
 
@@ -612,7 +620,11 @@ void M2ulPhyS::initIndirectionArrays() {
 
     // get the nodes IDs
     hposDofIds[2 * i] = tempNodes.size();
+    h_element_dof_offset[i] = tempNodes.size();
+
     hposDofIds[2 * i + 1] = dof;
+    h_element_dof_number[i] = dof;
+
     Array<int> dofs;
     vfes->GetElementVDofs(i, dofs);
     for (int n = 0; n < dof; n++) tempNodes.push_back(dofs[n]);
@@ -622,6 +634,13 @@ void M2ulPhyS::initIndirectionArrays() {
   gpuArrays.nodesIDs = 0;
   auto hnodesIDs = gpuArrays.nodesIDs.HostWrite();
   for (int i = 0; i < gpuArrays.nodesIDs.Size(); i++) hnodesIDs[i] = tempNodes[i];
+
+  gpuArrays.element_dofs_list.SetSize(tempNodes.size());
+  gpuArrays.element_dofs_list = 0;
+  auto h_element_dofs_list = gpuArrays.element_dofs_list.HostWrite();
+  for (int i = 0; i < gpuArrays.element_dofs_list.Size(); i++) {
+    h_element_dofs_list[i] = tempNodes[i];
+  }
 
   // count number of each type of element
   std::vector<int> tempNumElems;

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -480,8 +480,8 @@ void M2ulPhyS::initVariables() {
   bcIntegrator = NULL;
   if (local_attr.Size() > 0) {
     bcIntegrator = new BCintegrator(groupsMPI, mesh, vfes, intRules, rsolver, dt, mixture, d_mixture, fluxClass, Up,
-                                    gradUp, gpu_precomputed_data_.boundary_face_data, dim, num_equation, max_char_speed, config,
-                                    local_attr, maxIntPoints, maxDofs);
+                                    gradUp, gpu_precomputed_data_.boundary_face_data, dim, num_equation, max_char_speed,
+                                    config, local_attr, maxIntPoints, maxDofs);
   }
 
   // A->SetAssemblyLevel(AssemblyLevel::PARTIAL);
@@ -543,10 +543,11 @@ void M2ulPhyS::initVariables() {
       intRules, dim, num_equation);
   gradUp_A->AddInteriorFaceIntegrator(new GradFaceIntegrator(intRules, dim, num_equation));
 
-  rhsOperator = new RHSoperator(iter, dim, num_equation, order, eqSystem, max_char_speed, intRules, intRuleType,
-                                fluxClass, mixture, d_mixture, chemistry_, transportPtr, radiation_, vfes, gpu_precomputed_data_,
-                                maxIntPoints, maxDofs, A, Aflux, mesh, spaceVaryViscMult, U, Up, gradUp, gradUpfes,
-                                gradUp_A, bcIntegrator, isSBP, alpha, config, plasma_conductivity_, joule_heating_);
+  rhsOperator =
+      new RHSoperator(iter, dim, num_equation, order, eqSystem, max_char_speed, intRules, intRuleType, fluxClass,
+                      mixture, d_mixture, chemistry_, transportPtr, radiation_, vfes, gpu_precomputed_data_,
+                      maxIntPoints, maxDofs, A, Aflux, mesh, spaceVaryViscMult, U, Up, gradUp, gradUpfes, gradUp_A,
+                      bcIntegrator, isSBP, alpha, config, plasma_conductivity_, joule_heating_);
 
   CFL = config.GetCFLNumber();
   rhsOperator->SetTime(time);
@@ -658,8 +659,6 @@ void M2ulPhyS::initIndirectionArrays() {
   std::vector<double> shapes2, shapes1;
   shapes1.clear();
   shapes2.clear();
-
-  //Mesh *mesh = vfes->GetMesh();
 
   face_data.el1.SetSize(mesh->GetNumFaces());
   face_data.el1 = 0;

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -194,7 +194,6 @@ class M2ulPhyS : public TPS::Solver {
 
   precomputedIntegrationData gpuArrays;
 
-
   // The solution u has components {density, x-momentum, y-momentum, energy}.
   // These are stored contiguously in the BlockVector u_block.
   Array<int> *offsets;

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -193,7 +193,7 @@ class M2ulPhyS : public TPS::Solver {
   const int maxDofs = gpudata::MAXDOFS;            // corresponding to HEX with p=5
 
   /// Data required for residual evaluation in _GPU_ path
-  precomputedIntegrationData gpuArrays;
+  precomputedIntegrationData gpu_precomputed_data_;
 
   // The solution u has components {density, x-momentum, y-momentum, energy}.
   // These are stored contiguously in the BlockVector u_block.

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -194,10 +194,6 @@ class M2ulPhyS : public TPS::Solver {
 
   precomputedIntegrationData gpuArrays;
 
-  // BC integration
-  Vector shapesBC;
-  Vector normalsWBC;
-  Array<int> intPointsElIDBC;  // integration points and element ID
 
   // The solution u has components {density, x-momentum, y-momentum, energy}.
   // These are stored contiguously in the BlockVector u_block.

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -192,6 +192,7 @@ class M2ulPhyS : public TPS::Solver {
   const int maxIntPoints = gpudata::MAXINTPOINTS;  // corresponding to HEX face with p=5
   const int maxDofs = gpudata::MAXDOFS;            // corresponding to HEX with p=5
 
+  /// Data required for residual evaluation in _GPU_ path
   precomputedIntegrationData gpuArrays;
 
   // The solution u has components {density, x-momentum, y-momentum, energy}.
@@ -303,6 +304,13 @@ class M2ulPhyS : public TPS::Solver {
 
   void getAttributesInPartition(Array<int> &local_attr);
 
+  /** @brief Fill precomputedIntegrationData struct
+   *
+   *  The _GPU_ path required some quantities (e.g., basis function at
+   *  all face quadrature points) to be evaluated and stored at the
+   *  beginning of a simulation.  These quantities are evaluated by
+   *  this function.
+   */
   void initIndirectionArrays();
 
   void initVariables();

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -192,7 +192,7 @@ class M2ulPhyS : public TPS::Solver {
   const int maxIntPoints = gpudata::MAXINTPOINTS;  // corresponding to HEX face with p=5
   const int maxDofs = gpudata::MAXDOFS;            // corresponding to HEX with p=5
 
-  volumeFaceIntegrationArrays gpuArrays;
+  precomputedIntegrationData gpuArrays;
 
   // BC integration
   Vector shapesBC;

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -307,8 +307,18 @@ struct boundaryFaceIntegrationData {
 };
 
 struct sharedFaceIntegrationData {
-  Vector sharedShapeWnor1;
-  Vector sharedShape2;
+  /** Shape functions for "element 1" evaluated at all shared face quadrature points */
+  Vector face_el1_shape;
+
+  /** Shape functions for "element 2" evaluated at all shared face quadrature points */
+  Vector face_el2_shape;
+
+  /** Weights associated with all shared face quadrature points */
+  Vector face_quad_weight;
+
+  /** Normal vector (oriented from elem 1 toward elem 2) for all shared face quadrature points */
+  Vector face_normal;
+
   Array<int> sharedElem1Dof12Q;
   Array<int> sharedVdofs;
   Array<int> sharedVdofsGradUp;
@@ -326,7 +336,6 @@ struct precomputedIntegrationData {
   boundaryFaceIntegrationData boundary_face_data;
   sharedFaceIntegrationData shared_face_data;
 };
-
 
 struct dataTransferArrays {
   // vectors for data transfer

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -243,12 +243,12 @@ struct elementIndexingData {
   Array<int> num_elems_of_type;
 };
 
-/** @brief Storage for data used in the _GPU_ code path
+/** @brief Data for interior face integral calculations
  *
  * The _GPU_ path requires pre-computation of a number of quantities,
  * such as the values of the shape functions at each quadrature point
- * on each face.  These quantities, which are documented below, are
- * stored in this struct.
+ * on each face.  For the interior faces, these quantities, which are
+ * documented in more detail below, are stored in this struct.
  *
  */
 struct interiorFaceIntegrationData {
@@ -306,6 +306,16 @@ struct boundaryFaceIntegrationData {
   Array<int> face_num_quad;
 };
 
+/** @brief Data for shared face integral calculations
+ *
+ * The _GPU_ path requires pre-computation of a number of quantities,
+ * such as the values of the shape functions at each quadrature point
+ * on each face.  For shared faces (i.e., faces at the domain
+ * decomposition boundaries---interior faces whose elements sit on
+ * different mpi ranks), these quantities, which are documented in
+ * more detail below, are stored in this struct.
+ *
+ */
 struct sharedFaceIntegrationData {
   /** Shape functions for "element 1" evaluated at all shared face quadrature points */
   Vector face_el1_shape;

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -340,8 +340,11 @@ struct sharedFaceIntegrationData {
    */
   Array<int> sharedElemsFaces;
 
-  Array<int> sharedVdofs;
-  Array<int> sharedVdofsGradUp;
+  /** Degrees of freedom indices for element 2 */
+  Array<int> elem2_dofs;
+
+  /** Degrees of freedom indices for the gradient variables for element 2 */
+  Array<int> elem2_grad_dofs;
 };
 
 /** @brief Storage for data used in the _GPU_ code path

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -281,6 +281,13 @@ struct interiorFaceIntegrationData {
   Array<int> face_num_quad;
 };
 
+// BC integration
+struct boundaryFaceIntegrationData {
+  Vector shapesBC;
+  Vector normalsWBC;
+  Array<int> intPointsElIDBC;  // integration points and element ID
+};
+
 /** @brief Storage for data used in the _GPU_ code path
  *
  * The _GPU_ path requires pre-computation of a number of quantities.
@@ -289,6 +296,7 @@ struct interiorFaceIntegrationData {
 struct precomputedIntegrationData {
   elementIndexingData element_indexing_data;
   interiorFaceIntegrationData interior_face_data;
+  boundaryFaceIntegrationData boundary_face_data;
 };
 
 struct parallelFacesIntegrationArrays {

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -214,7 +214,6 @@ struct SpongeZoneData {
  *
  */
 struct volumeFaceIntegrationArrays {
-
   /** Maps element index to position of dofs in nodesIDs and number of dofs
    *  Specifically, for element index i,
    *  posDofIds[2*i] = offset to element i's dofs within nodesIDs
@@ -222,12 +221,37 @@ struct volumeFaceIntegrationArrays {
    */
   Array<int> posDofIds;
 
+  /** Dof array offset for element i
+   *
+   *  To be used with element_dofs_list.  Specifically,
+   *
+   *  element_dofs_list[element_dof_offset[i] + j] = index of jth dof of element i
+   */
+  Array<int> element_dof_offset;
+
+  /** Number of dofs for each element
+   *
+   *  element_dof_number[i] = number of dofs for element i
+   */
+  Array<int> element_dof_number;
+
   /** List of dof indices, ordered by element.  For element i, use
    *  posDofIds to get to correct position inside nodesIDs.
    *  Specifically, nodesIDs[posDofIds[2*i] + j] gives the dof index
    *  for the jth dof for element i.
    */
   Array<int> nodesIDs;
+
+  /** List of dof indices, ordered by element.
+   *
+   *  I.e. [ (dof indices for elem 0), (dof indices for elem 1), ... (dof indices for elem Ne-1) ]
+   *
+   *  Since elements may have different numbers of dofs, use
+   *  element_dof_offset to aid in indexing as follows:
+   *
+   *  element_dofs_list[element_dof_offset[i] + j] = index of jth dof of element i
+   */
+  Array<int> element_dofs_list;
 
   /** Number of elements of each type (e.g, number of tets, number of hexes, etc) */
   Array<int> numElems;

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -249,8 +249,14 @@ struct volumeFaceIntegrationArrays {
   /** Number of elements of each type (e.g, number of tets, number of hexes, etc) */
   Array<int> numElems;
 
-  /** shape functions, weight and normal for each face at each integration point */
-  Vector shapeWnor1;
+  /** Shape functions for "element 1" evaluated at all interior face quadrature points */
+  Vector face_el1_shape;
+
+  /** Weights associated with all interior face quadrature points */
+  Vector face_quad_weight;
+
+  /** Normal vector (oriented from elem 1 toward elem 2) for all interior face quadrature points */
+  Vector face_normal;
 
   /** shape functions for each face at each quadrature point */
   Vector shape2;

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -306,6 +306,15 @@ struct boundaryFaceIntegrationData {
   Array<int> face_num_quad;
 };
 
+struct parallelFacesIntegrationArrays {
+  Vector sharedShapeWnor1;
+  Vector sharedShape2;
+  Array<int> sharedElem1Dof12Q;
+  Array<int> sharedVdofs;
+  Array<int> sharedVdofsGradUp;
+  Array<int> sharedElemsFaces;
+};
+
 /** @brief Storage for data used in the _GPU_ code path
  *
  * The _GPU_ path requires pre-computation of a number of quantities.
@@ -315,16 +324,9 @@ struct precomputedIntegrationData {
   elementIndexingData element_indexing_data;
   interiorFaceIntegrationData interior_face_data;
   boundaryFaceIntegrationData boundary_face_data;
+  parallelFacesIntegrationArrays shared_face_data;
 };
 
-struct parallelFacesIntegrationArrays {
-  Vector sharedShapeWnor1;
-  Vector sharedShape2;
-  Array<int> sharedElem1Dof12Q;
-  Array<int> sharedVdofs;
-  Array<int> sharedVdofsGradUp;
-  Array<int> sharedElemsFaces;
-};
 
 struct dataTransferArrays {
   // vectors for data transfer

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -344,11 +344,12 @@ struct sharedFaceIntegrationData {
    *  shared faces rather than the shared faces themselves.  It
    *  contains the following information:
    *
-   * sharedElemsFaces[7*i] = element number for ith element with shared faces
-   * sharedElemsFaces[7*i + 1] = number of shared faces on ith elem with shared faces
-   * sharedElemsFaces[7*i + 1 + j] = shared face index for the jth shared face on the ith element with shared faces
+   * shared_elements_to_shared_faces[7*i] = element number for ith element with shared faces
+   * shared_elements_to_shared_faces[7*i + 1] = number of shared faces on ith elem with shared faces
+   * shared_elements_to_shared_faces[7*i + 1 + j] = shared face index for the jth shared face on the ith element with
+   * shared faces
    */
-  Array<int> sharedElemsFaces;
+  Array<int> shared_elements_to_shared_faces;
 
   /** Degrees of freedom indices for element 2 */
   Array<int> elem2_dofs;

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -319,7 +319,15 @@ struct sharedFaceIntegrationData {
   /** Normal vector (oriented from elem 1 toward elem 2) for all shared face quadrature points */
   Vector face_normal;
 
-  Array<int> sharedElem1Dof12Q;
+  /** for each shared face, index of element 1 */
+  Array<int> face_el1;
+
+  /** for each shared face, number of dofs for element 2 */
+  Array<int> face_num_quad;
+
+  /** for each shared face, number of quadrature points */
+  Array<int> face_num_dof2;
+
   Array<int> sharedVdofs;
   Array<int> sharedVdofsGradUp;
   Array<int> sharedElemsFaces;

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -281,11 +281,23 @@ struct interiorFaceIntegrationData {
   Array<int> face_num_quad;
 };
 
-// BC integration
+/** @brief Data for boundary face integral calculations
+ *
+ * The _GPU_ path requires pre-computation of a number of quantities,
+ * such as the values of the shape functions at each quadrature point
+ * on each face.  For the boundary faces, these quantities, which are
+ * documented in more detail below, are stored in this struct.
+ *
+ */
 struct boundaryFaceIntegrationData {
+  /** Shape functions evaluated at all boundary face quadrature points */
   Vector face_shape;
-  Vector face_normal;
+
+  /** Weights associated with all boundary face quadrature points */
   Vector face_quad_weight;
+
+  /** Normal vector (outward pointing) for all boundary face quadrature points */
+  Vector face_normal;
 
   /** for each boundary face, index of corresponding element */
   Array<int> face_el;

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -216,28 +216,28 @@ struct SpongeZoneData {
 struct elementIndexingData {
   /** Dof array offset for element i
    *
-   *  To be used with element_dofs_list.  Specifically,
+   *  To be used with dofs_list.  Specifically,
    *
-   *  element_dofs_list[element_dof_offset[i] + j] = index of jth dof of element i
+   *  dofs_list[dof_offset[i] + j] = index of jth dof of element i
    */
-  Array<int> element_dof_offset;
+  Array<int> dof_offset;
 
   /** Number of dofs for each element
    *
-   *  element_dof_number[i] = number of dofs for element i
+   *  dof_number[i] = number of dofs for element i
    */
-  Array<int> element_dof_number;
+  Array<int> dof_number;
 
   /** List of dof indices, ordered by element.
    *
    *  I.e. [ (dof indices for elem 0), (dof indices for elem 1), ... (dof indices for elem Ne-1) ]
    *
    *  Since elements may have different numbers of dofs, use
-   *  element_dof_offset to aid in indexing as follows:
+   *  dof_offset to aid in indexing as follows:
    *
-   *  element_dofs_list[element_dof_offset[i] + j] = index of jth dof of element i
+   *  dofs_list[dof_offset[i] + j] = index of jth dof of element i
    */
-  Array<int> element_dofs_list;
+  Array<int> dofs_list;
 
   /** Number of elements of each type (e.g, number of tets, number of hexes, etc) */
   Array<int> num_elems_of_type;
@@ -253,16 +253,16 @@ struct elementIndexingData {
  */
 struct interiorFaceIntegrationData {
   /** Shape functions for "element 1" evaluated at all interior face quadrature points */
-  Vector face_el1_shape;
+  Vector el1_shape;
 
   /** Shape functions for "element 2" evaluated at all interior face quadrature points */
-  Vector face_el2_shape;
+  Vector el2_shape;
 
   /** Weights associated with all interior face quadrature points */
-  Vector face_quad_weight;
+  Vector quad_weight;
 
   /** Normal vector (oriented from elem 1 toward elem 2) for all interior face quadrature points */
-  Vector face_normal;
+  Vector normal;
 
   /** maps from element index to face indices
    *
@@ -272,13 +272,13 @@ struct interiorFaceIntegrationData {
   Array<int> element_to_faces;
 
   /** for each interior face, index of element 1 */
-  Array<int> face_el1;
+  Array<int> el1;
 
   /** for each interior face, index of element 2 */
-  Array<int> face_el2;
+  Array<int> el2;
 
   /** for each interior face, number of quadrature points */
-  Array<int> face_num_quad;
+  Array<int> num_quad;
 };
 
 /** @brief Data for boundary face integral calculations
@@ -291,19 +291,19 @@ struct interiorFaceIntegrationData {
  */
 struct boundaryFaceIntegrationData {
   /** Shape functions evaluated at all boundary face quadrature points */
-  Vector face_shape;
+  Vector shape;
 
   /** Weights associated with all boundary face quadrature points */
-  Vector face_quad_weight;
+  Vector quad_weight;
 
   /** Normal vector (outward pointing) for all boundary face quadrature points */
-  Vector face_normal;
+  Vector normal;
 
   /** for each boundary face, index of corresponding element */
-  Array<int> face_el;
+  Array<int> el;
 
   /** for each boundary face, number of quadrature points */
-  Array<int> face_num_quad;
+  Array<int> num_quad;
 };
 
 /** @brief Data for shared face integral calculations
@@ -318,25 +318,25 @@ struct boundaryFaceIntegrationData {
  */
 struct sharedFaceIntegrationData {
   /** Shape functions for "element 1" evaluated at all shared face quadrature points */
-  Vector face_el1_shape;
+  Vector el1_shape;
 
   /** Shape functions for "element 2" evaluated at all shared face quadrature points */
-  Vector face_el2_shape;
+  Vector el2_shape;
 
   /** Weights associated with all shared face quadrature points */
-  Vector face_quad_weight;
+  Vector quad_weight;
 
   /** Normal vector (oriented from elem 1 toward elem 2) for all shared face quadrature points */
-  Vector face_normal;
+  Vector normal;
 
   /** for each shared face, index of element 1 */
-  Array<int> face_el1;
+  Array<int> el1;
 
   /** for each shared face, number of dofs for element 2 */
-  Array<int> face_num_quad;
+  Array<int> num_quad;
 
   /** for each shared face, number of quadrature points */
-  Array<int> face_num_dof2;
+  Array<int> num_dof2;
 
   /** @brief Map from shared element index to shared face index(ices)
    *

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -268,13 +268,14 @@ struct volumeFaceIntegrationArrays {
    */
   Array<int> elemFaces;  // number and faces IDs of each element
 
-  /** for each face, element 1, element 2, and number of quadrature points
-   *
-   * elems12Q[3*f + 0] = element 1 index for face f
-   * elems12Q[3*f + 1] = element 2 index for face f
-   * elems12Q[3*f + 2] = number of quadrature points for face f
-   */
-  Array<int> elems12Q;
+  /** for each interior face, index of element 1 */
+  Array<int> face_el1;
+
+  /** for each interior face, index of element 2 */
+  Array<int> face_el2;
+
+  /** for each interior face, number of quadrature points */
+  Array<int> face_num_quad;
 
   // used in gradient computation:
   // gradients of shape functions for all nodes and weight multiplied by det(Jac)

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -328,9 +328,20 @@ struct sharedFaceIntegrationData {
   /** for each shared face, number of quadrature points */
   Array<int> face_num_dof2;
 
+  /** @brief Map from shared element index to shared face index(ices)
+   *
+   *  This mapping makes it possible to loop over the elements with
+   *  shared faces rather than the shared faces themselves.  It
+   *  contains the following information:
+   *
+   * sharedElemsFaces[7*i] = element number for ith element with shared faces
+   * sharedElemsFaces[7*i + 1] = number of shared faces on ith elem with shared faces
+   * sharedElemsFaces[7*i + 1 + j] = shared face index for the jth shared face on the ith element with shared faces
+   */
+  Array<int> sharedElemsFaces;
+
   Array<int> sharedVdofs;
   Array<int> sharedVdofsGradUp;
-  Array<int> sharedElemsFaces;
 };
 
 /** @brief Storage for data used in the _GPU_ code path

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -214,9 +214,9 @@ struct SpongeZoneData {
  *
  */
 struct volumeFaceIntegrationArrays {
-  /** Maps element index to position of dofs in nodesIDs and number of dofs
+  /** Maps element index to position of dofs in element_dofs_list and number of dofs
    *  Specifically, for element index i,
-   *  posDofIds[2*i] = offset to element i's dofs within nodesIDs
+   *  posDofIds[2*i] = offset to element i's dofs within element_dofs_list
    *  posDofIds[2*i+1] = number of dofs for element i
    */
   Array<int> posDofIds;
@@ -234,13 +234,6 @@ struct volumeFaceIntegrationArrays {
    *  element_dof_number[i] = number of dofs for element i
    */
   Array<int> element_dof_number;
-
-  /** List of dof indices, ordered by element.  For element i, use
-   *  posDofIds to get to correct position inside nodesIDs.
-   *  Specifically, nodesIDs[posDofIds[2*i] + j] gives the dof index
-   *  for the jth dof for element i.
-   */
-  Array<int> nodesIDs;
 
   /** List of dof indices, ordered by element.
    *

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -205,15 +205,15 @@ struct SpongeZoneData {
   bool singleTemperature;
 };
 
-/** @brief Storage for data used in the _GPU_ code path
+/** @brief Array providing information about dof indices for elements
  *
- * The _GPU_ path requires pre-computation of a number of quantities,
- * such as the values of the shape functions at each quadrature point
- * on each face.  These quantities, which are documented below, are
- * stored in this struct.
- *
+ * These arrays store information about the degrees of freedom
+ * associated with each element.  They are used in the _GPU_ code path
+ * to provide information that would otherwise (i.e., on the cpu path)
+ * come from, for instance, a FiniteElement or FiniteElementSpace
+ * object.
  */
-struct volumeFaceIntegrationArrays {
+struct elementIndexingData {
   /** Maps element index to position of dofs in element_dofs_list and number of dofs
    *  Specifically, for element index i,
    *  posDofIds[2*i] = offset to element i's dofs within element_dofs_list
@@ -248,7 +248,17 @@ struct volumeFaceIntegrationArrays {
 
   /** Number of elements of each type (e.g, number of tets, number of hexes, etc) */
   Array<int> numElems;
+};
 
+/** @brief Storage for data used in the _GPU_ code path
+ *
+ * The _GPU_ path requires pre-computation of a number of quantities,
+ * such as the values of the shape functions at each quadrature point
+ * on each face.  These quantities, which are documented below, are
+ * stored in this struct.
+ *
+ */
+struct interiorFaceIntegrationData {
   /** Shape functions for "element 1" evaluated at all interior face quadrature points */
   Vector face_el1_shape;
 
@@ -276,6 +286,16 @@ struct volumeFaceIntegrationArrays {
 
   /** for each interior face, number of quadrature points */
   Array<int> face_num_quad;
+};
+
+/** @brief Storage for data used in the _GPU_ code path
+ *
+ * The _GPU_ path requires pre-computation of a number of quantities.
+ * These quantities are stored in this struct.
+ */
+struct precomputedIntegrationData {
+  elementIndexingData element_indexing_data;
+  interiorFaceIntegrationData interior_face_data;
 };
 
 struct parallelFacesIntegrationArrays {

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -252,14 +252,14 @@ struct volumeFaceIntegrationArrays {
   /** Shape functions for "element 1" evaluated at all interior face quadrature points */
   Vector face_el1_shape;
 
+  /** Shape functions for "element 2" evaluated at all interior face quadrature points */
+  Vector face_el2_shape;
+
   /** Weights associated with all interior face quadrature points */
   Vector face_quad_weight;
 
   /** Normal vector (oriented from elem 1 toward elem 2) for all interior face quadrature points */
   Vector face_normal;
-
-  /** shape functions for each face at each quadrature point */
-  Vector shape2;
 
   /** maps from element index to face indices
    *

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -283,7 +283,7 @@ struct interiorFaceIntegrationData {
 
 // BC integration
 struct boundaryFaceIntegrationData {
-  Vector shapesBC;
+  Vector face_shape;
   Vector normalsWBC;
   Array<int> intPointsElIDBC;  // integration points and element ID
 };

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -240,7 +240,7 @@ struct elementIndexingData {
   Array<int> element_dofs_list;
 
   /** Number of elements of each type (e.g, number of tets, number of hexes, etc) */
-  Array<int> numElems;
+  Array<int> num_elems_of_type;
 };
 
 /** @brief Storage for data used in the _GPU_ code path
@@ -269,7 +269,7 @@ struct interiorFaceIntegrationData {
    *  elemFaces[7*i] = number of faces for element i
    *  elemFaces[7*i + 1 + f] = face index for local face f of element i
    */
-  Array<int> elemFaces;  // number and faces IDs of each element
+  Array<int> element_to_faces;
 
   /** for each interior face, index of element 1 */
   Array<int> face_el1;

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -276,12 +276,6 @@ struct volumeFaceIntegrationArrays {
 
   /** for each interior face, number of quadrature points */
   Array<int> face_num_quad;
-
-  // used in gradient computation:
-  // gradients of shape functions for all nodes and weight multiplied by det(Jac)
-  // at each integration point
-  Vector elemShapeDshapeWJ;           // [...l_0(i),...,l_dof(i),l_0_x(i),...,l_dof_d(i), w_i*detJac_i ...]
-  Array<int> elemPosQ_shapeDshapeWJ;  // position and num. of integration points for each element
 };
 
 struct parallelFacesIntegrationArrays {

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -214,13 +214,6 @@ struct SpongeZoneData {
  * object.
  */
 struct elementIndexingData {
-  /** Maps element index to position of dofs in element_dofs_list and number of dofs
-   *  Specifically, for element index i,
-   *  posDofIds[2*i] = offset to element i's dofs within element_dofs_list
-   *  posDofIds[2*i+1] = number of dofs for element i
-   */
-  Array<int> posDofIds;
-
   /** Dof array offset for element i
    *
    *  To be used with element_dofs_list.  Specifically,

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -306,7 +306,7 @@ struct boundaryFaceIntegrationData {
   Array<int> face_num_quad;
 };
 
-struct parallelFacesIntegrationArrays {
+struct sharedFaceIntegrationData {
   Vector sharedShapeWnor1;
   Vector sharedShape2;
   Array<int> sharedElem1Dof12Q;
@@ -324,7 +324,7 @@ struct precomputedIntegrationData {
   elementIndexingData element_indexing_data;
   interiorFaceIntegrationData interior_face_data;
   boundaryFaceIntegrationData boundary_face_data;
-  parallelFacesIntegrationArrays shared_face_data;
+  sharedFaceIntegrationData shared_face_data;
 };
 
 

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -284,7 +284,9 @@ struct interiorFaceIntegrationData {
 // BC integration
 struct boundaryFaceIntegrationData {
   Vector face_shape;
-  Vector normalsWBC;
+  Vector face_normal;
+  Vector face_quad_weight;
+
   Array<int> intPointsElIDBC;  // integration points and element ID
 };
 

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -205,18 +205,53 @@ struct SpongeZoneData {
   bool singleTemperature;
 };
 
+/** @brief Storage for data used in the _GPU_ code path
+ *
+ * The _GPU_ path requires pre-computation of a number of quantities,
+ * such as the values of the shape functions at each quadrature point
+ * on each face.  These quantities, which are documented below, are
+ * stored in this struct.
+ *
+ */
 struct volumeFaceIntegrationArrays {
-  // nodes IDs and indirection array
-  Array<int> nodesIDs;
+
+  /** Maps element index to position of dofs in nodesIDs and number of dofs
+   *  Specifically, for element index i,
+   *  posDofIds[2*i] = offset to element i's dofs within nodesIDs
+   *  posDofIds[2*i+1] = number of dofs for element i
+   */
   Array<int> posDofIds;
-  // count of number of elements of each type
+
+  /** List of dof indices, ordered by element.  For element i, use
+   *  posDofIds to get to correct position inside nodesIDs.
+   *  Specifically, nodesIDs[posDofIds[2*i] + j] gives the dof index
+   *  for the jth dof for element i.
+   */
+  Array<int> nodesIDs;
+
+  /** Number of elements of each type (e.g, number of tets, number of hexes, etc) */
   Array<int> numElems;
-  // Array<int> posDofQshape1; // position, num. dof and integration points for each face
-  Vector shapeWnor1;  // shape functions, weight and normal for each face at ach integration point
+
+  /** shape functions, weight and normal for each face at each integration point */
+  Vector shapeWnor1;
+
+  /** shape functions for each face at each quadrature point */
   Vector shape2;
 
+  /** maps from element index to face indices
+   *
+   *  elemFaces[7*i] = number of faces for element i
+   *  elemFaces[7*i + 1 + f] = face index for local face f of element i
+   */
   Array<int> elemFaces;  // number and faces IDs of each element
-  Array<int> elems12Q;   // elements connecting a face and integration points
+
+  /** for each face, element 1, element 2, and number of quadrature points
+   *
+   * elems12Q[3*f + 0] = element 1 index for face f
+   * elems12Q[3*f + 1] = element 2 index for face f
+   * elems12Q[3*f + 2] = number of quadrature points for face f
+   */
+  Array<int> elems12Q;
 
   // used in gradient computation:
   // gradients of shape functions for all nodes and weight multiplied by det(Jac)

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -287,7 +287,11 @@ struct boundaryFaceIntegrationData {
   Vector face_normal;
   Vector face_quad_weight;
 
-  Array<int> intPointsElIDBC;  // integration points and element ID
+  /** for each boundary face, index of corresponding element */
+  Array<int> face_el;
+
+  /** for each boundary face, number of quadrature points */
+  Array<int> face_num_quad;
 };
 
 /** @brief Storage for data used in the _GPU_ code path

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -638,8 +638,8 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
   const double *d_shape2 = parallelData.face_el2_shape.Read();
   const int *d_face_num_quad = parallelData.face_num_quad.Read();
   const int *d_face_num_dof2 = parallelData.face_num_dof2.Read();
-  const int *d_sharedVdofs = parallelData.sharedVdofs.Read();
-  const int *d_sharedVdofsGrads = parallelData.sharedVdofsGradUp.Read();
+  const int *d_elem2_dofs = parallelData.elem2_dofs.Read();
+  const int *d_elem2_grad_dofs = parallelData.elem2_grad_dofs.Read();
   const int *d_sharedElemsFaces = parallelData.sharedElemsFaces.Read();
 
   const int maxNumElems = parallelData.sharedElemsFaces.Size() / 7;  // elements with shared faces
@@ -714,7 +714,7 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
 
           // load data elem2
           for (int j = 0; j < dof2; j++) {
-            int index = d_sharedVdofs[j + eq * maxDofs + f * num_equation * maxDofs];
+            int index = d_elem2_dofs[j + eq * maxDofs + f * num_equation * maxDofs];
             u2[eq] += d_faceData[index] * l2[j];
           }
 
@@ -728,8 +728,8 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
 
             // el2
             for (int j = 0; j < dof2; j++) {
-              int index =
-                  d_sharedVdofsGrads[j + eq * maxDofs + d * num_equation * maxDofs + f * dim * num_equation * maxDofs];
+              int loc_ind = j + eq * maxDofs + d * num_equation * maxDofs + f * dim * num_equation * maxDofs;
+              int index = d_elem2_grad_dofs[loc_ind];
               const double G = d_faceGradUp[index];
               gradUp2[eq + d * num_equation] += l2[j] * G;
             }

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -167,7 +167,7 @@ void DGNonLinearForm::Mult_domain(const Vector &x, Vector &y) {
   }
 
   // INTEGRATION BOUNDARIES
-  if (bfnfi.Size()) bcIntegrator->integrateBCs(y, x, elem_data.element_dofs_list, elem_data.posDofIds);
+  if (bfnfi.Size()) bcIntegrator->integrateBCs(y, x, elem_data);
 }
 
 void DGNonLinearForm::Mult_bdr(const Vector &x, Vector &y) {

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -539,7 +539,7 @@ void DGNonLinearForm::sharedFaceIntegration_gpu(Vector &y) {
   const double Pr = mixture->GetPrandtlNum();
   // const double Sc = mixture->GetSchmidtNum();
 
-  const parallelFacesIntegrationArrays &parallelData = gpuArrays.shared_face_data;
+  const sharedFaceIntegrationData &parallelData = gpuArrays.shared_face_data;
   const double *d_sharedShapeWnor1 = parallelData.sharedShapeWnor1.Read();
   const int *d_sharedElem1Dof12Q = parallelData.sharedElem1Dof12Q.Read();
   const int *d_sharedElemsFaces = parallelData.sharedElemsFaces.Read();
@@ -618,7 +618,7 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
   auto d_elem_dofs_list = elem_data.element_dofs_list.Read();
   auto d_elem_dof_off = elem_data.element_dof_offset.Read();
 
-  const parallelFacesIntegrationArrays &parallelData = gpuArrays.shared_face_data;
+  const sharedFaceIntegrationData &parallelData = gpuArrays.shared_face_data;
   const double *d_sharedShapeWnor1 = parallelData.sharedShapeWnor1.Read();
   const double *d_sharedShape2 = parallelData.sharedShape2.Read();
   const int *d_sharedElem1Dof12Q = parallelData.sharedElem1Dof12Q.Read();

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -539,15 +539,15 @@ void DGNonLinearForm::sharedFaceIntegration_gpu(Vector &y) {
   const double Pr = mixture->GetPrandtlNum();
   // const double Sc = mixture->GetSchmidtNum();
 
-  const sharedFaceIntegrationData &parallelData = gpuArrays.shared_face_data;
-  const double *d_weight = parallelData.quad_weight.Read();
-  const double *d_shape1 = parallelData.el1_shape.Read();
-  const int *d_face_num_quad = parallelData.num_quad.Read();
-  const int *d_shared_elements_to_shared_faces = parallelData.shared_elements_to_shared_faces.Read();
+  const sharedFaceIntegrationData &shared_face_data = gpuArrays.shared_face_data;
+  const double *d_weight = shared_face_data.quad_weight.Read();
+  const double *d_shape1 = shared_face_data.el1_shape.Read();
+  const int *d_face_num_quad = shared_face_data.num_quad.Read();
+  const int *d_shared_elements_to_shared_faces = shared_face_data.shared_elements_to_shared_faces.Read();
 
   const double *d_shared_flux = shared_flux.Read();
 
-  const int maxNumElems = parallelData.shared_elements_to_shared_faces.Size()/7;  // elements with shared faces
+  const int maxNumElems = shared_face_data.shared_elements_to_shared_faces.Size()/7;  // elements with shared faces
   const int Ndofs = vfes->GetNDofs();
   const int dim = dim_;
   const int num_equation = num_equation_;
@@ -567,7 +567,7 @@ void DGNonLinearForm::sharedFaceIntegration_gpu(Vector &y) {
   // So, for now I am leaving it alone, but the todo is to investigate
   // how much difference this makes.
 
-  MFEM_FORALL_2D(el, parallelData.shared_elements_to_shared_faces.Size() / 7, maxDofs, 1, 1, {
+  MFEM_FORALL_2D(el, shared_face_data.shared_elements_to_shared_faces.Size() / 7, maxDofs, 1, 1, {
     //
     double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS];  // double Fcontrib[216 * 5];
     double Rflux[gpudata::MAXEQUATIONS];  // double Rflux[5];
@@ -632,17 +632,17 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
   auto d_elem_dof_off = elem_data.dof_offset.Read();
   auto d_elem_dof_num = elem_data.dof_number.Read();
 
-  const sharedFaceIntegrationData &parallelData = gpuArrays.shared_face_data;
-  const double *d_normal = parallelData.normal.Read();
-  const double *d_shape1 = parallelData.el1_shape.Read();
-  const double *d_shape2 = parallelData.el2_shape.Read();
-  const int *d_face_num_quad = parallelData.num_quad.Read();
-  const int *d_face_num_dof2 = parallelData.num_dof2.Read();
-  const int *d_elem2_dofs = parallelData.elem2_dofs.Read();
-  const int *d_elem2_grad_dofs = parallelData.elem2_grad_dofs.Read();
-  const int *d_shared_elements_to_shared_faces = parallelData.shared_elements_to_shared_faces.Read();
+  const sharedFaceIntegrationData &shared_face_data = gpuArrays.shared_face_data;
+  const double *d_normal = shared_face_data.normal.Read();
+  const double *d_shape1 = shared_face_data.el1_shape.Read();
+  const double *d_shape2 = shared_face_data.el2_shape.Read();
+  const int *d_face_num_quad = shared_face_data.num_quad.Read();
+  const int *d_face_num_dof2 = shared_face_data.num_dof2.Read();
+  const int *d_elem2_dofs = shared_face_data.elem2_dofs.Read();
+  const int *d_elem2_grad_dofs = shared_face_data.elem2_grad_dofs.Read();
+  const int *d_shared_elements_to_shared_faces = shared_face_data.shared_elements_to_shared_faces.Read();
 
-  const int maxNumElems = parallelData.shared_elements_to_shared_faces.Size() / 7;  // elements with shared faces
+  const int maxNumElems = shared_face_data.shared_elements_to_shared_faces.Size() / 7;  // elements with shared faces
   const int Ndofs = vfes->GetNDofs();
   const int dim = dim_;
   const int num_equation = num_equation_;
@@ -660,7 +660,7 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
   const RiemannSolver *d_rsolver = rsolver_;
   Fluxes *d_flux = fluxes;
 
-  MFEM_FORALL_2D(el, parallelData.shared_elements_to_shared_faces.Size() / 7, maxIntPoints, 1, 1, {
+  MFEM_FORALL_2D(el, shared_face_data.shared_elements_to_shared_faces.Size() / 7, maxIntPoints, 1, 1, {
     double l1[gpudata::MAXDOFS], l2[gpudata::MAXDOFS];            // double l1[216], l2[216];
     double u1[gpudata::MAXEQUATIONS], u2[gpudata::MAXEQUATIONS];  // double u1[5], u2[5];
     double gradUp1[gpudata::MAXDIM * gpudata::MAXEQUATIONS],      // double gradUp1[3 * 5];

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -141,7 +141,7 @@ void DGNonLinearForm::Mult_domain(const Vector &x, Vector &y) {
   const elementIndexingData &elem_data = gpuArrays.element_indexing_data;
 
   auto h_num_elems_of_type = elem_data.num_elems_of_type.HostRead();
-  auto h_elem_dof_num = elem_data.element_dof_number.HostRead();
+  auto h_elem_dof_num = elem_data.dof_number.HostRead();
 
   // Internal face integration
   if (fnfi.Size()) {
@@ -195,15 +195,15 @@ void DGNonLinearForm::faceIntegration_gpu(Vector &y, int elType, int elemOffset,
   const double *d_f = face_flux_.Read();
 
   auto d_element_to_faces = face_data.element_to_faces.Read();
-  auto d_elem_dofs_list = elem_data.element_dofs_list.Read();
-  auto d_elem_dof_off = elem_data.element_dof_offset.Read();
-  auto d_elem_dof_num = elem_data.element_dof_number.Read();
-  auto d_shape1 = face_data.face_el1_shape.Read();
-  auto d_weight = face_data.face_quad_weight.Read();
-  const double *d_shape2 = face_data.face_el2_shape.Read();
-  auto d_face_el1 = face_data.face_el1.Read();
-  auto d_face_el2 = face_data.face_el1.Read();
-  auto d_face_nqp = face_data.face_num_quad.Read();
+  auto d_elem_dofs_list = elem_data.dofs_list.Read();
+  auto d_elem_dof_off = elem_data.dof_offset.Read();
+  auto d_elem_dof_num = elem_data.dof_number.Read();
+  auto d_shape1 = face_data.el1_shape.Read();
+  auto d_weight = face_data.quad_weight.Read();
+  const double *d_shape2 = face_data.el2_shape.Read();
+  auto d_face_el1 = face_data.el1.Read();
+  auto d_face_el2 = face_data.el1.Read();
+  auto d_face_nqp = face_data.num_quad.Read();
 
   const int Ndofs = vfes->GetNDofs();
   const int NumElemType = h_num_elems_of_type[elType];
@@ -300,8 +300,8 @@ void DGNonLinearForm::evalFaceFlux_gpu() {
   const elementIndexingData &elem_data = gpuArrays.element_indexing_data;
   const interiorFaceIntegrationData &face_data = gpuArrays.interior_face_data;
 
-  auto d_normal = face_data.face_normal.Read();
-  auto d_face_nqp = face_data.face_num_quad.Read();
+  auto d_normal = face_data.normal.Read();
+  auto d_face_nqp = face_data.num_quad.Read();
 
   const double gamma = mixture->GetSpecificHeatRatio();
   const double Rg = mixture->GetGasConstant();
@@ -411,12 +411,12 @@ void DGNonLinearForm::interpFaceData_gpu(const Vector &x, int elType, int elemOf
 
   const double *d_gradUp = gradUp->Read();
   auto d_element_to_faces = face_data.element_to_faces.Read();
-  auto d_elem_dofs_list = elem_data.element_dofs_list.Read();
-  auto d_elem_dof_off = elem_data.element_dof_offset.Read();
-  auto d_shape1 = face_data.face_el1_shape.Read();
-  const double *d_shape2 = face_data.face_el2_shape.Read();
-  auto d_face_el1 = face_data.face_el1.Read();
-  auto d_face_nqp = face_data.face_num_quad.Read();
+  auto d_elem_dofs_list = elem_data.dofs_list.Read();
+  auto d_elem_dof_off = elem_data.dof_offset.Read();
+  auto d_shape1 = face_data.el1_shape.Read();
+  const double *d_shape2 = face_data.el2_shape.Read();
+  auto d_face_el1 = face_data.el1.Read();
+  auto d_face_nqp = face_data.num_quad.Read();
 
   const int Ndofs = vfes->GetNDofs();
   const int NumElemsType = h_num_elems_of_type[elType];
@@ -528,9 +528,9 @@ void DGNonLinearForm::sharedFaceIntegration_gpu(Vector &y) {
   const elementIndexingData &elem_data = gpuArrays.element_indexing_data;
   const interiorFaceIntegrationData &face_data = gpuArrays.interior_face_data;
 
-  auto d_elem_dofs_list = elem_data.element_dofs_list.Read();
-  auto d_elem_dof_off = elem_data.element_dof_offset.Read();
-  auto d_elem_dof_num = elem_data.element_dof_number.Read();
+  auto d_elem_dofs_list = elem_data.dofs_list.Read();
+  auto d_elem_dof_off = elem_data.dof_offset.Read();
+  auto d_elem_dof_num = elem_data.dof_number.Read();
 
   const double gamma = mixture->GetSpecificHeatRatio();
   const double Rg    = mixture->GetGasConstant();
@@ -540,9 +540,9 @@ void DGNonLinearForm::sharedFaceIntegration_gpu(Vector &y) {
   // const double Sc = mixture->GetSchmidtNum();
 
   const sharedFaceIntegrationData &parallelData = gpuArrays.shared_face_data;
-  const double *d_weight = parallelData.face_quad_weight.Read();
-  const double *d_shape1 = parallelData.face_el1_shape.Read();
-  const int *d_face_num_quad = parallelData.face_num_quad.Read();
+  const double *d_weight = parallelData.quad_weight.Read();
+  const double *d_shape1 = parallelData.el1_shape.Read();
+  const int *d_face_num_quad = parallelData.num_quad.Read();
   const int *d_shared_elements_to_shared_faces = parallelData.shared_elements_to_shared_faces.Read();
 
   const double *d_shared_flux = shared_flux.Read();
@@ -628,16 +628,16 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
   const elementIndexingData &elem_data = gpuArrays.element_indexing_data;
   const interiorFaceIntegrationData &face_data = gpuArrays.interior_face_data;
 
-  auto d_elem_dofs_list = elem_data.element_dofs_list.Read();
-  auto d_elem_dof_off = elem_data.element_dof_offset.Read();
-  auto d_elem_dof_num = elem_data.element_dof_number.Read();
+  auto d_elem_dofs_list = elem_data.dofs_list.Read();
+  auto d_elem_dof_off = elem_data.dof_offset.Read();
+  auto d_elem_dof_num = elem_data.dof_number.Read();
 
   const sharedFaceIntegrationData &parallelData = gpuArrays.shared_face_data;
-  const double *d_normal = parallelData.face_normal.Read();
-  const double *d_shape1 = parallelData.face_el1_shape.Read();
-  const double *d_shape2 = parallelData.face_el2_shape.Read();
-  const int *d_face_num_quad = parallelData.face_num_quad.Read();
-  const int *d_face_num_dof2 = parallelData.face_num_dof2.Read();
+  const double *d_normal = parallelData.normal.Read();
+  const double *d_shape1 = parallelData.el1_shape.Read();
+  const double *d_shape2 = parallelData.el2_shape.Read();
+  const int *d_face_num_quad = parallelData.num_quad.Read();
+  const int *d_face_num_dof2 = parallelData.num_dof2.Read();
   const int *d_elem2_dofs = parallelData.elem2_dofs.Read();
   const int *d_elem2_grad_dofs = parallelData.elem2_grad_dofs.Read();
   const int *d_shared_elements_to_shared_faces = parallelData.shared_elements_to_shared_faces.Read();

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -554,6 +554,19 @@ void DGNonLinearForm::sharedFaceIntegration_gpu(Vector &y) {
   const int maxIntPoints = maxIntPoints_;
   const int maxDofs = maxDofs_;
 
+  // TODO(trevilo): Is this approach (i.e., looping over elements with
+  // shared faces rather than shared faces) really worthwhile?  It may
+  // (probably does) improve performance for any elements with
+  // multiple shared faces, but do we ever have enough of those for it
+  // to make enough of an overall performance difference to justify
+  // the increase in code complexity?  The alternative is to directly
+  // loop through the shared faces, which would allow simplification
+  // of some of the data structures (e.g., we could eliminate
+  // sharedElemsFaces entirely).  I am skeptical the approach here is
+  // significantly better; it feels like a premature optimization.
+  // So, for now I am leaving it alone, but the todo is to investigate
+  // how much difference this makes.
+
   MFEM_FORALL_2D(el, parallelData.sharedElemsFaces.Size() / 7, maxDofs, 1, 1, {
     //
     double Fcontrib[gpudata::MAXDOFS * gpudata::MAXEQUATIONS];  // double Fcontrib[216 * 5];

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -249,7 +249,7 @@ void DGNonLinearForm::faceIntegration_gpu(Vector &y, int elType, int elemOffset,
       int dof1 = elDof;
       int dof2 = d_elem_dof_num[elj];
       if (swapElems) {
-        dof1 = dof2; // = d_elem_dof_num[elj]
+        dof1 = dof2;  // = d_elem_dof_num[elj]
         dof2 = elDof;
       }
 
@@ -447,7 +447,6 @@ void DGNonLinearForm::interpFaceData_gpu(const Vector &x, int elType, int elemOf
     for (int face = 0; face < elFaces; face++) {
       const int gFace = d_elemFaces[7 * eli + face + 1];
       const int Q = d_face_nqp[gFace];
-      //int offsetShape1 = gFace * maxIntPoints * (maxDofs + 1 + dim);
       int offsetShape1 = gFace * maxIntPoints * maxDofs;
       int offsetShape2 = gFace * maxIntPoints * maxDofs;
 

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -196,7 +196,7 @@ void DGNonLinearForm::faceIntegration_gpu(Vector &y, int elType, int elemOffset,
   auto d_elem_dof_num = gpuArrays.element_dof_number.Read();
   auto d_shape1 = gpuArrays.face_el1_shape.Read();
   auto d_weight = gpuArrays.face_quad_weight.Read();
-  const double *d_shape2 = gpuArrays.shape2.Read();
+  const double *d_shape2 = gpuArrays.face_el2_shape.Read();
   auto d_elems12Q = gpuArrays.elems12Q.Read();
 
   const int Ndofs = vfes->GetNDofs();
@@ -402,7 +402,7 @@ void DGNonLinearForm::interpFaceData_gpu(const Vector &x, int elType, int elemOf
   auto d_elem_dofs_list = gpuArrays.element_dofs_list.Read();
   auto d_elem_dof_off = gpuArrays.element_dof_offset.Read();
   auto d_shape1 = gpuArrays.face_el1_shape.Read();
-  const double *d_shape2 = gpuArrays.shape2.Read();
+  const double *d_shape2 = gpuArrays.face_el2_shape.Read();
   auto d_elems12Q = gpuArrays.elems12Q.Read();
 
   const int Ndofs = vfes->GetNDofs();

--- a/src/dgNonlinearForm.hpp
+++ b/src/dgNonlinearForm.hpp
@@ -64,9 +64,6 @@ class DGNonLinearForm : public ParNonlinearForm {
 
   const volumeFaceIntegrationArrays &gpuArrays;
 
-  const int *h_numElems;
-  const int *h_posDofIds;
-
   // Parallel shared faces integration
   parallelFacesIntegrationArrays *parallelData;
   mutable dataTransferArrays *transferU;

--- a/src/dgNonlinearForm.hpp
+++ b/src/dgNonlinearForm.hpp
@@ -62,7 +62,7 @@ class DGNonLinearForm : public ParNonlinearForm {
   const int num_equation_;
   GasMixture *mixture;
 
-  const precomputedIntegrationData &gpuArrays;
+  const precomputedIntegrationData &gpu_precomputed_data_;
 
   mutable dataTransferArrays *transferU;
   mutable dataTransferArrays *transferGradUp;
@@ -79,7 +79,7 @@ class DGNonLinearForm : public ParNonlinearForm {
  public:
   DGNonLinearForm(RiemannSolver *rsolver, Fluxes *_flux, ParFiniteElementSpace *f, ParFiniteElementSpace *gradFes,
                   ParGridFunction *_gradUp, BCintegrator *_bcIntegrator, IntegrationRules *intRules, const int dim,
-                  const int num_equation, GasMixture *mixture, const precomputedIntegrationData &_gpuArrays,
+                  const int num_equation, GasMixture *mixture, const precomputedIntegrationData &gpu_precomputed_data,
                   const int &maxIntPoints, const int &maxDofs);
 
   void Mult(const Vector &x, Vector &y);

--- a/src/dgNonlinearForm.hpp
+++ b/src/dgNonlinearForm.hpp
@@ -62,7 +62,7 @@ class DGNonLinearForm : public ParNonlinearForm {
   const int num_equation_;
   GasMixture *mixture;
 
-  const volumeFaceIntegrationArrays &gpuArrays;
+  const precomputedIntegrationData &gpuArrays;
 
   // Parallel shared faces integration
   parallelFacesIntegrationArrays *parallelData;
@@ -81,7 +81,7 @@ class DGNonLinearForm : public ParNonlinearForm {
  public:
   DGNonLinearForm(RiemannSolver *rsolver, Fluxes *_flux, ParFiniteElementSpace *f, ParFiniteElementSpace *gradFes,
                   ParGridFunction *_gradUp, BCintegrator *_bcIntegrator, IntegrationRules *intRules, const int dim,
-                  const int num_equation, GasMixture *mixture, const volumeFaceIntegrationArrays &_gpuArrays,
+                  const int num_equation, GasMixture *mixture, const precomputedIntegrationData &_gpuArrays,
                   const int &maxIntPoints, const int &maxDofs);
 
   void Mult(const Vector &x, Vector &y);

--- a/src/dgNonlinearForm.hpp
+++ b/src/dgNonlinearForm.hpp
@@ -64,8 +64,6 @@ class DGNonLinearForm : public ParNonlinearForm {
 
   const precomputedIntegrationData &gpuArrays;
 
-  // Parallel shared faces integration
-  parallelFacesIntegrationArrays *parallelData;
   mutable dataTransferArrays *transferU;
   mutable dataTransferArrays *transferGradUp;
 
@@ -86,8 +84,7 @@ class DGNonLinearForm : public ParNonlinearForm {
 
   void Mult(const Vector &x, Vector &y);
 
-  void setParallelData(parallelFacesIntegrationArrays *_parallelData, dataTransferArrays *_transferU,
-                       dataTransferArrays *_transferGradUp);
+  void setParallelData(dataTransferArrays *_transferU, dataTransferArrays *_transferGradUp);
 
   void faceIntegration_gpu(Vector &y, int elType, int elemOffset, int elDof);
 

--- a/src/forcing_terms.cpp
+++ b/src/forcing_terms.cpp
@@ -116,7 +116,7 @@ void ConstantPressureGradient::updateTerms(Vector &in) {
 #ifdef _GPU_
   const elementIndexingData &elem_data = gpuArrays.element_indexing_data;
 
-  auto h_elem_dof_number = elem_data.element_dof_number.HostRead();
+  auto h_elem_dof_number = elem_data.dof_number.HostRead();
 
   for (int elType = 0; elType < elem_data.num_elems_of_type.Size(); elType++) {
     int elemOffset = 0;
@@ -183,8 +183,8 @@ void ConstantPressureGradient::updateTerms_gpu(const int numElems, const int off
   double *d_gradUp = gradUp.ReadWrite();
 
   const elementIndexingData &elem_data = gpuArrays.element_indexing_data;
-  auto d_elem_dof_off = elem_data.element_dof_offset.Read();
-  auto d_elem_dofs_list = elem_data.element_dofs_list.Read();
+  auto d_elem_dof_off = elem_data.dof_offset.Read();
+  auto d_elem_dofs_list = elem_data.dofs_list.Read();
 
   // clang-format off
   MFEM_FORALL_2D(el, numElems, elDof, 1, 1, {

--- a/src/forcing_terms.cpp
+++ b/src/forcing_terms.cpp
@@ -178,7 +178,7 @@ void ConstantPressureGradient::updateTerms_gpu(const int numElems, const int off
   const double *d_Up = Up.Read();
   double *d_gradUp = gradUp.ReadWrite();
   auto d_posDofIds = gpuArrays.posDofIds.Read();
-  auto d_nodesIDs = gpuArrays.nodesIDs.Read();
+  auto d_elem_dofs_list = gpuArrays.element_dofs_list.Read();
 
   // clang-format off
   MFEM_FORALL_2D(el, numElems, elDof, 1, 1, {
@@ -192,7 +192,7 @@ void ConstantPressureGradient::updateTerms_gpu(const int numElems, const int off
       const int eli = el + offsetElems;
       const int offsetIDs    = d_posDofIds[2 * eli];
 
-      const int indexi = d_nodesIDs[offsetIDs + i];
+      const int indexi = d_elem_dofs_list[offsetIDs + i];
 
       if (i < 3) pGrad[i] = d_pressGrad[i];
 

--- a/src/forcing_terms.cpp
+++ b/src/forcing_terms.cpp
@@ -35,8 +35,8 @@
 
 ForcingTerms::ForcingTerms(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                            IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U,
-                           ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpu_precomputed_data,
-                           bool axisym)
+                           ParGridFunction *_Up, ParGridFunction *_gradUp,
+                           const precomputedIntegrationData &gpu_precomputed_data, bool axisym)
     : dim(_dim),
       nvel(axisym ? 3 : _dim),
       num_equation(_num_equation),
@@ -240,7 +240,8 @@ AxisymmetricSource::AxisymmetricSource(const int &_dim, const int &_num_equation
                                        const Equations &_eqSystem, const int &_intRuleType, IntegrationRules *_intRules,
                                        ParFiniteElementSpace *_vfes, ParGridFunction *U, ParGridFunction *_Up,
                                        ParGridFunction *_gradUp, ParGridFunction *spaceVaryViscMult,
-                                       const precomputedIntegrationData &gpu_precomputed_data, RunConfiguration &_config)
+                                       const precomputedIntegrationData &gpu_precomputed_data,
+                                       RunConfiguration &_config)
     : ForcingTerms(_dim, _num_equation, _order, _intRuleType, _intRules, _vfes, U, _Up, _gradUp, gpu_precomputed_data,
                    _config.isAxisymmetric()),
       mixture(_mixture),

--- a/src/forcing_terms.cpp
+++ b/src/forcing_terms.cpp
@@ -50,7 +50,7 @@ ForcingTerms::ForcingTerms(const int &_dim, const int &_num_equation, const int 
       gradUp_(_gradUp),
       gpuArrays(_gpuArrays) {
   const elementIndexingData &elem_data = gpuArrays.element_indexing_data;
-  h_numElems = elem_data.numElems.HostRead();
+  h_num_elems_of_type = elem_data.num_elems_of_type.HostRead();
 
   //   b = new ParGridFunction(vfes);
   //
@@ -118,14 +118,14 @@ void ConstantPressureGradient::updateTerms(Vector &in) {
 
   auto h_elem_dof_number = elem_data.element_dof_number.HostRead();
 
-  for (int elType = 0; elType < elem_data.numElems.Size(); elType++) {
+  for (int elType = 0; elType < elem_data.num_elems_of_type.Size(); elType++) {
     int elemOffset = 0;
     if (elType != 0) {
-      for (int i = 0; i < elType; i++) elemOffset += h_numElems[i];
+      for (int i = 0; i < elType; i++) elemOffset += h_num_elems_of_type[i];
     }
     int dof_el = h_elem_dof_number[elemOffset];
 
-    updateTerms_gpu(h_numElems[elType], elemOffset, dof_el, vfes->GetNDofs(), pressGrad, in, *Up_, *gradUp_,
+    updateTerms_gpu(h_num_elems_of_type[elType], elemOffset, dof_el, vfes->GetNDofs(), pressGrad, in, *Up_, *gradUp_,
                     num_equation, dim, gpuArrays);
   }
 #else

--- a/src/forcing_terms.hpp
+++ b/src/forcing_terms.hpp
@@ -67,7 +67,7 @@ class ForcingTerms {
   ParGridFunction *Up_;
   ParGridFunction *gradUp_;
 
-  const volumeFaceIntegrationArrays &gpuArrays;
+  const precomputedIntegrationData &gpuArrays;
   const int *h_numElems;
   const int *h_posDofIds;
 
@@ -77,7 +77,7 @@ class ForcingTerms {
  public:
   ForcingTerms(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U, ParGridFunction *_Up,
-               ParGridFunction *_gradUp, const volumeFaceIntegrationArrays &gpuArrays, bool axisym);
+               ParGridFunction *_gradUp, const precomputedIntegrationData &gpuArrays, bool axisym);
   virtual ~ForcingTerms();
 
   void setTime(double _time) { time = _time; }
@@ -95,7 +95,7 @@ class ConstantPressureGradient : public ForcingTerms {
  public:
   ConstantPressureGradient(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                            IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U,
-                           ParGridFunction *_Up, ParGridFunction *_gradUp, const volumeFaceIntegrationArrays &gpuArrays,
+                           ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpuArrays,
                            RunConfiguration &_config, GasMixture *mixture);
   virtual ~ConstantPressureGradient() {}
 
@@ -106,7 +106,7 @@ class ConstantPressureGradient : public ForcingTerms {
 #ifdef _GPU_
   static void updateTerms_gpu(const int numElems, const int offsetElems, const int elDof, const int totalDofs,
                               Vector &pressGrad, Vector &in, const Vector &Up, Vector &gradUp, const int num_equation,
-                              const int dim, const volumeFaceIntegrationArrays &gpuArrays);
+                              const int dim, const precomputedIntegrationData &gpuArrays);
 #endif
 };
 
@@ -123,7 +123,7 @@ class AxisymmetricSource : public ForcingTerms {
                      TransportProperties *_transport, const Equations &_eqSystem, const int &_intRuleType,
                      IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U,
                      ParGridFunction *_Up, ParGridFunction *_gradUp, ParGridFunction *spaceVaryViscMult,
-                     const volumeFaceIntegrationArrays &gpuArrays, RunConfiguration &_config);
+                     const precomputedIntegrationData &gpuArrays, RunConfiguration &_config);
   virtual ~AxisymmetricSource() {}
 
   virtual void updateTerms(Vector &in);
@@ -139,7 +139,7 @@ class JouleHeating : public ForcingTerms {
   JouleHeating(const int &_dim, const int &_num_equation, const int &_order, GasMixture *_mixture,
                const Equations &_eqSystem, const int &_intRuleType, IntegrationRules *_intRules,
                ParFiniteElementSpace *_vfes, ParGridFunction *U, ParGridFunction *_Up, ParGridFunction *_gradUp,
-               const volumeFaceIntegrationArrays &gpuArrays, RunConfiguration &_config, ParGridFunction *jh_);
+               const precomputedIntegrationData &gpuArrays, RunConfiguration &_config, ParGridFunction *jh_);
   virtual ~JouleHeating() {}
 
   virtual void updateTerms(Vector &in);
@@ -169,7 +169,7 @@ class SpongeZone : public ForcingTerms {
  public:
   SpongeZone(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType, Fluxes *_fluxClass,
              GasMixture *_mixture, IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U,
-             ParGridFunction *_Up, ParGridFunction *_gradUp, const volumeFaceIntegrationArrays &gpuArrays,
+             ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpuArrays,
              RunConfiguration &_config, const int sz);
   virtual ~SpongeZone();
 
@@ -186,7 +186,7 @@ class PassiveScalar : public ForcingTerms {
  public:
   PassiveScalar(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                 IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, GasMixture *_mixture, ParGridFunction *U,
-                ParGridFunction *_Up, ParGridFunction *_gradUp, const volumeFaceIntegrationArrays &gpuArrays,
+                ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpuArrays,
                 RunConfiguration &_config);
 
   // Terms do not need updating
@@ -210,7 +210,7 @@ class HeatSource : public ForcingTerms {
   HeatSource(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
              heatSourceData &heatSource, GasMixture *_mixture, IntegrationRules *_intRules,
              ParFiniteElementSpace *_vfes, ParGridFunction *U, ParGridFunction *_Up, ParGridFunction *_gradUp,
-             const volumeFaceIntegrationArrays &gpuArrays, RunConfiguration &_config);
+             const precomputedIntegrationData &gpuArrays, RunConfiguration &_config);
   virtual ~HeatSource() {}
 
   virtual void updateTerms(Vector &in);
@@ -227,7 +227,7 @@ class MASA_forcings : public ForcingTerms {
  public:
   MASA_forcings(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                 IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U, ParGridFunction *_Up,
-                ParGridFunction *_gradUp, const volumeFaceIntegrationArrays &gpuArrays, RunConfiguration &_config);
+                ParGridFunction *_gradUp, const precomputedIntegrationData &gpuArrays, RunConfiguration &_config);
 
   virtual void updateTerms(Vector &in);
 };

--- a/src/forcing_terms.hpp
+++ b/src/forcing_terms.hpp
@@ -94,8 +94,9 @@ class ConstantPressureGradient : public ForcingTerms {
  public:
   ConstantPressureGradient(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                            IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U,
-                           ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpu_precomputed_data,
-                           RunConfiguration &_config, GasMixture *mixture);
+                           ParGridFunction *_Up, ParGridFunction *_gradUp,
+                           const precomputedIntegrationData &gpu_precomputed_data, RunConfiguration &_config,
+                           GasMixture *mixture);
   virtual ~ConstantPressureGradient() {}
 
   // Terms do not need updating
@@ -226,7 +227,8 @@ class MASA_forcings : public ForcingTerms {
  public:
   MASA_forcings(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                 IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U, ParGridFunction *_Up,
-                ParGridFunction *_gradUp, const precomputedIntegrationData &gpu_precomputed_data, RunConfiguration &_config);
+                ParGridFunction *_gradUp, const precomputedIntegrationData &gpu_precomputed_data,
+                RunConfiguration &_config);
 
   virtual void updateTerms(Vector &in);
 };

--- a/src/forcing_terms.hpp
+++ b/src/forcing_terms.hpp
@@ -68,7 +68,7 @@ class ForcingTerms {
   ParGridFunction *gradUp_;
 
   const precomputedIntegrationData &gpuArrays;
-  const int *h_numElems;
+  const int *h_num_elems_of_type;
 
   // added term
   //   ParGridFunction *b;

--- a/src/forcing_terms.hpp
+++ b/src/forcing_terms.hpp
@@ -67,7 +67,7 @@ class ForcingTerms {
   ParGridFunction *Up_;
   ParGridFunction *gradUp_;
 
-  const precomputedIntegrationData &gpuArrays;
+  const precomputedIntegrationData &gpu_precomputed_data_;
   const int *h_num_elems_of_type;
 
   // added term
@@ -76,7 +76,7 @@ class ForcingTerms {
  public:
   ForcingTerms(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U, ParGridFunction *_Up,
-               ParGridFunction *_gradUp, const precomputedIntegrationData &gpuArrays, bool axisym);
+               ParGridFunction *_gradUp, const precomputedIntegrationData &gpu_precomputed_data, bool axisym);
   virtual ~ForcingTerms();
 
   void setTime(double _time) { time = _time; }
@@ -94,7 +94,7 @@ class ConstantPressureGradient : public ForcingTerms {
  public:
   ConstantPressureGradient(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                            IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U,
-                           ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpuArrays,
+                           ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpu_precomputed_data,
                            RunConfiguration &_config, GasMixture *mixture);
   virtual ~ConstantPressureGradient() {}
 
@@ -105,7 +105,7 @@ class ConstantPressureGradient : public ForcingTerms {
 #ifdef _GPU_
   static void updateTerms_gpu(const int numElems, const int offsetElems, const int elDof, const int totalDofs,
                               Vector &pressGrad, Vector &in, const Vector &Up, Vector &gradUp, const int num_equation,
-                              const int dim, const precomputedIntegrationData &gpuArrays);
+                              const int dim, const precomputedIntegrationData &gpu_precomputed_data);
 #endif
 };
 
@@ -122,7 +122,7 @@ class AxisymmetricSource : public ForcingTerms {
                      TransportProperties *_transport, const Equations &_eqSystem, const int &_intRuleType,
                      IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U,
                      ParGridFunction *_Up, ParGridFunction *_gradUp, ParGridFunction *spaceVaryViscMult,
-                     const precomputedIntegrationData &gpuArrays, RunConfiguration &_config);
+                     const precomputedIntegrationData &gpu_precomputed_data, RunConfiguration &_config);
   virtual ~AxisymmetricSource() {}
 
   virtual void updateTerms(Vector &in);
@@ -138,7 +138,7 @@ class JouleHeating : public ForcingTerms {
   JouleHeating(const int &_dim, const int &_num_equation, const int &_order, GasMixture *_mixture,
                const Equations &_eqSystem, const int &_intRuleType, IntegrationRules *_intRules,
                ParFiniteElementSpace *_vfes, ParGridFunction *U, ParGridFunction *_Up, ParGridFunction *_gradUp,
-               const precomputedIntegrationData &gpuArrays, RunConfiguration &_config, ParGridFunction *jh_);
+               const precomputedIntegrationData &gpu_precomputed_data, RunConfiguration &_config, ParGridFunction *jh_);
   virtual ~JouleHeating() {}
 
   virtual void updateTerms(Vector &in);
@@ -168,7 +168,7 @@ class SpongeZone : public ForcingTerms {
  public:
   SpongeZone(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType, Fluxes *_fluxClass,
              GasMixture *_mixture, IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U,
-             ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpuArrays,
+             ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpu_precomputed_data,
              RunConfiguration &_config, const int sz);
   virtual ~SpongeZone();
 
@@ -185,7 +185,7 @@ class PassiveScalar : public ForcingTerms {
  public:
   PassiveScalar(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                 IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, GasMixture *_mixture, ParGridFunction *U,
-                ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpuArrays,
+                ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpu_precomputed_data,
                 RunConfiguration &_config);
 
   // Terms do not need updating
@@ -209,7 +209,7 @@ class HeatSource : public ForcingTerms {
   HeatSource(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
              heatSourceData &heatSource, GasMixture *_mixture, IntegrationRules *_intRules,
              ParFiniteElementSpace *_vfes, ParGridFunction *U, ParGridFunction *_Up, ParGridFunction *_gradUp,
-             const precomputedIntegrationData &gpuArrays, RunConfiguration &_config);
+             const precomputedIntegrationData &gpu_precomputed_data, RunConfiguration &_config);
   virtual ~HeatSource() {}
 
   virtual void updateTerms(Vector &in);
@@ -226,7 +226,7 @@ class MASA_forcings : public ForcingTerms {
  public:
   MASA_forcings(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                 IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U, ParGridFunction *_Up,
-                ParGridFunction *_gradUp, const precomputedIntegrationData &gpuArrays, RunConfiguration &_config);
+                ParGridFunction *_gradUp, const precomputedIntegrationData &gpu_precomputed_data, RunConfiguration &_config);
 
   virtual void updateTerms(Vector &in);
 };

--- a/src/forcing_terms.hpp
+++ b/src/forcing_terms.hpp
@@ -69,7 +69,6 @@ class ForcingTerms {
 
   const precomputedIntegrationData &gpuArrays;
   const int *h_numElems;
-  const int *h_posDofIds;
 
   // added term
   //   ParGridFunction *b;

--- a/src/gradNonLinearForm.cpp
+++ b/src/gradNonLinearForm.cpp
@@ -34,7 +34,7 @@
 #include "riemann_solver.hpp"
 
 GradNonLinearForm::GradNonLinearForm(ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, const int _dim,
-                                     const int _num_equation, const volumeFaceIntegrationArrays &_gpuArrays,
+                                     const int _num_equation, const precomputedIntegrationData &_gpuArrays,
                                      const int &_maxIntPoints, const int &_maxDofs)
     : ParNonlinearForm(_vfes),
       vfes(_vfes),

--- a/src/gradNonLinearForm.cpp
+++ b/src/gradNonLinearForm.cpp
@@ -34,16 +34,8 @@
 #include "riemann_solver.hpp"
 
 GradNonLinearForm::GradNonLinearForm(ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, const int _dim,
-                                     const int _num_equation, const precomputedIntegrationData &_gpuArrays,
-                                     const int &_maxIntPoints, const int &_maxDofs)
-    : ParNonlinearForm(_vfes),
-      vfes(_vfes),
-      intRules(_intRules),
-      dim(_dim),
-      num_equation(_num_equation),
-      gpuArrays(_gpuArrays),
-      maxIntPoints(_maxIntPoints),
-      maxDofs(_maxDofs) {}
+                                     const int _num_equation)
+    : ParNonlinearForm(_vfes), vfes(_vfes), intRules(_intRules), dim(_dim), num_equation(_num_equation) {}
 
 void GradNonLinearForm::Mult(const ParGridFunction *Up, Vector &y) {
   Vector x;

--- a/src/gradNonLinearForm.hpp
+++ b/src/gradNonLinearForm.hpp
@@ -47,14 +47,14 @@ class GradNonLinearForm : public ParNonlinearForm {
   const int dim;
   const int num_equation;
 
-  const volumeFaceIntegrationArrays &gpuArrays;
+  const precomputedIntegrationData &gpuArrays;
 
   const int &maxIntPoints;
   const int &maxDofs;
 
  public:
   GradNonLinearForm(ParFiniteElementSpace *f, IntegrationRules *intRules, const int dim, const int num_equation,
-                    const volumeFaceIntegrationArrays &gpuArrays, const int &maxIntPoints, const int &maxDofs);
+                    const precomputedIntegrationData &gpuArrays, const int &maxIntPoints, const int &maxDofs);
 
   void Mult(const ParGridFunction *Up, Vector &y);
 

--- a/src/gradNonLinearForm.hpp
+++ b/src/gradNonLinearForm.hpp
@@ -47,14 +47,8 @@ class GradNonLinearForm : public ParNonlinearForm {
   const int dim;
   const int num_equation;
 
-  const precomputedIntegrationData &gpuArrays;
-
-  const int &maxIntPoints;
-  const int &maxDofs;
-
  public:
-  GradNonLinearForm(ParFiniteElementSpace *f, IntegrationRules *intRules, const int dim, const int num_equation,
-                    const precomputedIntegrationData &gpuArrays, const int &maxIntPoints, const int &maxDofs);
+  GradNonLinearForm(ParFiniteElementSpace *f, IntegrationRules *intRules, const int dim, const int num_equation);
 
   void Mult(const ParGridFunction *Up, Vector &y);
 

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -571,15 +571,16 @@ void Gradients::interpGradSharedFace_gpu() {
   const int *d_elem_dofs_list = elem_data.element_dofs_list.Read();
   const int *d_elem_dof_off = elem_data.element_dof_offset.Read();
 
-  const double *d_sharedShapeWnor1 = parallelData->sharedShapeWnor1.Read();
-  const double *d_sharedShape2 = parallelData->sharedShape2.Read();
-  const int *d_sharedElem1Dof12Q = parallelData->sharedElem1Dof12Q.Read();
-  const int *d_sharedVdofs = parallelData->sharedVdofs.Read();
-  const int *d_sharedElemsFaces = parallelData->sharedElemsFaces.Read();
+  const parallelFacesIntegrationArrays &parallelData = gpuArrays.shared_face_data;
+  const double *d_sharedShapeWnor1 = parallelData.sharedShapeWnor1.Read();
+  const double *d_sharedShape2 = parallelData.sharedShape2.Read();
+  const int *d_sharedElem1Dof12Q = parallelData.sharedElem1Dof12Q.Read();
+  const int *d_sharedVdofs = parallelData.sharedVdofs.Read();
+  const int *d_sharedElemsFaces = parallelData.sharedElemsFaces.Read();
 
   double *d_dun = dun_shared_face.Write();
 
-  const int maxNumElems = parallelData->sharedElemsFaces.Size() / 7;  // elements with shared faces
+  const int maxNumElems = parallelData.sharedElemsFaces.Size() / 7;  // elements with shared faces
   const int dim = dim_;
   const int num_equation = num_equation_;
   const int maxIntPoints = maxIntPoints_;
@@ -662,9 +663,10 @@ void Gradients::integrationGradSharedFace_gpu() {
   const int *d_elem_dofs_list = elem_data.element_dofs_list.Read();
   const int *d_elem_dof_off = elem_data.element_dof_offset.Read();
 
-  const double *d_sharedShapeWnor1 = parallelData->sharedShapeWnor1.Read();
-  const int *d_sharedElem1Dof12Q = parallelData->sharedElem1Dof12Q.Read();
-  const int *d_sharedElemsFaces = parallelData->sharedElemsFaces.Read();
+  const parallelFacesIntegrationArrays &parallelData = gpuArrays.shared_face_data;
+  const double *d_sharedShapeWnor1 = parallelData.sharedShapeWnor1.Read();
+  const int *d_sharedElem1Dof12Q = parallelData.sharedElem1Dof12Q.Read();
+  const int *d_sharedElemsFaces = parallelData.sharedElemsFaces.Read();
 
   const double *d_dun = dun_shared_face.Read();
 
@@ -674,7 +676,7 @@ void Gradients::integrationGradSharedFace_gpu() {
   const int maxDofs = maxDofs_;
   const int Ndofs = vfes->GetNDofs();
 
-  MFEM_FORALL_2D(el, parallelData->sharedElemsFaces.Size() / 7, maxDofs, 1, 1, {  // NOLINT
+  MFEM_FORALL_2D(el, parallelData.sharedElemsFaces.Size() / 7, maxDofs, 1, 1, {  // NOLINT
     // double l1[216];
 
     const int el1 = d_sharedElemsFaces[0 + el * 7];

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -571,7 +571,7 @@ void Gradients::interpGradSharedFace_gpu() {
   const int *d_elem_dofs_list = elem_data.element_dofs_list.Read();
   const int *d_elem_dof_off = elem_data.element_dof_offset.Read();
 
-  const parallelFacesIntegrationArrays &parallelData = gpuArrays.shared_face_data;
+  const sharedFaceIntegrationData &parallelData = gpuArrays.shared_face_data;
   const double *d_sharedShapeWnor1 = parallelData.sharedShapeWnor1.Read();
   const double *d_sharedShape2 = parallelData.sharedShape2.Read();
   const int *d_sharedElem1Dof12Q = parallelData.sharedElem1Dof12Q.Read();
@@ -663,7 +663,7 @@ void Gradients::integrationGradSharedFace_gpu() {
   const int *d_elem_dofs_list = elem_data.element_dofs_list.Read();
   const int *d_elem_dof_off = elem_data.element_dof_offset.Read();
 
-  const parallelFacesIntegrationArrays &parallelData = gpuArrays.shared_face_data;
+  const sharedFaceIntegrationData &parallelData = gpuArrays.shared_face_data;
   const double *d_sharedShapeWnor1 = parallelData.sharedShapeWnor1.Read();
   const int *d_sharedElem1Dof12Q = parallelData.sharedElem1Dof12Q.Read();
   const int *d_sharedElemsFaces = parallelData.sharedElemsFaces.Read();

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -325,7 +325,6 @@ void Gradients::interpFaceData_gpu(const Vector &Up, int elType, int elemOffset,
     for (int face = 0; face < elFaces; face++) {
       const int gFace = d_elemFaces[7 * eli + face + 1];
       const int Q = d_face_nqp[gFace];
-      //int offsetShape1 = gFace * maxIntPoints * (maxDofs + 1 + dim);
       int offset_shape = gFace * maxIntPoints * maxDofs;
 
       // swapElems = false indicates that el is "element 1" for this face

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -35,9 +35,9 @@
 
 Gradients::Gradients(ParFiniteElementSpace *_vfes, ParFiniteElementSpace *_gradUpfes, int _dim, int _num_equation,
                      ParGridFunction *_Up, ParGridFunction *_gradUp, GasMixture *_mixture, GradNonLinearForm *_gradUp_A,
-                     IntegrationRules *_intRules, int _intRuleType, const precomputedIntegrationData &gpu_precomputed_data,
-                     Array<DenseMatrix *> &_Me_inv, Vector &_invMArray, Array<int> &_posDofInvM,
-                     const int &_maxIntPoints, const int &_maxDofs)
+                     IntegrationRules *_intRules, int _intRuleType,
+                     const precomputedIntegrationData &gpu_precomputed_data, Array<DenseMatrix *> &_Me_inv,
+                     Vector &_invMArray, Array<int> &_posDofInvM, const int &_maxIntPoints, const int &_maxDofs)
     : ParNonlinearForm(_vfes),
       vfes(_vfes),
       gradUpfes(_gradUpfes),

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -579,7 +579,7 @@ void Gradients::interpGradSharedFace_gpu() {
   const double *d_shape2 = parallelData.face_el2_shape.Read();
   const int *d_face_num_quad = parallelData.face_num_quad.Read();
   const int *d_face_num_dof2 = parallelData.face_num_dof2.Read();
-  const int *d_sharedVdofs = parallelData.sharedVdofs.Read();
+  const int *d_elem2_dofs = parallelData.elem2_dofs.Read();
   const int *d_sharedElemsFaces = parallelData.sharedElemsFaces.Read();
 
   double *d_dun = dun_shared_face.Write();
@@ -640,7 +640,7 @@ void Gradients::interpGradSharedFace_gpu() {
 
           // load data elem2
           for (int j = 0; j < dof2; j++) {
-            int index = d_sharedVdofs[j + eq * maxDofs + f * num_equation * maxDofs];
+            int index = d_elem2_dofs[j + eq * maxDofs + f * num_equation * maxDofs];
             u2 += d_faceData[index] * l2[j];
           }
 

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -579,11 +579,11 @@ void Gradients::interpGradSharedFace_gpu() {
   const int *d_face_num_quad = parallelData.face_num_quad.Read();
   const int *d_face_num_dof2 = parallelData.face_num_dof2.Read();
   const int *d_elem2_dofs = parallelData.elem2_dofs.Read();
-  const int *d_sharedElemsFaces = parallelData.sharedElemsFaces.Read();
+  const int *d_shared_elements_to_shared_faces = parallelData.shared_elements_to_shared_faces.Read();
 
   double *d_dun = dun_shared_face.Write();
 
-  const int maxNumElems = parallelData.sharedElemsFaces.Size() / 7;  // elements with shared faces
+  const int maxNumElems = parallelData.shared_elements_to_shared_faces.Size() / 7;  // elements with shared faces
   const int dim = dim_;
   const int num_equation = num_equation_;
   const int maxIntPoints = maxIntPoints_;
@@ -596,8 +596,8 @@ void Gradients::interpGradSharedFace_gpu() {
     double u1, u2;
     int index_i[gpudata::MAXDOFS];  // int index_i[216];
 
-    const int el1 = d_sharedElemsFaces[0 + el * 7];
-    const int numFaces = d_sharedElemsFaces[1 + el * 7];
+    const int el1 = d_shared_elements_to_shared_faces[0 + el * 7];
+    const int numFaces = d_shared_elements_to_shared_faces[1 + el * 7];
     const int dof1 = d_elem_dof_num[el1];
 
     const int offsetEl1 = d_elem_dof_off[el1];
@@ -607,7 +607,7 @@ void Gradients::interpGradSharedFace_gpu() {
     }
 
     for (int elFace = 0; elFace < numFaces; elFace++) {
-      const int f = d_sharedElemsFaces[1 + elFace + 1 + el * 7];
+      const int f = d_shared_elements_to_shared_faces[1 + elFace + 1 + el * 7];
       const int dof2 = d_face_num_dof2[f];
       const int Q = d_face_num_quad[f];
 
@@ -668,7 +668,7 @@ void Gradients::integrationGradSharedFace_gpu() {
   const sharedFaceIntegrationData &parallelData = gpuArrays.shared_face_data;
   const double *d_shape1 = parallelData.face_el1_shape.Read();
   const int *d_face_num_quad = parallelData.face_num_quad.Read();
-  const int *d_sharedElemsFaces = parallelData.sharedElemsFaces.Read();
+  const int *d_shared_elements_to_shared_faces = parallelData.shared_elements_to_shared_faces.Read();
 
   const double *d_dun = dun_shared_face.Read();
 
@@ -678,11 +678,11 @@ void Gradients::integrationGradSharedFace_gpu() {
   const int maxDofs = maxDofs_;
   const int Ndofs = vfes->GetNDofs();
 
-  MFEM_FORALL_2D(el, parallelData.sharedElemsFaces.Size() / 7, maxDofs, 1, 1, {  // NOLINT
+  MFEM_FORALL_2D(el, parallelData.shared_elements_to_shared_faces.Size() / 7, maxDofs, 1, 1, {  // NOLINT
     // double l1[216];
 
-    const int el1 = d_sharedElemsFaces[0 + el * 7];
-    const int numFaces = d_sharedElemsFaces[1 + el * 7];
+    const int el1 = d_shared_elements_to_shared_faces[0 + el * 7];
+    const int numFaces = d_shared_elements_to_shared_faces[1 + el * 7];
     const int dof1 = d_elem_dof_num[el1];
     const int offsetEl1 = d_elem_dof_off[el1];
 
@@ -690,7 +690,7 @@ void Gradients::integrationGradSharedFace_gpu() {
       const int indexi = d_elem_dofs_list[offsetEl1 + i];
 
       for (int elFace = 0; elFace < numFaces; elFace++) {
-        const int f = d_sharedElemsFaces[1 + elFace + 1 + el * 7];
+        const int f = d_shared_elements_to_shared_faces[1 + elFace + 1 + el * 7];
         const int Q = d_face_num_quad[f];
 
         for (int k = 0; k < Q; k++) {

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -282,7 +282,7 @@ void Gradients::interpFaceData_gpu(const Vector &Up, int elType, int elemOffset,
   auto d_elem_dofs_list = gpuArrays.element_dofs_list.Read();
   auto d_posDofIds = gpuArrays.posDofIds.Read();
   auto d_shape1 = gpuArrays.face_el1_shape.Read();
-  const double *d_shape2 = gpuArrays.shape2.Read();
+  const double *d_shape2 = gpuArrays.face_el2_shape.Read();
   auto d_elems12Q = gpuArrays.elems12Q.Read();
 
   const int Ndofs = vfes->GetNDofs();
@@ -485,7 +485,7 @@ void Gradients::faceContrib_gpu(const int elType, const int offsetElems, const i
   // pointers for face integration
   auto d_elemFaces = gpuArrays.elemFaces.Read();
   auto d_shape1 = gpuArrays.face_el1_shape.Read();
-  const double *d_shape2 = gpuArrays.shape2.Read();
+  const double *d_shape2 = gpuArrays.face_el2_shape.Read();
   auto d_elems12Q = gpuArrays.elems12Q.Read();
 
   const int numElems = h_numElems[elType];

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -571,19 +571,19 @@ void Gradients::interpGradSharedFace_gpu() {
   const int *d_elem_dof_off = elem_data.dof_offset.Read();
   const int *d_elem_dof_num = elem_data.dof_number.Read();
 
-  const sharedFaceIntegrationData &parallelData = gpuArrays.shared_face_data;
-  const double *d_weight = parallelData.quad_weight.Read();
-  const double *d_normal = parallelData.normal.Read();
-  const double *d_shape1 = parallelData.el1_shape.Read();
-  const double *d_shape2 = parallelData.el2_shape.Read();
-  const int *d_face_num_quad = parallelData.num_quad.Read();
-  const int *d_face_num_dof2 = parallelData.num_dof2.Read();
-  const int *d_elem2_dofs = parallelData.elem2_dofs.Read();
-  const int *d_shared_elements_to_shared_faces = parallelData.shared_elements_to_shared_faces.Read();
+  const sharedFaceIntegrationData &shared_face_data = gpuArrays.shared_face_data;
+  const double *d_weight = shared_face_data.quad_weight.Read();
+  const double *d_normal = shared_face_data.normal.Read();
+  const double *d_shape1 = shared_face_data.el1_shape.Read();
+  const double *d_shape2 = shared_face_data.el2_shape.Read();
+  const int *d_face_num_quad = shared_face_data.num_quad.Read();
+  const int *d_face_num_dof2 = shared_face_data.num_dof2.Read();
+  const int *d_elem2_dofs = shared_face_data.elem2_dofs.Read();
+  const int *d_shared_elements_to_shared_faces = shared_face_data.shared_elements_to_shared_faces.Read();
 
   double *d_dun = dun_shared_face.Write();
 
-  const int maxNumElems = parallelData.shared_elements_to_shared_faces.Size() / 7;  // elements with shared faces
+  const int maxNumElems = shared_face_data.shared_elements_to_shared_faces.Size() / 7;  // elements with shared faces
   const int dim = dim_;
   const int num_equation = num_equation_;
   const int maxIntPoints = maxIntPoints_;
@@ -665,10 +665,10 @@ void Gradients::integrationGradSharedFace_gpu() {
   const int *d_elem_dof_off = elem_data.dof_offset.Read();
   const int *d_elem_dof_num = elem_data.dof_number.Read();
 
-  const sharedFaceIntegrationData &parallelData = gpuArrays.shared_face_data;
-  const double *d_shape1 = parallelData.el1_shape.Read();
-  const int *d_face_num_quad = parallelData.num_quad.Read();
-  const int *d_shared_elements_to_shared_faces = parallelData.shared_elements_to_shared_faces.Read();
+  const sharedFaceIntegrationData &shared_face_data = gpuArrays.shared_face_data;
+  const double *d_shape1 = shared_face_data.el1_shape.Read();
+  const int *d_face_num_quad = shared_face_data.num_quad.Read();
+  const int *d_shared_elements_to_shared_faces = shared_face_data.shared_elements_to_shared_faces.Read();
 
   const double *d_dun = dun_shared_face.Read();
 
@@ -678,7 +678,7 @@ void Gradients::integrationGradSharedFace_gpu() {
   const int maxDofs = maxDofs_;
   const int Ndofs = vfes->GetNDofs();
 
-  MFEM_FORALL_2D(el, parallelData.shared_elements_to_shared_faces.Size() / 7, maxDofs, 1, 1, {  // NOLINT
+  MFEM_FORALL_2D(el, shared_face_data.shared_elements_to_shared_faces.Size() / 7, maxDofs, 1, 1, {  // NOLINT
     // double l1[216];
 
     const int el1 = d_shared_elements_to_shared_faces[0 + el * 7];

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -282,19 +282,18 @@ void Gradients::interpFaceData_gpu(const Vector &Up, int elType, int elemOffset,
   double *d_uk_el2 = uk_el2.Write();
 
   const elementIndexingData &elem_data = gpu_precomputed_data_.element_indexing_data;
-  const interiorFaceIntegrationData &face_data = gpu_precomputed_data_.interior_face_data;
-
-  auto d_element_to_faces = face_data.element_to_faces.Read();
   auto d_elem_dofs_list = elem_data.dofs_list.Read();
   auto d_elem_dof_off = elem_data.dof_offset.Read();
+
+  const interiorFaceIntegrationData &face_data = gpu_precomputed_data_.interior_face_data;
+  auto d_element_to_faces = face_data.element_to_faces.Read();
   auto d_shape1 = face_data.el1_shape.Read();
-  const double *d_shape2 = face_data.el2_shape.Read();
+  auto d_shape2 = face_data.el2_shape.Read();
   auto d_face_el1 = face_data.el1.Read();
   auto d_face_nqp = face_data.num_quad.Read();
 
   const int Ndofs = vfes->GetNDofs();
   const int NumElemsType = h_num_elems_of_type[elType];
-  const int dim = dim_;
   const int num_equation = num_equation_;
   const int maxIntPoints = maxIntPoints_;
   const int maxDofs = maxDofs_;
@@ -440,9 +439,7 @@ void Gradients::evalFaceIntegrand_gpu() {
   const double *d_uk_el1 = uk_el1.Read();
   const double *d_uk_el2 = uk_el2.Read();
 
-  const elementIndexingData &elem_data = gpu_precomputed_data_.element_indexing_data;
   const interiorFaceIntegrationData &face_data = gpu_precomputed_data_.interior_face_data;
-
   auto d_weight = face_data.quad_weight.Read();
   auto d_normal = face_data.normal.Read();
   auto d_face_nqp = face_data.num_quad.Read();
@@ -453,7 +450,6 @@ void Gradients::evalFaceIntegrand_gpu() {
   const int dim = dim_;
   const int num_equation = num_equation_;
   const int maxIntPoints = maxIntPoints_;
-  const int maxDofs = maxDofs_;
 
   MFEM_FORALL(iface, Nf, {
     double u1[gpudata::MAXEQUATIONS], u2[gpudata::MAXEQUATIONS],
@@ -492,15 +488,13 @@ void Gradients::faceContrib_gpu(const int elType, const int offsetElems, const i
   double *d_gradUp = gradUp->Write();  // NB: I assume this comes in set to zero!
 
   const elementIndexingData &elem_data = gpu_precomputed_data_.element_indexing_data;
-  const interiorFaceIntegrationData &face_data = gpu_precomputed_data_.interior_face_data;
-
   auto d_elem_dof_off = elem_data.dof_offset.Read();
   auto d_elem_dofs_list = elem_data.dofs_list.Read();
 
-  // pointers for face integration
+  const interiorFaceIntegrationData &face_data = gpu_precomputed_data_.interior_face_data;
   auto d_element_to_faces = face_data.element_to_faces.Read();
   auto d_shape1 = face_data.el1_shape.Read();
-  const double *d_shape2 = face_data.el2_shape.Read();
+  auto d_shape2 = face_data.el2_shape.Read();
   auto d_face_el1 = face_data.el1.Read();
   auto d_face_nqp = face_data.num_quad.Read();
 
@@ -562,8 +556,6 @@ void Gradients::interpGradSharedFace_gpu() {
   const double *d_faceData = transferUp->face_nbr_data.Read();
 
   const elementIndexingData &elem_data = gpu_precomputed_data_.element_indexing_data;
-  const interiorFaceIntegrationData &face_data = gpu_precomputed_data_.interior_face_data;
-
   const int *d_elem_dofs_list = elem_data.dofs_list.Read();
   const int *d_elem_dof_off = elem_data.dof_offset.Read();
   const int *d_elem_dof_num = elem_data.dof_number.Read();
@@ -656,8 +648,6 @@ void Gradients::integrationGradSharedFace_gpu() {
   double *d_gradUp = gradUp->ReadWrite();
 
   const elementIndexingData &elem_data = gpu_precomputed_data_.element_indexing_data;
-  const interiorFaceIntegrationData &face_data = gpu_precomputed_data_.interior_face_data;
-
   const int *d_elem_dofs_list = elem_data.dofs_list.Read();
   const int *d_elem_dof_off = elem_data.dof_offset.Read();
   const int *d_elem_dof_num = elem_data.dof_number.Read();
@@ -713,10 +703,9 @@ void Gradients::multInverse_gpu(const int numElems, const int offsetElems, const
   double *d_gradUp = gradUp->ReadWrite();
 
   const elementIndexingData &elem_data = gpu_precomputed_data_.element_indexing_data;
-  const interiorFaceIntegrationData &face_data = gpu_precomputed_data_.interior_face_data;
-
   auto d_elem_dof_off = elem_data.dof_offset.Read();
   auto d_elem_dofs_list = elem_data.dofs_list.Read();
+
   const double *d_invMArray = invMArray.Read();
   auto d_posDofInvM = posDofInvM.Read();
 

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -62,7 +62,7 @@ class Gradients : public ParNonlinearForm {
   IntegrationRules *intRules;
   const int intRuleType;
 
-  const precomputedIntegrationData &gpuArrays;
+  const precomputedIntegrationData &gpu_precomputed_data_;
   Vector uk_el1;
   Vector uk_el2;
   Vector dun_face;
@@ -93,7 +93,7 @@ class Gradients : public ParNonlinearForm {
  public:
   Gradients(ParFiniteElementSpace *_vfes, ParFiniteElementSpace *_gradUpfes, int _dim, int _num_equation,
             ParGridFunction *_Up, ParGridFunction *_gradUp, GasMixture *_mixture, GradNonLinearForm *_gradUp_A,
-            IntegrationRules *_intRules, int _intRuleType, const precomputedIntegrationData &gpuArrays,
+            IntegrationRules *_intRules, int _intRuleType, const precomputedIntegrationData &gpu_precomputed_data,
             Array<DenseMatrix *> &Me_inv, Vector &_invMArray, Array<int> &_posDofInvM, const int &_maxIntPoints,
             const int &_maxDofs);
 
@@ -105,7 +105,7 @@ class Gradients : public ParNonlinearForm {
     dun_shared_face.UseDevice(true);
 
     int maxNumElems =
-        gpuArrays.shared_face_data.shared_elements_to_shared_faces.Size() / 7;  // elements with shared faces
+        gpu_precomputed_data_.shared_face_data.shared_elements_to_shared_faces.Size() / 7;  // elements with shared faces
     dun_shared_face.SetSize(dim_ * maxNumElems * 5 * maxIntPoints_ * num_equation_);
   }
 

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -68,7 +68,6 @@ class Gradients : public ParNonlinearForm {
   Vector dun_face;
 
   const int *h_numElems;
-  const int *h_posDofIds;
 
   // DenseMatrix *Me_inv;
   Array<DenseMatrix *> &Me_inv;

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -62,7 +62,7 @@ class Gradients : public ParNonlinearForm {
   IntegrationRules *intRules;
   const int intRuleType;
 
-  const volumeFaceIntegrationArrays &gpuArrays;
+  const precomputedIntegrationData &gpuArrays;
   Vector uk_el1;
   Vector uk_el2;
   Vector dun_face;
@@ -95,7 +95,7 @@ class Gradients : public ParNonlinearForm {
  public:
   Gradients(ParFiniteElementSpace *_vfes, ParFiniteElementSpace *_gradUpfes, int _dim, int _num_equation,
             ParGridFunction *_Up, ParGridFunction *_gradUp, GasMixture *_mixture, GradNonLinearForm *_gradUp_A,
-            IntegrationRules *_intRules, int _intRuleType, const volumeFaceIntegrationArrays &gpuArrays,
+            IntegrationRules *_intRules, int _intRuleType, const precomputedIntegrationData &gpuArrays,
             Array<DenseMatrix *> &Me_inv, Vector &_invMArray, Array<int> &_posDofInvM, const int &_maxIntPoints,
             const int &_maxDofs);
 

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -104,8 +104,11 @@ class Gradients : public ParNonlinearForm {
 
     dun_shared_face.UseDevice(true);
 
-    int maxNumElems =
-        gpu_precomputed_data_.shared_face_data.shared_elements_to_shared_faces.Size() / 7;  // elements with shared faces
+    const sharedFaceIntegrationData &shared_face_data = gpu_precomputed_data_.shared_face_data;
+
+    // number of elements with shared faces
+    int maxNumElems = shared_face_data.shared_elements_to_shared_faces.Size() / 7;
+
     dun_shared_face.SetSize(dim_ * maxNumElems * 5 * maxIntPoints_ * num_equation_);
   }
 

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -67,7 +67,7 @@ class Gradients : public ParNonlinearForm {
   Vector uk_el2;
   Vector dun_face;
 
-  const int *h_numElems;
+  const int *h_num_elems_of_type;
 
   // DenseMatrix *Me_inv;
   Array<DenseMatrix *> &Me_inv;

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -86,7 +86,6 @@ class Gradients : public ParNonlinearForm {
   //   Vector elemShapeDshapeWJ; // [...l_0(i),...,l_dof(i),l_0_x(i),...,l_dof_d(i), w_i*detJac_i ...]
   //   Array<int> elemPosQ_shapeDshapeWJ; // position and num. of integration points for each element
 
-  parallelFacesIntegrationArrays *parallelData;
   dataTransferArrays *transferUp;
 
   Vector dun_shared_face;
@@ -100,13 +99,12 @@ class Gradients : public ParNonlinearForm {
 
   ~Gradients();
 
-  void setParallelData(parallelFacesIntegrationArrays *_parData, dataTransferArrays *_transferUp) {
-    parallelData = _parData;
+  void setParallelData(dataTransferArrays *_transferUp) {
     transferUp = _transferUp;
 
     dun_shared_face.UseDevice(true);
 
-    int maxNumElems = parallelData->sharedElemsFaces.Size() / 7;  // elements with shared faces
+    int maxNumElems = gpuArrays.shared_face_data.sharedElemsFaces.Size() / 7;  // elements with shared faces
     dun_shared_face.SetSize(dim_ * maxNumElems * 5 * maxIntPoints_ * num_equation_);
   }
 

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -104,7 +104,8 @@ class Gradients : public ParNonlinearForm {
 
     dun_shared_face.UseDevice(true);
 
-    int maxNumElems = gpuArrays.shared_face_data.sharedElemsFaces.Size() / 7;  // elements with shared faces
+    int maxNumElems =
+        gpuArrays.shared_face_data.shared_elements_to_shared_faces.Size() / 7;  // elements with shared faces
     dun_shared_face.SetSize(dim_ * maxNumElems * 5 * maxIntPoints_ * num_equation_);
   }
 

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -544,12 +544,12 @@ void InletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
 
 void InletBC::integrationBC(Vector &y,  // output
                             const Vector &x, const elementIndexingData &elem_index_data,
-                            ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
-                            Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs) {
-  interpInlet_gpu(x, elem_index_data, shapesBC, normalsWBC, intPointsElIDBC, listElems, offsetsBoundaryU);
+                            ParGridFunction *Up, ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
+                            const int &maxIntPoints, const int &maxDofs) {
+  interpInlet_gpu(x, elem_index_data, boundary_face_data, listElems, offsetsBoundaryU);
 
   integrateInlets_gpu(y,  // output
-                      x, elem_index_data, shapesBC, normalsWBC, intPointsElIDBC, listElems, offsetsBoundaryU);
+                      x, elem_index_data, boundary_face_data, listElems, offsetsBoundaryU);
 }
 
 void InletBC::subsonicNonReflectingDensityVelocity(Vector &normal, Vector &stateIn, DenseMatrix &gradState,
@@ -735,16 +735,16 @@ void InletBC::subsonicReflectingDensityVelocity(Vector &normal, Vector &stateIn,
 }
 
 void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,
-                                  Vector &shapesBC, Vector &normalsWBC,
-                                  Array<int> &intPointsElIDBC, Array<int> &listElems, Array<int> &offsetsBoundaryU) {
+                                  boundaryFaceIntegrationData &boundary_face_data,
+                                  Array<int> &listElems, Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   double *d_y = y.Write();
   const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
   const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
-  const double *d_shapesBC = shapesBC.Read();
-  const double *d_normW = normalsWBC.Read();
-  const int *d_intPointsElIDBC = intPointsElIDBC.Read();
+  const double *d_shapesBC = boundary_face_data.shapesBC.Read();
+  const double *d_normW = boundary_face_data.normalsWBC.Read();
+  const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
   const int *d_listElems = listElems.Read();
   const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
 
@@ -800,7 +800,7 @@ void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndex
 }
 
 void InletBC::interpInlet_gpu(const mfem::Vector &x,  const elementIndexingData &elem_index_data,
-                              mfem::Vector &shapesBC, mfem::Vector &normalsWBC, Array<int> &intPointsElIDBC,
+                              boundaryFaceIntegrationData &boundary_face_data,
                               Array<int> &listElems, Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   const double *d_inputState = inputState.Read();
@@ -808,9 +808,9 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x,  const elementIndexingData 
   const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
   const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
-  const double *d_shapesBC = shapesBC.Read();
-  const double *d_normW = normalsWBC.Read();
-  const int *d_intPointsElIDBC = intPointsElIDBC.Read();
+  const double *d_shapesBC = boundary_face_data.shapesBC.Read();
+  const double *d_normW = boundary_face_data.normalsWBC.Read();
+  const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
   const int *d_listElems = listElems.Read();
   const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
 

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -543,13 +543,13 @@ void InletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
 }
 
 void InletBC::integrationBC(Vector &y,  // output
-                            const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+                            const Vector &x, const elementIndexingData &elem_index_data,
                             ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                             Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs) {
-  interpInlet_gpu(x, elem_dofs_list, posDofIds, shapesBC, normalsWBC, intPointsElIDBC, listElems, offsetsBoundaryU);
+  interpInlet_gpu(x, elem_index_data, shapesBC, normalsWBC, intPointsElIDBC, listElems, offsetsBoundaryU);
 
   integrateInlets_gpu(y,  // output
-                      x, elem_dofs_list, posDofIds, shapesBC, normalsWBC, intPointsElIDBC, listElems, offsetsBoundaryU);
+                      x, elem_index_data, shapesBC, normalsWBC, intPointsElIDBC, listElems, offsetsBoundaryU);
 }
 
 void InletBC::subsonicNonReflectingDensityVelocity(Vector &normal, Vector &stateIn, DenseMatrix &gradState,
@@ -734,13 +734,13 @@ void InletBC::subsonicReflectingDensityVelocity(Vector &normal, Vector &stateIn,
   rsolver->Eval(stateIn, state2, normal, bdrFlux, true);
 }
 
-void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const Array<int> &elem_dofs_list,
-                                  const Array<int> &posDofIds, Vector &shapesBC, Vector &normalsWBC,
+void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,
+                                  Vector &shapesBC, Vector &normalsWBC,
                                   Array<int> &intPointsElIDBC, Array<int> &listElems, Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   double *d_y = y.Write();
-  const int *d_elem_dofs_list = elem_dofs_list.Read();
-  const int *d_posDofIds = posDofIds.Read();
+  const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
+  const int *d_posDofIds = elem_index_data.posDofIds.Read();
   const double *d_shapesBC = shapesBC.Read();
   const double *d_normW = normalsWBC.Read();
   const int *d_intPointsElIDBC = intPointsElIDBC.Read();
@@ -798,14 +798,14 @@ void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const Array<int> &
 #endif
 }
 
-void InletBC::interpInlet_gpu(const mfem::Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+void InletBC::interpInlet_gpu(const mfem::Vector &x,  const elementIndexingData &elem_index_data,
                               mfem::Vector &shapesBC, mfem::Vector &normalsWBC, Array<int> &intPointsElIDBC,
                               Array<int> &listElems, Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   const double *d_inputState = inputState.Read();
   const double *d_U = x.Read();
-  const int *d_elem_dofs_list = elem_dofs_list.Read();
-  const int *d_posDofIds = posDofIds.Read();
+  const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
+  const int *d_posDofIds = elem_index_data.posDofIds.Read();
   const double *d_shapesBC = shapesBC.Read();
   const double *d_normW = normalsWBC.Read();
   const int *d_intPointsElIDBC = intPointsElIDBC.Read();

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -739,13 +739,13 @@ void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndex
                                   Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   double *d_y = y.Write();
-  const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
-  const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
-  const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
-  const double *d_face_shape = boundary_face_data.face_shape.Read();
-  const double *d_weight = boundary_face_data.face_quad_weight.Read();
-  const int *d_face_el = boundary_face_data.face_el.Read();
-  const int *d_face_num_quad = boundary_face_data.face_num_quad.Read();
+  const int *d_elem_dofs_list = elem_index_data.dofs_list.Read();
+  const int *d_elem_dof_off = elem_index_data.dof_offset.Read();
+  const int *d_elem_dof_num = elem_index_data.dof_number.Read();
+  const double *d_face_shape = boundary_face_data.shape.Read();
+  const double *d_weight = boundary_face_data.quad_weight.Read();
+  const int *d_face_el = boundary_face_data.el.Read();
+  const int *d_face_num_quad = boundary_face_data.num_quad.Read();
   const int *d_listElems = listElems.Read();
   const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
 
@@ -806,13 +806,13 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x, const elementIndexingData &
 #ifdef _GPU_
   const double *d_inputState = inputState.Read();
   const double *d_U = x.Read();
-  const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
-  const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
-  const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
-  const double *d_face_shape = boundary_face_data.face_shape.Read();
-  const double *d_normal = boundary_face_data.face_normal.Read();
-  const int *d_face_el = boundary_face_data.face_el.Read();
-  const int *d_face_num_quad = boundary_face_data.face_num_quad.Read();
+  const int *d_elem_dofs_list = elem_index_data.dofs_list.Read();
+  const int *d_elem_dof_off = elem_index_data.dof_offset.Read();
+  const int *d_elem_dof_num = elem_index_data.dof_number.Read();
+  const double *d_face_shape = boundary_face_data.shape.Read();
+  const double *d_normal = boundary_face_data.normal.Read();
+  const int *d_face_el = boundary_face_data.el.Read();
+  const int *d_face_num_quad = boundary_face_data.num_quad.Read();
   const int *d_listElems = listElems.Read();
   const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
 

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -543,8 +543,8 @@ void InletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
 }
 
 void InletBC::integrationBC(Vector &y,  // output
-                            const Vector &x, const elementIndexingData &elem_index_data,
-                            ParGridFunction *Up, ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
+                            const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
+                            ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
                             const int &maxIntPoints, const int &maxDofs) {
   interpInlet_gpu(x, elem_index_data, boundary_face_data, listElems, offsetsBoundaryU);
 
@@ -735,8 +735,8 @@ void InletBC::subsonicReflectingDensityVelocity(Vector &normal, Vector &stateIn,
 }
 
 void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,
-                                  boundaryFaceIntegrationData &boundary_face_data,
-                                  Array<int> &listElems, Array<int> &offsetsBoundaryU) {
+                                  boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
+                                  Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   double *d_y = y.Write();
   const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
@@ -800,9 +800,9 @@ void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndex
 #endif
 }
 
-void InletBC::interpInlet_gpu(const mfem::Vector &x,  const elementIndexingData &elem_index_data,
-                              boundaryFaceIntegrationData &boundary_face_data,
-                              Array<int> &listElems, Array<int> &offsetsBoundaryU) {
+void InletBC::interpInlet_gpu(const mfem::Vector &x, const elementIndexingData &elem_index_data,
+                              boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
+                              Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   const double *d_inputState = inputState.Read();
   const double *d_U = x.Read();

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -742,7 +742,7 @@ void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndex
   const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
   const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
-  const double *d_shapesBC = boundary_face_data.shapesBC.Read();
+  const double *d_face_shape = boundary_face_data.face_shape.Read();
   const double *d_normW = boundary_face_data.normalsWBC.Read();
   const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
   const int *d_listElems = listElems.Read();
@@ -783,7 +783,7 @@ void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndex
 
       // sum contributions to integral
       MFEM_FOREACH_THREAD(i, x, elDof) {
-        const double shape = d_shapesBC[i + q * maxDofs + el * maxIntPoints * maxDofs];
+        const double shape = d_face_shape[i + q * maxDofs + el * maxIntPoints * maxDofs];
         for (int eq = 0; eq < num_equation; eq++) Fcontrib[i + eq * elDof] -= Rflux[eq] * shape;
       }
       MFEM_SYNC_THREAD;
@@ -808,7 +808,7 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x,  const elementIndexingData 
   const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
   const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
-  const double *d_shapesBC = boundary_face_data.shapesBC.Read();
+  const double *d_face_shape = boundary_face_data.face_shape.Read();
   const double *d_normW = boundary_face_data.normalsWBC.Read();
   const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
   const int *d_listElems = listElems.Read();
@@ -860,7 +860,7 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x,  const elementIndexingData 
       for (int d = 0; d < dim; d++) nor[d] = d_normW[d + q * (dim + 1) + el * maxIntPoints * (dim + 1)];
 
       for (int i = 0; i < elDof; i++) {
-        shape[i] = d_shapesBC[i + q * maxDofs + el * maxIntPoints * maxDofs];
+        shape[i] = d_face_shape[i + q * maxDofs + el * maxIntPoints * maxDofs];
       }
 
       for (int eq = 0; eq < num_equation; eq++) {

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -744,7 +744,8 @@ void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndex
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
   const double *d_face_shape = boundary_face_data.face_shape.Read();
   const double *d_weight = boundary_face_data.face_quad_weight.Read();
-  const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
+  const int *d_face_el = boundary_face_data.face_el.Read();
+  const int *d_face_num_quad = boundary_face_data.face_num_quad.Read();
   const int *d_listElems = listElems.Read();
   const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
 
@@ -763,8 +764,8 @@ void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndex
     double Rflux[gpudata::MAXEQUATIONS];                                    // double Rflux[5];
 
     const int el = d_listElems[n];
-    const int Q = d_intPointsElIDBC[2 * el];
-    const int elID = d_intPointsElIDBC[2 * el + 1];
+    const int Q = d_face_num_quad[el];
+    const int elID = d_face_el[el];
     const int elOffset = d_elem_dof_off[elID];
     const int elDof = d_elem_dof_num[elID];
 
@@ -810,7 +811,8 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x,  const elementIndexingData 
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
   const double *d_face_shape = boundary_face_data.face_shape.Read();
   const double *d_normal = boundary_face_data.face_normal.Read();
-  const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
+  const int *d_face_el = boundary_face_data.face_el.Read();
+  const int *d_face_num_quad = boundary_face_data.face_num_quad.Read();
   const int *d_listElems = listElems.Read();
   const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
 
@@ -850,8 +852,8 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x,  const elementIndexingData 
     double p;
 
     const int el = d_listElems[n];
-    const int Q = d_intPointsElIDBC[2 * el];
-    const int elID = d_intPointsElIDBC[2 * el + 1];
+    const int Q = d_face_num_quad[el];
+    const int elID = d_face_el[el];
     const int elOffset = d_elem_dof_off[elID];
     const int elDof = d_elem_dof_num[elID];
 

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -544,7 +544,7 @@ void InletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
 
 void InletBC::integrationBC(Vector &y,  // output
                             const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
-                            ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
+                            ParGridFunction *gradUp, const boundaryFaceIntegrationData &boundary_face_data,
                             const int &maxIntPoints, const int &maxDofs) {
   interpInlet_gpu(x, elem_index_data, boundary_face_data, listElems, offsetsBoundaryU);
 
@@ -735,7 +735,7 @@ void InletBC::subsonicReflectingDensityVelocity(Vector &normal, Vector &stateIn,
 }
 
 void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,
-                                  boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
+                                  const boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
                                   Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   double *d_y = y.Write();
@@ -801,7 +801,7 @@ void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndex
 }
 
 void InletBC::interpInlet_gpu(const mfem::Vector &x, const elementIndexingData &elem_index_data,
-                              boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
+                              const boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
                               Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   const double *d_inputState = inputState.Read();

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -740,7 +740,8 @@ void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndex
 #ifdef _GPU_
   double *d_y = y.Write();
   const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
-  const int *d_posDofIds = elem_index_data.posDofIds.Read();
+  const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
+  const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
   const double *d_shapesBC = shapesBC.Read();
   const double *d_normW = normalsWBC.Read();
   const int *d_intPointsElIDBC = intPointsElIDBC.Read();
@@ -764,8 +765,8 @@ void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndex
     const int el = d_listElems[n];
     const int Q = d_intPointsElIDBC[2 * el];
     const int elID = d_intPointsElIDBC[2 * el + 1];
-    const int elOffset = d_posDofIds[2 * elID];
-    const int elDof = d_posDofIds[2 * elID + 1];
+    const int elOffset = d_elem_dof_off[elID];
+    const int elDof = d_elem_dof_num[elID];
 
     MFEM_FOREACH_THREAD(i, x, elDof) {
       for (int eq = 0; eq < num_equation; eq++) Fcontrib[i + eq * elDof] = 0.;
@@ -805,7 +806,8 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x,  const elementIndexingData 
   const double *d_inputState = inputState.Read();
   const double *d_U = x.Read();
   const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
-  const int *d_posDofIds = elem_index_data.posDofIds.Read();
+  const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
+  const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
   const double *d_shapesBC = shapesBC.Read();
   const double *d_normW = normalsWBC.Read();
   const int *d_intPointsElIDBC = intPointsElIDBC.Read();
@@ -850,8 +852,8 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x,  const elementIndexingData 
     const int el = d_listElems[n];
     const int Q = d_intPointsElIDBC[2 * el];
     const int elID = d_intPointsElIDBC[2 * el + 1];
-    const int elOffset = d_posDofIds[2 * elID];
-    const int elDof = d_posDofIds[2 * elID + 1];
+    const int elOffset = d_elem_dof_off[elID];
+    const int elDof = d_elem_dof_num[elID];
 
     // for (int q = 0; q < Q; q++) {
     MFEM_FOREACH_THREAD(q, x, Q) {

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -101,7 +101,7 @@ class InletBC : public BoundaryCondition {
   virtual void initBCs();
 
   virtual void integrationBC(Vector &y,  // output
-                             const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
+                             const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
                              ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                              Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs);
 
@@ -112,10 +112,10 @@ class InletBC : public BoundaryCondition {
   // functions for BC integration on GPU
 
   void integrateInlets_gpu(Vector &y,  // output
-                           const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds, Vector &shapesBC,
-                           Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
+                           const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+                           Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
                            Array<int> &offsetsBoundaryU);
-  void interpInlet_gpu(const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds, Vector &shapesBC,
+  void interpInlet_gpu(const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds, Vector &shapesBC,
                        Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
                        Array<int> &offsetsBoundaryU);
 

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -101,7 +101,7 @@ class InletBC : public BoundaryCondition {
   virtual void initBCs();
 
   virtual void integrationBC(Vector &y,  // output
-                             const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+                             const Vector &x, const elementIndexingData &elem_index_data,
                              ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                              Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs);
 
@@ -112,10 +112,10 @@ class InletBC : public BoundaryCondition {
   // functions for BC integration on GPU
 
   void integrateInlets_gpu(Vector &y,  // output
-                           const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+                           const Vector &x, const elementIndexingData &elem_index_data,
                            Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
                            Array<int> &offsetsBoundaryU);
-  void interpInlet_gpu(const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds, Vector &shapesBC,
+  void interpInlet_gpu(const Vector &x, const elementIndexingData &elem_index_data, Vector &shapesBC,
                        Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
                        Array<int> &offsetsBoundaryU);
 

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -102,8 +102,9 @@ class InletBC : public BoundaryCondition {
 
   virtual void integrationBC(Vector &y,  // output
                              const Vector &x, const elementIndexingData &elem_index_data,
-                             ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
-                             Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs);
+                             ParGridFunction *Up, ParGridFunction *gradUp,
+                             boundaryFaceIntegrationData &boundary_face_data, const int &maxIntPoints,
+                             const int &maxDofs);
 
   static void updateMean_gpu(ParGridFunction *Up, Vector &localMeanUp, const int _num_equation, const int numBdrElems,
                              const int totalDofs, Vector &bdrUp, Array<int> &bdrElemsQ, Array<int> &bdrDofs,
@@ -113,10 +114,10 @@ class InletBC : public BoundaryCondition {
 
   void integrateInlets_gpu(Vector &y,  // output
                            const Vector &x, const elementIndexingData &elem_index_data,
-                           Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
+                           boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
                            Array<int> &offsetsBoundaryU);
-  void interpInlet_gpu(const Vector &x, const elementIndexingData &elem_index_data, Vector &shapesBC,
-                       Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
+  void interpInlet_gpu(const Vector &x, const elementIndexingData &elem_index_data,
+                       boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
                        Array<int> &offsetsBoundaryU);
 
 #ifdef _GPU_

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -102,7 +102,7 @@ class InletBC : public BoundaryCondition {
 
   virtual void integrationBC(Vector &y,  // output
                              const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
-                             ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
+                             ParGridFunction *gradUp, const boundaryFaceIntegrationData &boundary_face_data,
                              const int &maxIntPoints, const int &maxDofs);
 
   static void updateMean_gpu(ParGridFunction *Up, Vector &localMeanUp, const int _num_equation, const int numBdrElems,
@@ -113,10 +113,10 @@ class InletBC : public BoundaryCondition {
 
   void integrateInlets_gpu(Vector &y,  // output
                            const Vector &x, const elementIndexingData &elem_index_data,
-                           boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
+                           const boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
                            Array<int> &offsetsBoundaryU);
   void interpInlet_gpu(const Vector &x, const elementIndexingData &elem_index_data,
-                       boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
+                       const boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
                        Array<int> &offsetsBoundaryU);
 
 #ifdef _GPU_

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -101,10 +101,9 @@ class InletBC : public BoundaryCondition {
   virtual void initBCs();
 
   virtual void integrationBC(Vector &y,  // output
-                             const Vector &x, const elementIndexingData &elem_index_data,
-                             ParGridFunction *Up, ParGridFunction *gradUp,
-                             boundaryFaceIntegrationData &boundary_face_data, const int &maxIntPoints,
-                             const int &maxDofs);
+                             const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
+                             ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
+                             const int &maxIntPoints, const int &maxDofs);
 
   static void updateMean_gpu(ParGridFunction *Up, Vector &localMeanUp, const int _num_equation, const int numBdrElems,
                              const int totalDofs, Vector &bdrUp, Array<int> &bdrElemsQ, Array<int> &bdrDofs,

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -1024,7 +1024,8 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementInd
   double *d_y = y.Write();
   const double *d_U = x.Read();
   const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
-  const int *d_posDofIds = elem_index_data.posDofIds.Read();
+  const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
+  const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
 
   const double *d_shapesBC = shapesBC.Read();
   const double *d_normW = normalsWBC.Read();
@@ -1053,8 +1054,8 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementInd
     const int Q    = d_intPointsElIDBC[2 * el  ];
     const int elID = d_intPointsElIDBC[2 * el + 1];
 
-    const int elOffset = d_posDofIds[2 * elID  ];
-    const int elDof    = d_posDofIds[2 * elID + 1];
+    const int elOffset = d_elem_dof_off[elID];
+    const int elDof = d_elem_dof_num[elID];
 
     MFEM_FOREACH_THREAD(i, x, elDof) {
       for ( int eq = 0; eq < num_equation; eq++ ) Fcontrib[i+eq*elDof] = 0.;
@@ -1096,7 +1097,8 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const elementIndexingData
   const double *d_U = x.Read();
   const double *d_gradUp = gradUp->Read();
   const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
-  const int *d_posDofIds = elem_index_data.posDofIds.Read();
+  const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
+  const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
   const double *d_shapesBC = shapesBC.Read();
   const double *d_normW = normalsWBC.Read();
   const int *d_intPointsElIDBC = intPointsElIDBC.Read();
@@ -1151,8 +1153,9 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const elementIndexingData
     const int offsetBdrU = d_offsetBoundaryU[n];
     const int Q = d_intPointsElIDBC[2 * el];
     const int elID = d_intPointsElIDBC[2 * el + 1];
-    const int elOffset = d_posDofIds[2 * elID];
-    const int elDof = d_posDofIds[2 * elID + 1];
+    const int elOffset = d_elem_dof_off[elID];
+    const int elDof = d_elem_dof_num[elID];
+
 
     // get data
     for (int i = 0; i < elDof; i++) {

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -550,14 +550,14 @@ void OutletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
   }
 }
 
-void OutletBC::integrationBC(Vector &y, const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+void OutletBC::integrationBC(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,
                              ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                              Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs) {
-  interpOutlet_gpu(x, elem_dofs_list, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, listElems,
+  interpOutlet_gpu(x, elem_index_data, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, listElems,
                    offsetsBoundaryU);
 
   integrateOutlets_gpu(y,  // output
-                       x, elem_dofs_list, posDofIds, shapesBC, normalsWBC, intPointsElIDBC, listElems,
+                       x, elem_index_data, shapesBC, normalsWBC, intPointsElIDBC, listElems,
                        offsetsBoundaryU);
 }
 
@@ -1017,14 +1017,14 @@ void OutletBC::subsonicNonRefPWMassFlow(Vector &normal, Vector &stateIn, DenseMa
   rsolver->Eval(stateIn, state2, normal, bdrFlux, true);
 }
 
-void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const Array<int> &elem_dofs_list,
-                                    const Array<int> &posDofIds, Vector &shapesBC, Vector &normalsWBC,
+void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,
+                                    Vector &shapesBC, Vector &normalsWBC,
                                     Array<int> &intPointsElIDBC, Array<int> &listElems, Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   double *d_y = y.Write();
   const double *d_U = x.Read();
-  const int *d_elem_dofs_list = elem_dofs_list.Read();
-  const int *d_posDofIds = posDofIds.Read();
+  const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
+  const int *d_posDofIds = elem_index_data.posDofIds.Read();
 
   const double *d_shapesBC = shapesBC.Read();
   const double *d_normW = normalsWBC.Read();
@@ -1087,7 +1087,7 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const Array<int>
   // clang-format on
 }
 
-void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const elementIndexingData &elem_index_data,
                                 mfem::ParGridFunction *Up, mfem::ParGridFunction *gradUp, mfem::Vector &shapesBC,
                                 mfem::Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
                                 Array<int> &offsetsBoundaryU) {
@@ -1095,8 +1095,8 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const Array<int> &elem_do
   const double *d_inputState = inputState.Read();
   const double *d_U = x.Read();
   const double *d_gradUp = gradUp->Read();
-  const int *d_elem_dofs_list = elem_dofs_list.Read();
-  const int *d_posDofIds = posDofIds.Read();
+  const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
+  const int *d_posDofIds = elem_index_data.posDofIds.Read();
   const double *d_shapesBC = shapesBC.Read();
   const double *d_normW = normalsWBC.Read();
   const int *d_intPointsElIDBC = intPointsElIDBC.Read();

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -461,8 +461,6 @@ void OutletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
 
   bdrN = 0;
 
-  int Nbdr = 0;
-
 #ifdef _GPU_
   DGNonLinearForm::setToZero_gpu(bdrUp, bdrUp.Size());
 
@@ -474,6 +472,7 @@ void OutletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
   if (!bdrUInit) initBoundaryU(Up);
 
 #else
+  int Nbdr = 0;
 
   Vector elUp;
   Vector shape;
@@ -1021,7 +1020,6 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementInd
                                     Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   double *d_y = y.Write();
-  const double *d_U = x.Read();
   const int *d_elem_dofs_list = elem_index_data.dofs_list.Read();
   const int *d_elem_dof_off = elem_index_data.dof_offset.Read();
   const int *d_elem_dof_num = elem_index_data.dof_number.Read();
@@ -1031,12 +1029,11 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementInd
   const int *d_face_el = boundary_face_data.el.Read();
   const int *d_face_num_quad = boundary_face_data.num_quad.Read();
   const int *d_listElems = listElems.Read();
-  const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
+  // const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
 
   const int totDofs = x.Size() / num_equation_;
   const int numBdrElem = listElems.Size();
 
-  const int dim = dim_;
   const int num_equation = num_equation_;
   const int maxIntPoints = maxIntPoints_;
   const int maxDofs = maxDofs_;

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -552,7 +552,8 @@ void OutletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
 
 void OutletBC::integrationBC(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,
                              ParGridFunction *Up, ParGridFunction *gradUp,
-                             boundaryFaceIntegrationData &boundary_face_data, const int &maxIntPoints, const int &maxDofs) {
+                             boundaryFaceIntegrationData &boundary_face_data, const int &maxIntPoints,
+                             const int &maxDofs) {
   interpOutlet_gpu(x, elem_index_data, Up, gradUp, boundary_face_data, listElems, offsetsBoundaryU);
 
   integrateOutlets_gpu(y,  // output
@@ -1016,8 +1017,8 @@ void OutletBC::subsonicNonRefPWMassFlow(Vector &normal, Vector &stateIn, DenseMa
 }
 
 void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,
-                                    boundaryFaceIntegrationData &boundary_face_data,
-                                    Array<int> &listElems, Array<int> &offsetsBoundaryU) {
+                                    boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
+                                    Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   double *d_y = y.Write();
   const double *d_U = x.Read();
@@ -1155,7 +1156,6 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const elementIndexingData
     const int elID = d_face_el[el];
     const int elOffset = d_elem_dof_off[elID];
     const int elDof = d_elem_dof_num[elID];
-
 
     // get data
     for (int i = 0; i < elDof; i++) {

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -1025,7 +1025,7 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementInd
   const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
 
-  const double *d_shapesBC = boundary_face_data.shapesBC.Read();
+  const double *d_face_shape = boundary_face_data.face_shape.Read();
   const double *d_normW = boundary_face_data.normalsWBC.Read();
   const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
   const int *d_listElems = listElems.Read();
@@ -1069,7 +1069,7 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementInd
       }
 
       MFEM_FOREACH_THREAD(i, x, elDof) {
-        const double shape = d_shapesBC[i + q * maxDofs + el * maxIntPoints * maxDofs];
+        const double shape = d_face_shape[i + q * maxDofs + el * maxIntPoints * maxDofs];
         for (int eq = 0; eq < num_equation; eq++) Fcontrib[i + eq * elDof] -= Rflux[eq] * shape;
       }
       MFEM_SYNC_THREAD;
@@ -1097,7 +1097,7 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const elementIndexingData
   const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
   const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
-  const double *d_shapesBC = boundary_face_data.shapesBC.Read();
+  const double *d_face_shape = boundary_face_data.face_shape.Read();
   const double *d_normW = boundary_face_data.normalsWBC.Read();
   const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
   const int *d_listElems = listElems.Read();
@@ -1172,7 +1172,7 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const elementIndexingData
 
       // extract shape functions at this quad point
       for (int j = 0; j < elDof; j++) {
-        shape[j] = d_shapesBC[j + q * maxDofs + el * maxIntPoints * maxDofs];
+        shape[j] = d_face_shape[j + q * maxDofs + el * maxIntPoints * maxDofs];
       }
 
       // extract normal vector at this quad point

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -552,7 +552,7 @@ void OutletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
 
 void OutletBC::integrationBC(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,
                              ParGridFunction *Up, ParGridFunction *gradUp,
-                             boundaryFaceIntegrationData &boundary_face_data, const int &maxIntPoints,
+                             const boundaryFaceIntegrationData &boundary_face_data, const int &maxIntPoints,
                              const int &maxDofs) {
   interpOutlet_gpu(x, elem_index_data, Up, gradUp, boundary_face_data, listElems, offsetsBoundaryU);
 
@@ -1017,7 +1017,7 @@ void OutletBC::subsonicNonRefPWMassFlow(Vector &normal, Vector &stateIn, DenseMa
 }
 
 void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,
-                                    boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
+                                    const boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
                                     Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   double *d_y = y.Write();
@@ -1090,7 +1090,7 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementInd
 
 void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const elementIndexingData &elem_index_data,
                                 mfem::ParGridFunction *Up, mfem::ParGridFunction *gradUp,
-                                boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
+                                const boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
                                 Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   const double *d_inputState = inputState.Read();

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -1022,14 +1022,14 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementInd
 #ifdef _GPU_
   double *d_y = y.Write();
   const double *d_U = x.Read();
-  const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
-  const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
-  const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
+  const int *d_elem_dofs_list = elem_index_data.dofs_list.Read();
+  const int *d_elem_dof_off = elem_index_data.dof_offset.Read();
+  const int *d_elem_dof_num = elem_index_data.dof_number.Read();
 
-  const double *d_face_shape = boundary_face_data.face_shape.Read();
-  const double *d_weight = boundary_face_data.face_quad_weight.Read();
-  const int *d_face_el = boundary_face_data.face_el.Read();
-  const int *d_face_num_quad = boundary_face_data.face_num_quad.Read();
+  const double *d_face_shape = boundary_face_data.shape.Read();
+  const double *d_weight = boundary_face_data.quad_weight.Read();
+  const int *d_face_el = boundary_face_data.el.Read();
+  const int *d_face_num_quad = boundary_face_data.num_quad.Read();
   const int *d_listElems = listElems.Read();
   const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
 
@@ -1096,13 +1096,13 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const elementIndexingData
   const double *d_inputState = inputState.Read();
   const double *d_U = x.Read();
   const double *d_gradUp = gradUp->Read();
-  const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
-  const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
-  const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
-  const double *d_face_shape = boundary_face_data.face_shape.Read();
-  const double *d_normal = boundary_face_data.face_normal.Read();
-  const int *d_face_el = boundary_face_data.face_el.Read();
-  const int *d_face_num_quad = boundary_face_data.face_num_quad.Read();
+  const int *d_elem_dofs_list = elem_index_data.dofs_list.Read();
+  const int *d_elem_dof_off = elem_index_data.dof_offset.Read();
+  const int *d_elem_dof_num = elem_index_data.dof_number.Read();
+  const double *d_face_shape = boundary_face_data.shape.Read();
+  const double *d_normal = boundary_face_data.normal.Read();
+  const int *d_face_el = boundary_face_data.el.Read();
+  const int *d_face_num_quad = boundary_face_data.num_quad.Read();
   const int *d_listElems = listElems.Read();
   const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
   const double *d_meanUp = meanUp.Read();

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -550,14 +550,15 @@ void OutletBC::updateMean(IntegrationRules *intRules, ParGridFunction *Up) {
   }
 }
 
-void OutletBC::integrationBC(Vector &y, const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
+void OutletBC::integrationBC(Vector &y, const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
                              ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                              Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs) {
-  interpOutlet_gpu(x, nodesIDs, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, listElems,
+  interpOutlet_gpu(x, elem_dofs_list, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, listElems,
                    offsetsBoundaryU);
 
   integrateOutlets_gpu(y,  // output
-                       x, nodesIDs, posDofIds, shapesBC, normalsWBC, intPointsElIDBC, listElems, offsetsBoundaryU);
+                       x, elem_dofs_list, posDofIds, shapesBC, normalsWBC, intPointsElIDBC, listElems,
+                       offsetsBoundaryU);
 }
 
 void OutletBC::subsonicNonReflectingPressure(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector &bdrFlux) {
@@ -1016,13 +1017,13 @@ void OutletBC::subsonicNonRefPWMassFlow(Vector &normal, Vector &stateIn, DenseMa
   rsolver->Eval(stateIn, state2, normal, bdrFlux, true);
 }
 
-void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
-                                    Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
-                                    Array<int> &listElems, Array<int> &offsetsBoundaryU) {
+void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const Array<int> &elem_dofs_list,
+                                    const Array<int> &posDofIds, Vector &shapesBC, Vector &normalsWBC,
+                                    Array<int> &intPointsElIDBC, Array<int> &listElems, Array<int> &offsetsBoundaryU) {
 #ifdef _GPU_
   double *d_y = y.Write();
   const double *d_U = x.Read();
-  const int *d_nodesIDs = nodesIDs.Read();
+  const int *d_elem_dofs_list = elem_dofs_list.Read();
   const int *d_posDofIds = posDofIds.Read();
 
   const double *d_shapesBC = shapesBC.Read();
@@ -1077,7 +1078,7 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const Array<int>
 
     // add to global data
     MFEM_FOREACH_THREAD(i, x, elDof) {
-      const int indexi = d_nodesIDs[elOffset + i];
+      const int indexi = d_elem_dofs_list[elOffset + i];
       for (int eq = 0; eq < num_equation; eq++) d_y[indexi + eq * totDofs] += Fcontrib[i + eq * elDof];
     }
     MFEM_SYNC_THREAD;
@@ -1086,7 +1087,7 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const Array<int>
   // clang-format on
 }
 
-void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
+void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
                                 mfem::ParGridFunction *Up, mfem::ParGridFunction *gradUp, mfem::Vector &shapesBC,
                                 mfem::Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
                                 Array<int> &offsetsBoundaryU) {
@@ -1094,7 +1095,7 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const Array<int> &nodesID
   const double *d_inputState = inputState.Read();
   const double *d_U = x.Read();
   const double *d_gradUp = gradUp->Read();
-  const int *d_nodesIDs = nodesIDs.Read();
+  const int *d_elem_dofs_list = elem_dofs_list.Read();
   const int *d_posDofIds = posDofIds.Read();
   const double *d_shapesBC = shapesBC.Read();
   const double *d_normW = normalsWBC.Read();
@@ -1155,7 +1156,7 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const Array<int> &nodesID
 
     // get data
     for (int i = 0; i < elDof; i++) {
-      index_i[i] = d_nodesIDs[elOffset + i];
+      index_i[i] = d_elem_dofs_list[elOffset + i];
     }
 
     // for (int q = 0; q < Q; q++) {

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -1027,7 +1027,8 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementInd
 
   const double *d_face_shape = boundary_face_data.face_shape.Read();
   const double *d_weight = boundary_face_data.face_quad_weight.Read();
-  const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
+  const int *d_face_el = boundary_face_data.face_el.Read();
+  const int *d_face_num_quad = boundary_face_data.face_num_quad.Read();
   const int *d_listElems = listElems.Read();
   const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
 
@@ -1049,8 +1050,8 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementInd
 
     const int el = d_listElems[n];
 
-    const int Q    = d_intPointsElIDBC[2 * el  ];
-    const int elID = d_intPointsElIDBC[2 * el + 1];
+    const int Q    = d_face_num_quad[el];
+    const int elID = d_face_el[el];
 
     const int elOffset = d_elem_dof_off[elID];
     const int elDof = d_elem_dof_num[elID];
@@ -1099,7 +1100,8 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const elementIndexingData
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
   const double *d_face_shape = boundary_face_data.face_shape.Read();
   const double *d_normal = boundary_face_data.face_normal.Read();
-  const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
+  const int *d_face_el = boundary_face_data.face_el.Read();
+  const int *d_face_num_quad = boundary_face_data.face_num_quad.Read();
   const int *d_listElems = listElems.Read();
   const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
   const double *d_meanUp = meanUp.Read();
@@ -1149,8 +1151,8 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const elementIndexingData
 
     const int el = d_listElems[n];
     const int offsetBdrU = d_offsetBoundaryU[n];
-    const int Q = d_intPointsElIDBC[2 * el];
-    const int elID = d_intPointsElIDBC[2 * el + 1];
+    const int Q = d_face_num_quad[el];
+    const int elID = d_face_el[el];
     const int elOffset = d_elem_dof_off[elID];
     const int elDof = d_elem_dof_num[elID];
 

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -1026,7 +1026,7 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementInd
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
 
   const double *d_face_shape = boundary_face_data.face_shape.Read();
-  const double *d_normW = boundary_face_data.normalsWBC.Read();
+  const double *d_weight = boundary_face_data.face_quad_weight.Read();
   const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
   const int *d_listElems = listElems.Read();
   const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
@@ -1061,7 +1061,7 @@ void OutletBC::integrateOutlets_gpu(Vector &y, const Vector &x, const elementInd
     MFEM_SYNC_THREAD;
 
     for (int q = 0; q < Q; q++) {  // loop over int. points
-      const double weight = d_normW[dim + q * (dim + 1) + el * maxIntPoints * (dim + 1)];
+      const double weight = d_weight[el * maxIntPoints + q];
 
       // get interpolated data
       for (int eq = 0; eq < num_equation; eq++) {
@@ -1098,7 +1098,7 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const elementIndexingData
   const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
   const double *d_face_shape = boundary_face_data.face_shape.Read();
-  const double *d_normW = boundary_face_data.normalsWBC.Read();
+  const double *d_normal = boundary_face_data.face_normal.Read();
   const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
   const int *d_listElems = listElems.Read();
   const int *d_offsetBoundaryU = offsetsBoundaryU.Read();
@@ -1177,7 +1177,7 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const elementIndexingData
 
       // extract normal vector at this quad point
       for (int d = 0; d < dim; d++) {
-        nor[d] = d_normW[d + q * (dim + 1) + el * maxIntPoints * (dim + 1)];
+        nor[d] = d_normal[el * maxIntPoints * dim + q * dim + d];
       }
 
       // interpolate to this quad point

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -109,7 +109,7 @@ class OutletBC : public BoundaryCondition {
 
   virtual void integrationBC(Vector &y,  // output
                              const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
-                             ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
+                             ParGridFunction *gradUp, const boundaryFaceIntegrationData &boundary_face_data,
                              const int &maxIntPoints, const int &maxDofs);
 
   static void updateMean_gpu(ParGridFunction *Up, Vector &localMeanUp, const int _num_equation, const int numBdrElems,
@@ -120,12 +120,12 @@ class OutletBC : public BoundaryCondition {
 
   void integrateOutlets_gpu(Vector &y,  // output
                             const Vector &x, const elementIndexingData &elem_index_data,
-                            boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
+                            const boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
                             Array<int> &offsetBoundaryU);
 
   void interpOutlet_gpu(const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
-                        ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
-                        Array<int> &offsetsBoundaryU);
+                        ParGridFunction *gradUp, const boundaryFaceIntegrationData &boundary_face_data,
+                        Array<int> &listElems, Array<int> &offsetsBoundaryU);
 
 #ifdef _GPU_  // GPU functions
   static MFEM_HOST_DEVICE void computeSubPressure(const double *u1, double *u2, const double *nor, const double &press,

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -108,7 +108,7 @@ class OutletBC : public BoundaryCondition {
   virtual void initBCs();
 
   virtual void integrationBC(Vector &y,  // output
-                             const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
+                             const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
                              ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                              Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs);
 
@@ -119,13 +119,13 @@ class OutletBC : public BoundaryCondition {
   // functions for BC integration on GPU
 
   void integrateOutlets_gpu(Vector &y,  // output
-                            const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds, Vector &shapesBC,
-                            Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
+                            const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+                            Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
                             Array<int> &offsetBoundaryU);
 
-  void interpOutlet_gpu(const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds, ParGridFunction *Up,
-                        ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
-                        Array<int> &listElems, Array<int> &offsetsBoundaryU);
+  void interpOutlet_gpu(const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+                        ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
+                        Array<int> &intPointsElIDBC, Array<int> &listElems, Array<int> &offsetsBoundaryU);
 
 #ifdef _GPU_  // GPU functions
   static MFEM_HOST_DEVICE void computeSubPressure(const double *u1, double *u2, const double *nor, const double &press,

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -108,7 +108,7 @@ class OutletBC : public BoundaryCondition {
   virtual void initBCs();
 
   virtual void integrationBC(Vector &y,  // output
-                             const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+                             const Vector &x, const elementIndexingData &elem_index_data,
                              ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                              Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs);
 
@@ -119,11 +119,11 @@ class OutletBC : public BoundaryCondition {
   // functions for BC integration on GPU
 
   void integrateOutlets_gpu(Vector &y,  // output
-                            const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+                            const Vector &x, const elementIndexingData &elem_index_data,
                             Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
                             Array<int> &offsetBoundaryU);
 
-  void interpOutlet_gpu(const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+  void interpOutlet_gpu(const Vector &x, const elementIndexingData &elem_index_data,
                         ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                         Array<int> &intPointsElIDBC, Array<int> &listElems, Array<int> &offsetsBoundaryU);
 

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -108,9 +108,8 @@ class OutletBC : public BoundaryCondition {
   virtual void initBCs();
 
   virtual void integrationBC(Vector &y,  // output
-                             const Vector &x, const elementIndexingData &elem_index_data,
-                             ParGridFunction *Up, ParGridFunction *gradUp,
-                             boundaryFaceIntegrationData &boundary_face_data,
+                             const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
+                             ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
                              const int &maxIntPoints, const int &maxDofs);
 
   static void updateMean_gpu(ParGridFunction *Up, Vector &localMeanUp, const int _num_equation, const int numBdrElems,
@@ -124,9 +123,9 @@ class OutletBC : public BoundaryCondition {
                             boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
                             Array<int> &offsetBoundaryU);
 
-  void interpOutlet_gpu(const Vector &x, const elementIndexingData &elem_index_data,
-                        ParGridFunction *Up, ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
-                        Array<int> &listElems, Array<int> &offsetsBoundaryU);
+  void interpOutlet_gpu(const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
+                        ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
+                        Array<int> &offsetsBoundaryU);
 
 #ifdef _GPU_  // GPU functions
   static MFEM_HOST_DEVICE void computeSubPressure(const double *u1, double *u2, const double *nor, const double &press,

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -109,8 +109,9 @@ class OutletBC : public BoundaryCondition {
 
   virtual void integrationBC(Vector &y,  // output
                              const Vector &x, const elementIndexingData &elem_index_data,
-                             ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
-                             Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs);
+                             ParGridFunction *Up, ParGridFunction *gradUp,
+                             boundaryFaceIntegrationData &boundary_face_data,
+                             const int &maxIntPoints, const int &maxDofs);
 
   static void updateMean_gpu(ParGridFunction *Up, Vector &localMeanUp, const int _num_equation, const int numBdrElems,
                              const int totalDofs, Vector &bdrUp, Array<int> &bdrElemsQ, Array<int> &bdrDofs,
@@ -120,12 +121,12 @@ class OutletBC : public BoundaryCondition {
 
   void integrateOutlets_gpu(Vector &y,  // output
                             const Vector &x, const elementIndexingData &elem_index_data,
-                            Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, Array<int> &listElems,
+                            boundaryFaceIntegrationData &boundary_face_data, Array<int> &listElems,
                             Array<int> &offsetBoundaryU);
 
   void interpOutlet_gpu(const Vector &x, const elementIndexingData &elem_index_data,
-                        ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
-                        Array<int> &intPointsElIDBC, Array<int> &listElems, Array<int> &offsetsBoundaryU);
+                        ParGridFunction *Up, ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
+                        Array<int> &listElems, Array<int> &offsetsBoundaryU);
 
 #ifdef _GPU_  // GPU functions
   static MFEM_HOST_DEVICE void computeSubPressure(const double *u1, double *u2, const double *nor, const double &press,

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -122,9 +122,9 @@ RHSoperator::RHSoperator(int &_iter, const int _dim, const int &_num_equation, c
   }
 
   if (_config.GetWorkingFluid() != WorkingFluid::DRY_AIR) {
-    forcing.Append(new SourceTerm(dim_, num_equation_, _order, intRuleType, intRules, vfes, U_, Up, gradUp, gpu_precomputed_data_,
-                                  _config, mixture, d_mixture_, _transport, _chemistry, _radiation,
-                                  plasma_conductivity_));
+    forcing.Append(new SourceTerm(dim_, num_equation_, _order, intRuleType, intRules, vfes, U_, Up, gradUp,
+                                  gpu_precomputed_data_, _config, mixture, d_mixture_, _transport, _chemistry,
+                                  _radiation, plasma_conductivity_));
   }
 #ifdef HAVE_MASA
   if (config_.use_mms_) {
@@ -136,7 +136,8 @@ RHSoperator::RHSoperator(int &_iter, const int _dim, const int &_num_equation, c
 
   if (config_.isAxisymmetric()) {
     forcing.Append(new AxisymmetricSource(dim_, num_equation_, _order, mixture, transport_, eqSystem, intRuleType,
-                                          intRules, vfes, U_, Up, gradUp, spaceVaryViscMult, gpu_precomputed_data_, _config));
+                                          intRules, vfes, U_, Up, gradUp, spaceVaryViscMult, gpu_precomputed_data_,
+                                          _config));
     const FiniteElementCollection *fec = vfes->FEColl();
     dfes = new ParFiniteElementSpace(mesh, fec, dim_, Ordering::byNODES);
     coordsDof = new ParGridFunction(dfes);

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -659,7 +659,7 @@ void RHSoperator::multiPlyInvers_gpu(Vector &y, Vector &z, const volumeFaceInteg
 #ifdef _GPU_
   double *d_y = y.ReadWrite();
   const double *d_z = z.Read();
-  auto d_nodesIDs = gpuArrays.nodesIDs.Read();
+  auto d_elem_dofs_list = gpuArrays.element_dofs_list.Read();
   auto d_posDofIds = gpuArrays.posDofIds.Read();
   auto d_posDofInvM = posDofInvM.Read();
   const double *d_invM = invMArray.Read();
@@ -672,7 +672,7 @@ void RHSoperator::multiPlyInvers_gpu(Vector &y, Vector &z, const volumeFaceInteg
     int offsetIds = d_posDofIds[2 * eli];
 
     MFEM_FOREACH_THREAD(i, x, dof) {
-      int index = d_nodesIDs[offsetIds + i];
+      int index = d_elem_dofs_list[offsetIds + i];
       for (int eq = 0; eq < num_equation; eq++) {
         data[i + eq * dof] = d_z[index + eq * totNumDof];
       }
@@ -680,7 +680,7 @@ void RHSoperator::multiPlyInvers_gpu(Vector &y, Vector &z, const volumeFaceInteg
     MFEM_SYNC_THREAD;
 
     MFEM_FOREACH_THREAD(i, x, dof) {
-      int index = d_nodesIDs[offsetIds + i];
+      int index = d_elem_dofs_list[offsetIds + i];
       for (int eq = 0; eq < num_equation; eq++) {
         double tmp = 0.;
         for (int k = 0; k < dof; k++) tmp += d_invM[offsetInv + i * dof + k] * data[k + eq * dof];

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -206,7 +206,7 @@ RHSoperator::RHSoperator(int &_iter, const int _dim, const int &_num_equation, c
   auto hinvMArray = invMArray.HostWrite();
   for (int i = 0; i < static_cast<int>(temp.size()); i++) hinvMArray[i] = temp[i];
 
-  fillSharedData();
+  allocateTransferData();
 
   A->setParallelData(&transferU, &transferGradUp);
 
@@ -696,7 +696,7 @@ void RHSoperator::multiPlyInvers_gpu(Vector &y, Vector &z, const precomputedInte
 #endif
 }
 
-void RHSoperator::fillSharedData() {
+void RHSoperator::allocateTransferData() {
   ParFiniteElementSpace *pfes = Up->ParFESpace();
   ParMesh *mesh = pfes->GetParMesh();
   mesh->ExchangeFaceNbrNodes();

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -89,7 +89,7 @@ RHSoperator::RHSoperator(int &_iter, const int _dim, const int &_num_equation, c
   zk.SetSize(vfes->GetNDofs());
 
   const elementIndexingData &elem_data = gpuArrays.element_indexing_data;
-  h_numElems = elem_data.numElems.HostRead();
+  h_num_elems_of_type = elem_data.num_elems_of_type.HostRead();
 
   Me_inv.SetSize(vfes->GetNE());
   Me_inv_rad.SetSize(vfes->GetNE());
@@ -384,16 +384,16 @@ void RHSoperator::Mult(const Vector &x, Vector &y) const {
 #ifdef _GPU_
   const elementIndexingData &elem_data = gpuArrays.element_indexing_data;
   auto h_elem_dof_num = elem_data.element_dof_number.HostRead();
-  for (int eltype = 0; eltype < elem_data.numElems.Size(); eltype++) {
+  for (int eltype = 0; eltype < elem_data.num_elems_of_type.Size(); eltype++) {
     int elemOffset = 0;
     if (eltype != 0) {
-      for (int i = 0; i < eltype; i++) elemOffset += h_numElems[i];
+      for (int i = 0; i < eltype; i++) elemOffset += h_num_elems_of_type[i];
     }
     int dof = h_elem_dof_num[elemOffset];
     const int totDofs = vfes->GetNDofs();
 
-    RHSoperator::multiPlyInvers_gpu(y, z, gpuArrays, invMArray, posDofInvM, num_equation_, totDofs, h_numElems[eltype],
-                                    elemOffset, dof);
+    RHSoperator::multiPlyInvers_gpu(y, z, gpuArrays, invMArray, posDofInvM, num_equation_, totDofs,
+                                    h_num_elems_of_type[eltype], elemOffset, dof);
   }
 
 #else

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -210,11 +210,6 @@ RHSoperator::RHSoperator(int &_iter, const int _dim, const int &_num_equation, c
 
   A->setParallelData(&transferU, &transferGradUp);
 
-#ifdef _GPU_
-  auto dposDogInvM = posDofInvM.ReadWrite();
-  auto dinvMarray = invMArray.ReadWrite();
-#endif
-
   // create gradients object
   gradients = new Gradients(vfes, gradUpfes, dim_, num_equation_, Up, gradUp, mixture, gradUp_A, intRules, intRuleType,
                             gpu_precomputed_data_, Me_inv, invMArray, posDofInvM, maxIntPoints, maxDofs);

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -208,7 +208,7 @@ RHSoperator::RHSoperator(int &_iter, const int _dim, const int &_num_equation, c
 
   fillSharedData();
 
-  A->setParallelData(&parallelData, &transferU, &transferGradUp);
+  A->setParallelData(&transferU, &transferGradUp);
 
 #ifdef _GPU_
   auto dposDogInvM = posDofInvM.ReadWrite();
@@ -218,7 +218,7 @@ RHSoperator::RHSoperator(int &_iter, const int _dim, const int &_num_equation, c
   // create gradients object
   gradients = new Gradients(vfes, gradUpfes, dim_, num_equation_, Up, gradUp, mixture, gradUp_A, intRules, intRuleType,
                             gpuArrays, Me_inv, invMArray, posDofInvM, maxIntPoints, maxDofs);
-  gradients->setParallelData(&parallelData, &transferUp);
+  gradients->setParallelData(&transferUp);
 
   local_timeDerivatives.UseDevice(true);
   local_timeDerivatives.SetSize(num_equation_);
@@ -707,127 +707,7 @@ void RHSoperator::fillSharedData() {
 
   const int Nshared = mesh->GetNSharedFaces();
   if (Nshared > 0) {
-    parallelData.sharedShapeWnor1.UseDevice(true);
-    parallelData.sharedShape2.UseDevice(true);
-
-    parallelData.sharedShapeWnor1.SetSize(Nshared * maxIntPoints * (maxDofs + 1 + dim_));
-    parallelData.sharedShape2.SetSize(Nshared * maxIntPoints * maxDofs);
-    parallelData.sharedElem1Dof12Q.SetSize(Nshared * 4);
-    parallelData.sharedVdofs.SetSize(Nshared * num_equation_ * maxDofs);
-    parallelData.sharedVdofsGradUp.SetSize(Nshared * num_equation_ * maxDofs * dim_);
-
-    parallelData.sharedShapeWnor1 = 0.;
-    parallelData.sharedShape2 = 0.;
-    parallelData.sharedElem1Dof12Q = 0;
-    parallelData.sharedVdofs = 0;
-    parallelData.sharedVdofsGradUp = 0;
-
-    auto hsharedShapeWnor1 = parallelData.sharedShapeWnor1.HostReadWrite();
-    auto hsharedShape2 = parallelData.sharedShape2.HostReadWrite();
-    auto hsharedElem1Dof12Q = parallelData.sharedElem1Dof12Q.HostReadWrite();
-    auto hsharedVdofs = parallelData.sharedVdofs.HostReadWrite();
-    auto hsharedVdofsGrads = parallelData.sharedVdofsGradUp.HostReadWrite();
-
-    std::vector<int> unicElems;
-    unicElems.clear();
-
-    Array<int> vdofs2, vdofsGrad;
-    FaceElementTransformations *tr;
-    for (int i = 0; i < Nshared; i++) {
-      tr = mesh->GetSharedFaceTransformations(i, true);
-      int Elem2NbrNo = tr->Elem2No - mesh->GetNE();
-
-      const FiniteElement *fe1 = vfes->GetFE(tr->Elem1No);
-      const FiniteElement *fe2 = vfes->GetFaceNbrFE(Elem2NbrNo);
-      const int dof1 = fe1->GetDof();
-      const int dof2 = fe2->GetDof();
-
-      // vfes->GetElementVDofs(tr->Elem1No, vdofs1); // get these from nodesIDs
-      vfes->GetFaceNbrElementVDofs(Elem2NbrNo, vdofs2);
-      gradFes->GetFaceNbrElementVDofs(Elem2NbrNo, vdofsGrad);
-
-      for (int n = 0; n < dof2; n++) {
-        for (int eq = 0; eq < num_equation_; eq++) {
-          hsharedVdofs[n + eq * maxDofs + i * num_equation_ * maxDofs] = vdofs2[n + eq * dof2];
-          for (int d = 0; d < dim_; d++) {
-            int index = n + eq * maxDofs + d * num_equation_ * maxDofs + i * dim_ * num_equation_ * maxDofs;
-            hsharedVdofsGrads[index] = vdofsGrad[n + eq * dof2 + d * num_equation_ * dof2];
-          }
-        }
-      }
-
-      int intorder;
-      if (tr->Elem2No >= 0) {
-        intorder = (min(tr->Elem1->OrderW(), tr->Elem2->OrderW()) + 2 * max(fe1->GetOrder(), fe2->GetOrder()));
-      } else {
-        intorder = tr->Elem1->OrderW() + 2 * fe1->GetOrder();
-      }
-      if (fe1->Space() == FunctionSpace::Pk) {
-        intorder++;
-      }
-      // IntegrationRules IntRules2(0, Quadrature1D::GaussLobatto);
-      const IntegrationRule *ir = &intRules->Get(tr->GetGeometryType(), intorder);
-
-      hsharedElem1Dof12Q[0 + i * 4] = tr->Elem1No;
-      hsharedElem1Dof12Q[1 + i * 4] = dof1;
-      hsharedElem1Dof12Q[2 + i * 4] = dof2;
-      hsharedElem1Dof12Q[3 + i * 4] = ir->GetNPoints();
-
-      bool inList = false;
-      for (size_t n = 0; n < unicElems.size(); n++) {
-        if (unicElems[n] == tr->Elem1No) inList = true;
-      }
-      if (!inList) unicElems.push_back(tr->Elem1No);
-
-      Vector shape1, shape2, nor;
-      shape1.UseDevice(false);
-      shape2.UseDevice(false);
-      nor.UseDevice(false);
-      shape1.SetSize(dof1);
-      shape2.SetSize(dof2);
-      nor.SetSize(dim_);
-
-      for (int q = 0; q < ir->GetNPoints(); q++) {
-        const IntegrationPoint &ip = ir->IntPoint(q);
-        tr->SetAllIntPoints(&ip);
-
-        fe1->CalcShape(tr->GetElement1IntPoint(), shape1);
-        fe2->CalcShape(tr->GetElement2IntPoint(), shape2);
-        CalcOrtho(tr->Jacobian(), nor);
-
-        for (int n = 0; n < dof1; n++) {
-          hsharedShapeWnor1[n + q * (maxDofs + 1 + dim_) + i * maxIntPoints * (maxDofs + 1 + dim_)] = shape1[n];
-        }
-        hsharedShapeWnor1[maxDofs + q * (maxDofs + 1 + dim_) + i * maxIntPoints * (maxDofs + 1 + dim_)] = ip.weight;
-
-        for (int d = 0; d < dim_; d++)
-          hsharedShapeWnor1[maxDofs + 1 + d + q * (maxDofs + 1 + dim_) + i * maxIntPoints * (maxDofs + 1 + dim_)] =
-              nor[d];
-        for (int n = 0; n < dof2; n++) {
-          hsharedShape2[n + q * maxDofs + i * maxIntPoints * maxDofs] = shape2[n];
-        }
-      }
-    }
-
-    parallelData.sharedElemsFaces.SetSize(7 * unicElems.size());
-    parallelData.sharedElemsFaces = -1;
-    auto hsharedElemsFaces = parallelData.sharedElemsFaces.HostWrite();
-    for (size_t el = 0; el < unicElems.size(); el++) {
-      const int eli = unicElems[el];
-      for (int f = 0; f < parallelData.sharedElem1Dof12Q.Size() / 4; f++) {
-        if (eli == hsharedElem1Dof12Q[0 + f * 4]) {
-          hsharedElemsFaces[0 + 7 * el] = hsharedElem1Dof12Q[0 + f * 4];
-          int numFace = hsharedElemsFaces[1 + 7 * el];
-          if (numFace == -1) numFace = 0;
-          numFace++;
-          hsharedElemsFaces[1 + numFace + 7 * el] = f;
-          hsharedElemsFaces[1 + 7 * el] = numFace;
-        }
-      }
-    }
-
     // data transfer arrays
-
     vfes->ExchangeFaceNbrData();
     gradUpfes->ExchangeFaceNbrData();
     transferU.face_nbr_data.UseDevice(true);
@@ -865,13 +745,6 @@ void RHSoperator::fillSharedData() {
     transferUp.statuses = new MPI_Status[transferUp.num_face_nbrs];
     transferGradUp.statuses = new MPI_Status[transferGradUp.num_face_nbrs];
   } else {
-    parallelData.sharedShapeWnor1.SetSize(1);
-    parallelData.sharedShape2.SetSize(1);
-    parallelData.sharedElem1Dof12Q.SetSize(1);
-    parallelData.sharedVdofs.SetSize(1);
-    parallelData.sharedVdofsGradUp.SetSize(1);
-    parallelData.sharedElemsFaces.SetSize(1);
-
     transferU.requests = NULL;
     transferUp.requests = NULL;
     transferGradUp.requests = NULL;
@@ -880,15 +753,6 @@ void RHSoperator::fillSharedData() {
     transferUp.statuses = NULL;
     transferGradUp.statuses = NULL;
   }
-
-#ifdef _GPU_
-  auto dsharedShapeWnor1 = parallelData.sharedShapeWnor1.ReadWrite();
-  auto dsharedShape2 = parallelData.sharedShape2.ReadWrite();
-  auto dsharedElemDof12Q = parallelData.sharedElem1Dof12Q.ReadWrite();
-  auto dsharedVdofs = parallelData.sharedVdofs.ReadWrite();
-  auto dsharedVdofsGradUp = parallelData.sharedVdofsGradUp.ReadWrite();
-  auto dsharedElemsFaces = parallelData.sharedElemsFaces.ReadWrite();
-#endif
 }
 
 void RHSoperator::initNBlockDataTransfer(const Vector &x, ParFiniteElementSpace *pfes,

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -383,7 +383,7 @@ void RHSoperator::Mult(const Vector &x, Vector &y) const {
   // 3. Multiply element-wise by the inverse mass matrices.
 #ifdef _GPU_
   const elementIndexingData &elem_data = gpuArrays.element_indexing_data;
-  auto h_elem_dof_num = elem_data.element_dof_number.HostRead();
+  auto h_elem_dof_num = elem_data.dof_number.HostRead();
   for (int eltype = 0; eltype < elem_data.num_elems_of_type.Size(); eltype++) {
     int elemOffset = 0;
     if (eltype != 0) {
@@ -663,8 +663,8 @@ void RHSoperator::multiPlyInvers_gpu(Vector &y, Vector &z, const precomputedInte
   const double *d_z = z.Read();
 
   const elementIndexingData &elem_data = gpuArrays.element_indexing_data;
-  auto d_elem_dofs_list = elem_data.element_dofs_list.Read();
-  auto d_elem_dof_off = elem_data.element_dof_offset.Read();
+  auto d_elem_dofs_list = elem_data.dofs_list.Read();
+  auto d_elem_dof_off = elem_data.dof_offset.Read();
   auto d_posDofInvM = posDofInvM.Read();
   const double *d_invM = invMArray.Read();
 

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -80,7 +80,7 @@ class RHSoperator : public TimeDependentOperator {
 
   ParFiniteElementSpace *vfes;
 
-  const precomputedIntegrationData &gpuArrays;
+  const precomputedIntegrationData &gpu_precomputed_data_;
 
   const int *h_num_elems_of_type;
 
@@ -146,7 +146,7 @@ class RHSoperator : public TimeDependentOperator {
   RHSoperator(int &_iter, const int _dim, const int &_num_equation, const int &_order, const Equations &_eqSystem,
               double &_max_char_speed, IntegrationRules *_intRules, int _intRuleType, Fluxes *_fluxClass,
               GasMixture *_mixture, GasMixture *d_mixture, Chemistry *_chemistry, TransportProperties *_transport,
-              Radiation *_radiation, ParFiniteElementSpace *_vfes, const precomputedIntegrationData &gpuArrays,
+              Radiation *_radiation, ParFiniteElementSpace *_vfes, const precomputedIntegrationData &gpu_precomputed_data,
               const int &_maxIntPoints, const int &_maxDofs, DGNonLinearForm *_A, MixedBilinearForm *_Aflux,
               ParMesh *_mesh, ParGridFunction *_spaceVaryViscMult, ParGridFunction *U, ParGridFunction *_Up,
               ParGridFunction *_gradUp, ParFiniteElementSpace *_gradUpfes, GradNonLinearForm *_gradUp_A,
@@ -174,7 +174,7 @@ class RHSoperator : public TimeDependentOperator {
   static void copyZk2Z_gpu(Vector &z, Vector &zk, const int eq, const int dof);
   static void copyDataForFluxIntegration_gpu(const Vector &z, DenseTensor &flux, Vector &fk, Vector &zk, const int eq,
                                              const int dof, const int dim);
-  static void multiPlyInvers_gpu(Vector &y, Vector &z, const precomputedIntegrationData &gpuArrays,
+  static void multiPlyInvers_gpu(Vector &y, Vector &z, const precomputedIntegrationData &gpu_precomputed_data,
                                  const Vector &invMArray, const Array<int> &posDofInvM, const int num_equation,
                                  const int totNumDof, const int NE, const int elemOffset, const int dof);
 

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -131,7 +131,6 @@ class RHSoperator : public TimeDependentOperator {
   mutable Vector z;
   mutable Vector fk, zk;  // temp vectors for flux volume integral
 
-  mutable parallelFacesIntegrationArrays parallelData;
   mutable dataTransferArrays transferU;
   mutable dataTransferArrays transferUp;
   mutable dataTransferArrays transferGradUp;

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -80,7 +80,7 @@ class RHSoperator : public TimeDependentOperator {
 
   ParFiniteElementSpace *vfes;
 
-  const volumeFaceIntegrationArrays &gpuArrays;
+  const precomputedIntegrationData &gpuArrays;
 
   const int *h_numElems;
   const int *h_posDofIds;
@@ -148,7 +148,7 @@ class RHSoperator : public TimeDependentOperator {
   RHSoperator(int &_iter, const int _dim, const int &_num_equation, const int &_order, const Equations &_eqSystem,
               double &_max_char_speed, IntegrationRules *_intRules, int _intRuleType, Fluxes *_fluxClass,
               GasMixture *_mixture, GasMixture *d_mixture, Chemistry *_chemistry, TransportProperties *_transport,
-              Radiation *_radiation, ParFiniteElementSpace *_vfes, const volumeFaceIntegrationArrays &gpuArrays,
+              Radiation *_radiation, ParFiniteElementSpace *_vfes, const precomputedIntegrationData &gpuArrays,
               const int &_maxIntPoints, const int &_maxDofs, DGNonLinearForm *_A, MixedBilinearForm *_Aflux,
               ParMesh *_mesh, ParGridFunction *_spaceVaryViscMult, ParGridFunction *U, ParGridFunction *_Up,
               ParGridFunction *_gradUp, ParFiniteElementSpace *_gradUpfes, GradNonLinearForm *_gradUp_A,
@@ -176,7 +176,7 @@ class RHSoperator : public TimeDependentOperator {
   static void copyZk2Z_gpu(Vector &z, Vector &zk, const int eq, const int dof);
   static void copyDataForFluxIntegration_gpu(const Vector &z, DenseTensor &flux, Vector &fk, Vector &zk, const int eq,
                                              const int dof, const int dim);
-  static void multiPlyInvers_gpu(Vector &y, Vector &z, const volumeFaceIntegrationArrays &gpuArrays,
+  static void multiPlyInvers_gpu(Vector &y, Vector &z, const precomputedIntegrationData &gpuArrays,
                                  const Vector &invMArray, const Array<int> &posDofInvM, const int num_equation,
                                  const int totNumDof, const int NE, const int elemOffset, const int dof);
 

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -82,7 +82,7 @@ class RHSoperator : public TimeDependentOperator {
 
   const precomputedIntegrationData &gpuArrays;
 
-  const int *h_numElems;
+  const int *h_num_elems_of_type;
 
   const int &maxIntPoints;
   const int &maxDofs;

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -83,7 +83,6 @@ class RHSoperator : public TimeDependentOperator {
   const precomputedIntegrationData &gpuArrays;
 
   const int *h_numElems;
-  const int *h_posDofIds;
 
   const int &maxIntPoints;
   const int &maxDofs;

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -134,7 +134,7 @@ class RHSoperator : public TimeDependentOperator {
   mutable dataTransferArrays transferU;
   mutable dataTransferArrays transferUp;
   mutable dataTransferArrays transferGradUp;
-  void fillSharedData();
+  void allocateTransferData();
 
   // void GetFlux(const DenseMatrix &state, DenseTensor &flux) const;
   void GetFlux(const Vector &state, DenseTensor &flux) const;

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -146,12 +146,12 @@ class RHSoperator : public TimeDependentOperator {
   RHSoperator(int &_iter, const int _dim, const int &_num_equation, const int &_order, const Equations &_eqSystem,
               double &_max_char_speed, IntegrationRules *_intRules, int _intRuleType, Fluxes *_fluxClass,
               GasMixture *_mixture, GasMixture *d_mixture, Chemistry *_chemistry, TransportProperties *_transport,
-              Radiation *_radiation, ParFiniteElementSpace *_vfes, const precomputedIntegrationData &gpu_precomputed_data,
-              const int &_maxIntPoints, const int &_maxDofs, DGNonLinearForm *_A, MixedBilinearForm *_Aflux,
-              ParMesh *_mesh, ParGridFunction *_spaceVaryViscMult, ParGridFunction *U, ParGridFunction *_Up,
-              ParGridFunction *_gradUp, ParFiniteElementSpace *_gradUpfes, GradNonLinearForm *_gradUp_A,
-              BCintegrator *_bcIntegrator, bool &_isSBP, double &_alpha, RunConfiguration &_config, ParGridFunction *pc,
-              ParGridFunction *jh);
+              Radiation *_radiation, ParFiniteElementSpace *_vfes,
+              const precomputedIntegrationData &gpu_precomputed_data, const int &_maxIntPoints, const int &_maxDofs,
+              DGNonLinearForm *_A, MixedBilinearForm *_Aflux, ParMesh *_mesh, ParGridFunction *_spaceVaryViscMult,
+              ParGridFunction *U, ParGridFunction *_Up, ParGridFunction *_gradUp, ParFiniteElementSpace *_gradUpfes,
+              GradNonLinearForm *_gradUp_A, BCintegrator *_bcIntegrator, bool &_isSBP, double &_alpha,
+              RunConfiguration &_config, ParGridFunction *pc, ParGridFunction *jh);
 
   virtual void Mult(const Vector &x, Vector &y) const;
   void updatePrimitives(const Vector &x) const;

--- a/src/source_term.cpp
+++ b/src/source_term.cpp
@@ -35,10 +35,10 @@
 
 SourceTerm::SourceTerm(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                        IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U,
-                       ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpuArrays,
+                       ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpu_precomputed_data,
                        RunConfiguration &_config, GasMixture *mixture, GasMixture *d_mixture,
                        TransportProperties *transport, Chemistry *chemistry, Radiation *radiation, ParGridFunction *pc)
-    : ForcingTerms(_dim, _num_equation, _order, _intRuleType, _intRules, _vfes, U, _Up, _gradUp, gpuArrays,
+    : ForcingTerms(_dim, _num_equation, _order, _intRuleType, _intRules, _vfes, U, _Up, _gradUp, gpu_precomputed_data,
                    _config.isAxisymmetric()),
       mixture_(mixture),
       d_mixture_(d_mixture),

--- a/src/source_term.cpp
+++ b/src/source_term.cpp
@@ -35,9 +35,10 @@
 
 SourceTerm::SourceTerm(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                        IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U,
-                       ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpu_precomputed_data,
-                       RunConfiguration &_config, GasMixture *mixture, GasMixture *d_mixture,
-                       TransportProperties *transport, Chemistry *chemistry, Radiation *radiation, ParGridFunction *pc)
+                       ParGridFunction *_Up, ParGridFunction *_gradUp,
+                       const precomputedIntegrationData &gpu_precomputed_data, RunConfiguration &_config,
+                       GasMixture *mixture, GasMixture *d_mixture, TransportProperties *transport, Chemistry *chemistry,
+                       Radiation *radiation, ParGridFunction *pc)
     : ForcingTerms(_dim, _num_equation, _order, _intRuleType, _intRules, _vfes, U, _Up, _gradUp, gpu_precomputed_data,
                    _config.isAxisymmetric()),
       mixture_(mixture),

--- a/src/source_term.cpp
+++ b/src/source_term.cpp
@@ -35,7 +35,7 @@
 
 SourceTerm::SourceTerm(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
                        IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U,
-                       ParGridFunction *_Up, ParGridFunction *_gradUp, const volumeFaceIntegrationArrays &gpuArrays,
+                       ParGridFunction *_Up, ParGridFunction *_gradUp, const precomputedIntegrationData &gpuArrays,
                        RunConfiguration &_config, GasMixture *mixture, GasMixture *d_mixture,
                        TransportProperties *transport, Chemistry *chemistry, Radiation *radiation, ParGridFunction *pc)
     : ForcingTerms(_dim, _num_equation, _order, _intRuleType, _intRules, _vfes, U, _Up, _gradUp, gpuArrays,

--- a/src/source_term.hpp
+++ b/src/source_term.hpp
@@ -64,8 +64,7 @@ class SourceTerm : public ForcingTerms {
   // ParGridFunction *gradUp;
   //
   // const precomputedIntegrationData &gpuArrays;
-  // const int *h_numElems;
-  // const int *h_posDofIds;
+  // const int *h_num_elems_of_type;
 
   int numSpecies_;
   int numActiveSpecies_;

--- a/src/source_term.hpp
+++ b/src/source_term.hpp
@@ -63,7 +63,7 @@ class SourceTerm : public ForcingTerms {
   // ParGridFunction *Up;
   // ParGridFunction *gradUp;
   //
-  // const volumeFaceIntegrationArrays &gpuArrays;
+  // const precomputedIntegrationData &gpuArrays;
   // const int *h_numElems;
   // const int *h_posDofIds;
 
@@ -85,7 +85,7 @@ class SourceTerm : public ForcingTerms {
  public:
   SourceTerm(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
              IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U, ParGridFunction *_Up,
-             ParGridFunction *_gradUp, const volumeFaceIntegrationArrays &gpuArrays, RunConfiguration &_config,
+             ParGridFunction *_gradUp, const precomputedIntegrationData &gpuArrays, RunConfiguration &_config,
              GasMixture *mixture, GasMixture *d_mixture, TransportProperties *transport, Chemistry *chemistry,
              Radiation *radiation, ParGridFunction *pc);
   ~SourceTerm();

--- a/src/source_term.hpp
+++ b/src/source_term.hpp
@@ -63,7 +63,7 @@ class SourceTerm : public ForcingTerms {
   // ParGridFunction *Up;
   // ParGridFunction *gradUp;
   //
-  // const precomputedIntegrationData &gpuArrays;
+  // const precomputedIntegrationData &gpu_precomputed_data_
   // const int *h_num_elems_of_type;
 
   int numSpecies_;

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -209,7 +209,7 @@ void WallBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradSt
 }
 
 void WallBC::integrationBC(Vector &y, const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
-                           ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
+                           ParGridFunction *gradUp, const boundaryFaceIntegrationData &boundary_face_data,
                            const int &maxIntPoints, const int &maxDofs) {
   interpWalls_gpu(x, elem_index_data, Up, gradUp, boundary_face_data, maxDofs);
 
@@ -389,7 +389,7 @@ void WallBC::computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix
 }
 
 void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,
-                                boundaryFaceIntegrationData &boundary_face_data, const int &maxDofs) {
+                                const boundaryFaceIntegrationData &boundary_face_data, const int &maxDofs) {
 #ifdef _GPU_
   double *d_y = y.Write();
   //   const double *d_U = x.Read();
@@ -487,7 +487,7 @@ void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const elementIndexin
 
 void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &elem_index_data,
                              mfem::ParGridFunction *Up, mfem::ParGridFunction *gradUp,
-                             boundaryFaceIntegrationData &boundary_face_data, const int &maxDofs) {
+                             const boundaryFaceIntegrationData &boundary_face_data, const int &maxDofs) {
 #ifdef _GPU_
   double *d_flux = face_flux_.Write();
 

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -154,7 +154,7 @@ void WallBC::initBCs() {
 
 void WallBC::buildWallElemsArray() {
   auto hlistElems = listElems.HostRead();  // this is actually a list of faces
-  auto h_face_el = boundary_face_data_.face_el.HostRead();
+  auto h_face_el = boundary_face_data_.el.HostRead();
 
   std::vector<int> unicElems;
   unicElems.clear();
@@ -393,13 +393,13 @@ void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const elementIndexin
 #ifdef _GPU_
   double *d_y = y.Write();
   //   const double *d_U = x.Read();
-  const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
-  const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
-  const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
-  const double *d_face_shape = boundary_face_data.face_shape.Read();
-  const double *d_weight = boundary_face_data.face_quad_weight.Read();
-  const int *d_face_el = boundary_face_data.face_el.Read();
-  const int *d_face_num_quad = boundary_face_data.face_num_quad.Read();
+  const int *d_elem_dofs_list = elem_index_data.dofs_list.Read();
+  const int *d_elem_dof_off = elem_index_data.dof_offset.Read();
+  const int *d_elem_dof_num = elem_index_data.dof_number.Read();
+  const double *d_face_shape = boundary_face_data.shape.Read();
+  const double *d_weight = boundary_face_data.quad_weight.Read();
+  const int *d_face_el = boundary_face_data.el.Read();
+  const int *d_face_num_quad = boundary_face_data.num_quad.Read();
   const int *d_wallElems = wallElems.Read();
   const int *d_listElems = listElems.Read();
 
@@ -493,13 +493,13 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &e
 
   const double *d_U = x.Read();
   const double *d_gradUp = gradUp->Read();
-  const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
-  const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
-  const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
-  const double *d_face_shape = boundary_face_data.face_shape.Read();
-  const double *d_normal = boundary_face_data.face_normal.Read();
-  const int *d_face_num_quad = boundary_face_data.face_num_quad.Read();
-  const int *d_face_el = boundary_face_data.face_el.Read();
+  const int *d_elem_dofs_list = elem_index_data.dofs_list.Read();
+  const int *d_elem_dof_off = elem_index_data.dof_offset.Read();
+  const int *d_elem_dof_num = elem_index_data.dof_number.Read();
+  const double *d_face_shape = boundary_face_data.shape.Read();
+  const double *d_normal = boundary_face_data.normal.Read();
+  const int *d_face_num_quad = boundary_face_data.num_quad.Read();
+  const int *d_face_el = boundary_face_data.el.Read();
   const int *d_wallElems = wallElems.Read();
   const int *d_listElems = listElems.Read();
 

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -397,7 +397,7 @@ void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const elementIndexin
   const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
   const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
-  const double *d_shapesBC = boundary_face_data.shapesBC.Read();
+  const double *d_face_shape = boundary_face_data.face_shape.Read();
   const double *d_normW = boundary_face_data.normalsWBC.Read();
   const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
   const int *d_wallElems = wallElems.Read();
@@ -465,7 +465,7 @@ void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const elementIndexin
         // sum contributions to integral
         // for (int i = 0; i < elDof; i++) {
         MFEM_FOREACH_THREAD(i, x, elDof) {
-          const double shape = d_shapesBC[i + q * maxDofs + el_bdry * maxIntPoints * maxDofs];
+          const double shape = d_face_shape[i + q * maxDofs + el_bdry * maxIntPoints * maxDofs];
           for (int eq = 0; eq < num_equation; eq++) {
             Fcontrib[i + eq * elDof] -= Rflux[eq] * shape;
           }
@@ -496,7 +496,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &e
   const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
   const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
-  const double *d_shapesBC = boundary_face_data.shapesBC.Read();
+  const double *d_face_shape = boundary_face_data.face_shape.Read();
   const double *d_normW = boundary_face_data.normalsWBC.Read();
   const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
   const int *d_wallElems = wallElems.Read();
@@ -567,7 +567,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &e
 
         // extract shape functions at this quad point
         for (int j = 0; j < elDof; j++) {
-          shape[j] = d_shapesBC[j + q * maxDofs + el_bdry * maxIntPoints * maxDofs];
+          shape[j] = d_face_shape[j + q * maxDofs + el_bdry * maxIntPoints * maxDofs];
         }
 
         // extract normal vector at this quad point

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -403,16 +403,8 @@ void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const elementIndexin
   const int *d_listElems = listElems.Read();
 
   const int totDofs = x.Size() / num_equation_;
-  const int numBdrElem = listElems.Size();
+  // const int numBdrElem = listElems.Size();
 
-  const double Rg = mixture->GetGasConstant();
-  const double gamma = mixture->GetSpecificHeatRatio();
-  const double viscMult = mixture->GetViscMultiplyer();
-  const double bulkViscMult = mixture->GetBulkViscMultiplyer();
-  const double Pr = mixture->GetPrandtlNum();
-  const double Sc = mixture->GetSchmidtNum();
-
-  const int dim = dim_;
   const int num_equation = num_equation_;
   const int maxIntPoints = maxIntPoints_;
 
@@ -503,18 +495,9 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &e
   const int *d_listElems = listElems.Read();
 
   const int totDofs = x.Size() / num_equation_;
-  const int numBdrElem = listElems.Size();
+  // const int numBdrElem = listElems.Size();
 
-  const double Rg = mixture->GetGasConstant();
-  const double gamma = mixture->GetSpecificHeatRatio();
-  const double viscMult = mixture->GetViscMultiplyer();
-  const double bulkViscMult = mixture->GetBulkViscMultiplyer();
-  const double Pr = mixture->GetPrandtlNum();
-  const double Sc = mixture->GetSchmidtNum();
-
-  const WorkingFluid fluid = mixture->GetWorkingFluid();
   const WallType type = wallType_;
-  const double wallTemp = wallTemp_;
 
   const int dim = dim_;
   const int num_equation = num_equation_;
@@ -539,7 +522,8 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &e
 
     BoundaryPrimitiveData bcState;
     BoundaryViscousFluxData bcFlux;
-    double unitNorm[gpudata::MAXDIM], normN;
+    // double unitNorm[gpudata::MAXDIM], normN;
+    double normN;
 
     const int numFaces = d_wallElems[0 + el_wall * 7];
 

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -140,9 +140,8 @@ WallBC::~WallBC() {}
 
 void WallBC::initBCs() {
   if (!BCinit) {
-    buildWallElemsArray();
-
 #ifdef _GPU_
+    buildWallElemsArray();
     face_flux_.UseDevice(true);
     face_flux_.SetSize(num_equation_ * maxIntPoints_ * listElems.Size());
     face_flux_ = 0.;

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -208,13 +208,13 @@ void WallBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradSt
   }
 }
 
-void WallBC::integrationBC(Vector &y, const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+void WallBC::integrationBC(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,
                            ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                            Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs) {
-  interpWalls_gpu(x, elem_dofs_list, posDofIds, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, maxDofs);
+  interpWalls_gpu(x, elem_index_data, Up, gradUp, shapesBC, normalsWBC, intPointsElIDBC, maxDofs);
 
   integrateWalls_gpu(y,  // output
-                     x, elem_dofs_list, posDofIds, shapesBC, normalsWBC, intPointsElIDBC, maxDofs);
+                     x, elem_index_data, shapesBC, normalsWBC, intPointsElIDBC, maxDofs);
 }
 
 void WallBC::computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius,
@@ -388,14 +388,14 @@ void WallBC::computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix
   }
 }
 
-void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const Array<int> &elem_dofs_list,
-                                const Array<int> &posDofIds, Vector &shapesBC, Vector &normalsWBC,
+void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,
+                                Vector &shapesBC, Vector &normalsWBC,
                                 Array<int> &intPointsElIDBC, const int &maxDofs) {
 #ifdef _GPU_
   double *d_y = y.Write();
   //   const double *d_U = x.Read();
-  const int *d_elem_dofs_list = elem_dofs_list.Read();
-  const int *d_posDofIds = posDofIds.Read();
+  const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
+  const int *d_posDofIds = elem_index_data.posDofIds.Read();
   const double *d_shapesBC = shapesBC.Read();
   const double *d_normW = normalsWBC.Read();
   const int *d_intPointsElIDBC = intPointsElIDBC.Read();
@@ -484,7 +484,7 @@ void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const Array<int> &el
 #endif
 }
 
-void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &elem_index_data,
                              mfem::ParGridFunction *Up, mfem::ParGridFunction *gradUp, mfem::Vector &shapesBC,
                              mfem::Vector &normalsWBC, Array<int> &intPointsElIDBC, const int &maxDofs) {
 #ifdef _GPU_
@@ -492,8 +492,8 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const Array<int> &elem_dofs_
 
   const double *d_U = x.Read();
   const double *d_gradUp = gradUp->Read();
-  const int *d_elem_dofs_list = elem_dofs_list.Read();
-  const int *d_posDofIds = posDofIds.Read();
+  const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
+  const int *d_posDofIds = elem_index_data.posDofIds.Read();
   const double *d_shapesBC = shapesBC.Read();
   const double *d_normW = normalsWBC.Read();
   const int *d_intPointsElIDBC = intPointsElIDBC.Read();

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -395,7 +395,8 @@ void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const elementIndexin
   double *d_y = y.Write();
   //   const double *d_U = x.Read();
   const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
-  const int *d_posDofIds = elem_index_data.posDofIds.Read();
+  const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
+  const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
   const double *d_shapesBC = shapesBC.Read();
   const double *d_normW = normalsWBC.Read();
   const int *d_intPointsElIDBC = intPointsElIDBC.Read();
@@ -442,8 +443,8 @@ void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const elementIndexin
 
       el = d_intPointsElIDBC[2 * el_bdry + 1];
 
-      elOffset = d_posDofIds[2 * el];
-      elDof = d_posDofIds[2 * el + 1];
+      elOffset = d_elem_dof_off[el];
+      elDof = d_elem_dof_num[el];
 
       if (!elemDataRecovered) {
         MFEM_FOREACH_THREAD(i, x, elDof) {
@@ -493,7 +494,8 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &e
   const double *d_U = x.Read();
   const double *d_gradUp = gradUp->Read();
   const int *d_elem_dofs_list = elem_index_data.element_dofs_list.Read();
-  const int *d_posDofIds = elem_index_data.posDofIds.Read();
+  const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
+  const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
   const double *d_shapesBC = shapesBC.Read();
   const double *d_normW = normalsWBC.Read();
   const int *d_intPointsElIDBC = intPointsElIDBC.Read();
@@ -547,8 +549,8 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &e
       const int Q = d_intPointsElIDBC[2 * el_bdry];
       const int el = d_intPointsElIDBC[2 * el_bdry + 1];  // global element number (on this mpi rank) ?
 
-      const int elOffset = d_posDofIds[2 * el];
-      const int elDof = d_posDofIds[2 * el + 1];
+      const int elOffset = d_elem_dof_off[el];
+      const int elDof = d_elem_dof_num[el];
 
       for (int i = 0; i < elDof; i++) {
         index_i[i] = d_elem_dofs_list[elOffset + i];

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -208,9 +208,8 @@ void WallBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradSt
   }
 }
 
-void WallBC::integrationBC(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,
-                           ParGridFunction *Up, ParGridFunction *gradUp,
-                           boundaryFaceIntegrationData &boundary_face_data,
+void WallBC::integrationBC(Vector &y, const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
+                           ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
                            const int &maxIntPoints, const int &maxDofs) {
   interpWalls_gpu(x, elem_index_data, Up, gradUp, boundary_face_data, maxDofs);
 

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -398,7 +398,7 @@ void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const elementIndexin
   const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
   const double *d_face_shape = boundary_face_data.face_shape.Read();
-  const double *d_normW = boundary_face_data.normalsWBC.Read();
+  const double *d_weight = boundary_face_data.face_quad_weight.Read();
   const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
   const int *d_wallElems = wallElems.Read();
   const int *d_listElems = listElems.Read();
@@ -457,7 +457,7 @@ void WallBC::integrateWalls_gpu(Vector &y, const Vector &x, const elementIndexin
       }
 
       for (int q = 0; q < Q; q++) {  // loop over int. points
-        const double weight = d_normW[dim + q * (dim + 1) + el_bdry * maxIntPoints * (dim + 1)];
+        const double weight = d_weight[el_bdry * maxIntPoints + q];
 
         for (int eq = 0; eq < num_equation; eq++)
           Rflux[eq] = weight * d_flux[eq + q * num_equation + n * maxIntPoints * num_equation];
@@ -497,7 +497,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &e
   const int *d_elem_dof_off = elem_index_data.element_dof_offset.Read();
   const int *d_elem_dof_num = elem_index_data.element_dof_number.Read();
   const double *d_face_shape = boundary_face_data.face_shape.Read();
-  const double *d_normW = boundary_face_data.normalsWBC.Read();
+  const double *d_normal = boundary_face_data.face_normal.Read();
   const int *d_intPointsElIDBC = boundary_face_data.intPointsElIDBC.Read();
   const int *d_wallElems = wallElems.Read();
   const int *d_listElems = listElems.Read();
@@ -573,7 +573,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &e
         // extract normal vector at this quad point
         normN = 0.0;
         for (int d = 0; d < dim; d++) {
-          nor[d] = d_normW[d + q * (dim + 1) + el_bdry * maxIntPoints * (dim + 1)];
+          nor[d] = d_normal[el_bdry * maxIntPoints * dim + q * dim + d];
           normN += nor[d] * nor[d];
         }
 

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -86,15 +86,15 @@ class WallBC : public BoundaryCondition {
   // functions for BC integration on GPU
 
   virtual void integrationBC(Vector &y,  // output
-                             const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+                             const Vector &x, const elementIndexingData &elem_index_data,
                              ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                              Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs);
 
   void integrateWalls_gpu(Vector &y,  // output
-                          const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+                          const Vector &x, const elementIndexingData &elem_index_data,
                           Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, const int &maxDofs);
 
-  void interpWalls_gpu(const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+  void interpWalls_gpu(const Vector &x, const elementIndexingData &elem_index_data,
                        ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                        Array<int> &intPointsElIDBC, const int &maxDofs);
 

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -86,18 +86,16 @@ class WallBC : public BoundaryCondition {
   // functions for BC integration on GPU
 
   virtual void integrationBC(Vector &y,  // output
-                             const Vector &x, const elementIndexingData &elem_index_data,
-                             ParGridFunction *Up, ParGridFunction *gradUp,
-                             boundaryFaceIntegrationData &boundary_face_data,
+                             const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
+                             ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
                              const int &maxIntPoints, const int &maxDofs);
 
   void integrateWalls_gpu(Vector &y,  // output
                           const Vector &x, const elementIndexingData &elem_index_data,
                           boundaryFaceIntegrationData &boundary_face_data, const int &maxDofs);
 
-  void interpWalls_gpu(const Vector &x, const elementIndexingData &elem_index_data,
-                       ParGridFunction *Up, ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
-                       const int &maxDofs);
+  void interpWalls_gpu(const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
+                       ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data, const int &maxDofs);
 
 #ifdef _GPU_
   static MFEM_HOST_DEVICE void computeInvWallState(const double *u1, double *u2, const double *nor, const int &dim,

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -87,16 +87,17 @@ class WallBC : public BoundaryCondition {
 
   virtual void integrationBC(Vector &y,  // output
                              const Vector &x, const elementIndexingData &elem_index_data,
-                             ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
-                             Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs);
+                             ParGridFunction *Up, ParGridFunction *gradUp,
+                             boundaryFaceIntegrationData &boundary_face_data,
+                             const int &maxIntPoints, const int &maxDofs);
 
   void integrateWalls_gpu(Vector &y,  // output
                           const Vector &x, const elementIndexingData &elem_index_data,
-                          Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, const int &maxDofs);
+                          boundaryFaceIntegrationData &boundary_face_data, const int &maxDofs);
 
   void interpWalls_gpu(const Vector &x, const elementIndexingData &elem_index_data,
-                       ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
-                       Array<int> &intPointsElIDBC, const int &maxDofs);
+                       ParGridFunction *Up, ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
+                       const int &maxDofs);
 
 #ifdef _GPU_
   static MFEM_HOST_DEVICE void computeInvWallState(const double *u1, double *u2, const double *nor, const int &dim,

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -86,17 +86,17 @@ class WallBC : public BoundaryCondition {
   // functions for BC integration on GPU
 
   virtual void integrationBC(Vector &y,  // output
-                             const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds,
+                             const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
                              ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
                              Array<int> &intPointsElIDBC, const int &maxIntPoints, const int &maxDofs);
 
   void integrateWalls_gpu(Vector &y,  // output
-                          const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds, Vector &shapesBC,
-                          Vector &normalsWBC, Array<int> &intPointsElIDBC, const int &maxDofs);
+                          const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+                          Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC, const int &maxDofs);
 
-  void interpWalls_gpu(const Vector &x, const Array<int> &nodesIDs, const Array<int> &posDofIds, ParGridFunction *Up,
-                       ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC, Array<int> &intPointsElIDBC,
-                       const int &maxDofs);
+  void interpWalls_gpu(const Vector &x, const Array<int> &elem_dofs_list, const Array<int> &posDofIds,
+                       ParGridFunction *Up, ParGridFunction *gradUp, Vector &shapesBC, Vector &normalsWBC,
+                       Array<int> &intPointsElIDBC, const int &maxDofs);
 
 #ifdef _GPU_
   static MFEM_HOST_DEVICE void computeInvWallState(const double *u1, double *u2, const double *nor, const int &dim,

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -57,11 +57,11 @@ class WallBC : public BoundaryCondition {
   BoundaryViscousFluxData bcFlux_;
   BoundaryPrimitiveData bcState_;
 
-  const Array<int> &intPointsElIDBC;
+  const boundaryFaceIntegrationData &boundary_face_data_;
   const int &maxIntPoints_;
 
   Array<int> wallElems;
-  void buildWallElemsArray(const Array<int> &intPointsElIDBC);
+  void buildWallElemsArray();
 
   void computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector &bdrFlux);
   void computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius,
@@ -74,7 +74,7 @@ class WallBC : public BoundaryCondition {
   WallBC(RiemannSolver *rsolver_, GasMixture *_mixture, GasMixture *d_mixture, Equations _eqSystem, Fluxes *_fluxClass,
          ParFiniteElementSpace *_vfes, IntegrationRules *_intRules, double &_dt, const int _dim,
          const int _num_equation, int _patchNumber, WallType _bcType, const WallData _inputData,
-         const Array<int> &intPointsElIDBC, const int &maxIntPoints, bool axisym);
+         const boundaryFaceIntegrationData &boundary_face_data, const int &maxIntPoints, bool axisym);
   ~WallBC();
 
   void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector &bdrFlux);

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -87,15 +87,16 @@ class WallBC : public BoundaryCondition {
 
   virtual void integrationBC(Vector &y,  // output
                              const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
-                             ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data,
+                             ParGridFunction *gradUp, const boundaryFaceIntegrationData &boundary_face_data,
                              const int &maxIntPoints, const int &maxDofs);
 
   void integrateWalls_gpu(Vector &y,  // output
                           const Vector &x, const elementIndexingData &elem_index_data,
-                          boundaryFaceIntegrationData &boundary_face_data, const int &maxDofs);
+                          const boundaryFaceIntegrationData &boundary_face_data, const int &maxDofs);
 
   void interpWalls_gpu(const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
-                       ParGridFunction *gradUp, boundaryFaceIntegrationData &boundary_face_data, const int &maxDofs);
+                       ParGridFunction *gradUp, const boundaryFaceIntegrationData &boundary_face_data,
+                       const int &maxDofs);
 
 #ifdef _GPU_
   static MFEM_HOST_DEVICE void computeInvWallState(const double *u1, double *u2, const double *nor, const int &dim,


### PR DESCRIPTION
This PR is intended to clean up and clarify some of the data that is precomputed and used to evaluate the residual, mostly the face integral contributions, on the `_GPU_` code path.  The motivation for doing so now is that porting some capabilities (e.g., the SGS models from PR #197) will require additions to this data.  Prior to this PR, the necessary data where spread across multiple `struct` objects, and the storage was very confusing, since multiple different quantities were often stored together in a single array without any clear motivation for that choice.  This PR aims to improve this situation by 1) storing each required quantity in a single `Vector` or `Array` where possible and 2) unifying the various different pieces into a single `struct`---i.e., `struct precomputedIntegrationData`---that itself contains four objects, each of which stores logically different data.  Improved comments should also help others understand the data stored in these objects, how to use it, and how to extend it when necessary.