### PR TITLE
Compute the distance function 

### DIFF
--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -419,6 +419,8 @@ class M2ulPhyS : public TPS::Solver {
   GasMixture *getMixture() { return mixture; }
   Chemistry *getChemistry() { return chemistry_; }
 
+  const ParGridFunction *getDistanceFcn() { return distance_; }
+
   void updatePrimitives();
 
   ParGridFunction *GetPlasmaConductivityGF() { return plasma_conductivity_; }

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -159,6 +159,9 @@ class M2ulPhyS : public TPS::Solver {
 
   ParGridFunction *spaceVaryViscMult;  // space varying viscosity multiplier
 
+  /// Distance to nearest no-slip wall
+  ParGridFunction *distance_;
+
   Fluxes *fluxClass;
 
   RHSoperator *rhsOperator;

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -255,6 +255,8 @@ class RunConfiguration {
 
   PostProcessInput postprocessInput;
 
+  bool compute_distance;
+
   RunConfiguration();
   ~RunConfiguration();
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -32,6 +32,10 @@
 #ifndef UTILS_HPP_
 #define UTILS_HPP_
 
+/** @file
+ * @brief A place for miscellaneous utility functions.
+ */
+
 #include <assert.h>
 #include <hdf5.h>
 
@@ -108,5 +112,23 @@ void LocalProjectDiscCoefficient(mfem::GridFunction &gf, mfem::VectorCoefficient
  * LocalProjectDiscCoefficient.
  */
 void GlobalProjectDiscCoefficient(mfem::ParGridFunction &gf, mfem::VectorCoefficient &coeff);
+
+/** @brief Evaluate the distance function
+ *
+ *  Compute minimum distance from each node to a no-slip wall.
+ *
+ *  @param mesh A serial mesh
+ *  @param wall_patches Array of patch indices corresponding to walls
+ *  @param coords Grid function containing mesh coordinates
+ *  @param distance Grid function to store the distance
+ *
+ *  No allocation or resizing is done.  The incoming
+ *  GridFunction objects must already be set up and sized correctly.
+ *
+ *  This function is not guarenteed to work for nonlinear elements.
+ *  See comments in source about why.
+ */
+void evaluateDistanceSerial(mfem::Mesh &mesh, const mfem::Array<int> &wall_patches, const mfem::GridFunction &coords,
+                            mfem::GridFunction &distance);
 
 #endif  // UTILS_HPP_

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -32,7 +32,7 @@ EXTRA_DIST      = tap-driver.sh soln_differ inputs meshes ref_solns/*.h5 \
 	 	  inflow_outflow.test mms.ternary_2d.test mms.ternary_2d_wall.test \
 	 	  mms.ternary_2d_inout.test cuda-memcheck.test mms.general_wall.test \
 		  independent_coupling.test interp_em.test mms.euler_2d.test mms.cns_2d.test \
-		  gradient.test coupled-3d.test tabulated.test lte_mixture.test
+		  gradient.test coupled-3d.test tabulated.test lte_mixture.test distance_fcn.test
 
 TESTS = vpath.sh
 XFAIL_TESTS =
@@ -169,5 +169,11 @@ test_lte_mixture_SOURCES      = test_lte_mixture.cpp
 test_lte_mixture_LDADD        = ../src/libtps.la
 test_lte_mixture_LDADD       += $(HDF5_LIBS)
 test_lte_mixture_LDADD       += $(GRVY_LIBS)
+
+check_PROGRAMS               += test_distance_fcn
+test_distance_fcn_SOURCES     = test_distance_fcn.cpp
+test_distance_fcn_LDADD       = ../src/libtps.la
+test_distance_fcn_LDADD      += $(HDF5_LIBS)
+test_distance_fcn_LDADD      += $(GRVY_LIBS)
 
 endif # if !GPU_ENABLED

--- a/test/distance_fcn.test
+++ b/test/distance_fcn.test
@@ -1,0 +1,9 @@
+#!./bats
+# -*- mode: sh -*-
+
+TEST="distance_fcn"
+
+@test "[$TEST] Unit tests for the distance function calculation" {
+    test -e ./test_distance_fcn
+    ./test_distance_fcn -run inputs/pipe.axisym.viscous.ini
+}

--- a/test/inputs/pipe.axisym.viscous.ini
+++ b/test/inputs/pipe.axisym.viscous.ini
@@ -15,6 +15,7 @@ refLength = 1.
 equation_system = navier-stokes
 viscosityMultiplier = 63000.
 axisymmetric = True
+computeDistance = True
 
 [io]
 outdirBase = output-pipe

--- a/test/test_distance_fcn.cpp
+++ b/test/test_distance_fcn.cpp
@@ -1,0 +1,58 @@
+#include <tps_config.h>
+#include "../src/M2ulPhyS.hpp"
+#include "mfem.hpp"
+#include <fstream>
+#include <hdf5.h>
+
+using namespace mfem;
+using namespace std;
+
+// This function checks the distance function computed for
+// meshes/axi-pipe.msh, assuming that only the outer right boundary
+// (at x=1) is set to be a wall, as in inputs/pipe.axisym.viscous.ini.
+// For this case, the distance function is simply 1-x.
+int checkTrivialDistance(const ParGridFunction &distance, const ParGridFunction &coordinates) {
+  int err = 0;
+  const double rel_tol = 1e-13;
+  const double abs_tol = 1e-20;
+  for (int i = 0; i < distance.Size(); i++) {
+    const double dist_computed = distance[i];
+    const double dist_expected = 1.0 - coordinates[i];
+
+    if (dist_expected > 0) {
+      const double rel_err = std::abs(dist_computed - dist_expected)/std::abs(dist_expected);
+      if( rel_err > rel_tol) err++;
+    } else {
+      if (dist_computed > abs_tol) err++;
+    }
+  }
+  return err;
+}
+
+int main (int argc, char *argv[]) {
+  // This test is intended to be run with inputs/pipe.axisym.viscous.ini
+  TPS::Tps tps;
+  tps.parseCommandLineArgs(argc, argv);
+  tps.parseInput();
+  tps.chooseDevices();
+
+  // Instantiate flow solver (NB: distance fcn happens internally)
+  M2ulPhyS *flow = new M2ulPhyS(tps.getMPISession(), tps.getInputFilename(), &tps);
+
+  // Get mesh coordinates
+  ParMesh *mesh = flow->GetMesh();
+  ParFiniteElementSpace *dfes = flow->GetVectorFES();
+  ParGridFunction coordinates(dfes);
+  mesh->GetNodes(coordinates);
+
+  // Get distance function
+  const ParGridFunction *distance = flow->getDistanceFcn();
+
+  // Compare distance function to expected result
+  int ierr = checkTrivialDistance(*distance, coordinates);
+
+  // Clean up
+  delete flow;
+
+  return ierr;
+}


### PR DESCRIPTION
Add a naive calculation of the distance function.  For now, this is computed serially using the serial mesh (i.e., prior to decomposing the mesh).  This is obviously the simplest approach (e.g., it avoids needing to communicate boundary faces to ensure that the closest wall face isn't on another mpi rank) but has drawbacks, especially for large 3D meshes.  I envision using this capability primarily in 2D for now, so this is not an issue for the moment.

Two other known issues:
  1. The solve for the nearest wall point uses an approximate Newton solve that may not perform well for highly curved elements (see further comments [here](https://github.com/pecos/tps/blob/107a732c09d56c6afe2bcbe6f2af1dc495cdf9f6/src/utils.cpp#L376))
  2. The distance function is compute at the nodes for the finite element space used for the flow variables.  This may not be ideal, especially for coarse meshes in the vicinity of features that lead to distance functions with discontinuous derivatives (e.g., corners).

Resolves #201
