### PR TITLE
Port axisymmetric solver to gpu

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -3362,14 +3362,6 @@ void M2ulPhyS::checkSolverOptions() const {
       exit(ERROR);
     }
   }
-
-  if (config.isAxisymmetric()) {
-    if (mpi.Root()) {
-      std::cerr << "[ERROR]: Axisymmetric simulations not supported on GPU." << std::endl;
-      std::cerr << std::endl;
-      exit(ERROR);
-    }
-  }
 #endif
 
   // Axisymmetric solver does not yet support all options.  Check that

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -525,7 +525,7 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeSourceTransportProperties(
 }
 
 MFEM_HOST_DEVICE void ArgonMinimalTransport::GetViscosities(const double *conserved, const double *primitive,
-                                                            double &visc, double &bulk_visc) {
+                                                            double *visc) {
   double n_sp[3], X_sp[3], Y_sp[3];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
   double nTotal = 0.0;
@@ -548,16 +548,14 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::GetViscosities(const double *conser
   speciesViscosity[neutralIndex_] = viscosityFactor_ * sqrt(mw_[neutralIndex_] * Th) / collision::argon::ArAr22(Th);
   speciesViscosity[electronIndex_] = 0.0;
 
-  visc = linearAverage(X_sp, speciesViscosity);
-  bulk_visc = 0.0;
+  visc[0] = linearAverage(X_sp, speciesViscosity);
+  visc[1] = 0.0;
 
   // Apply artificial multipliers.
   if (multiply_) {
-    visc *= fluxTrnsMultiplier_[FluxTrns::VISCOSITY];
-    bulk_visc *= fluxTrnsMultiplier_[FluxTrns::BULK_VISCOSITY];
+    visc[0] *= fluxTrnsMultiplier_[FluxTrns::VISCOSITY];
+    visc[1] *= fluxTrnsMultiplier_[FluxTrns::BULK_VISCOSITY];
   }
-
-  return;
 }
 
 //////////////////////////////////////////////////////
@@ -1016,7 +1014,7 @@ MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeSourceTransportProperties(
 }
 
 MFEM_HOST_DEVICE void ArgonMixtureTransport::GetViscosities(const double *conserved, const double *primitive,
-                                                            double &visc, double &bulk_visc) {
+                                                            double *visc) {
   double n_sp[gpudata::MAXSPECIES], X_sp[gpudata::MAXSPECIES], Y_sp[gpudata::MAXSPECIES];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
   double nTotal = 0.0;
@@ -1033,13 +1031,13 @@ MFEM_HOST_DEVICE void ArgonMixtureTransport::GetViscosities(const double *conser
     speciesViscosity[sp] =
         viscosityFactor_ * sqrt(mw_[sp] * collInputs.Th) / collisionIntegral(sp, sp, 2, 2, collInputs);
   }
-  visc = linearAverage(X_sp, speciesViscosity);
-  bulk_visc = 0.0;
+  visc[0] = linearAverage(X_sp, speciesViscosity);
+  visc[1] = 0.0;
 
   // Apply artificial multipliers.
   if (multiply_) {
-    visc *= fluxTrnsMultiplier_[FluxTrns::VISCOSITY];
-    bulk_visc *= fluxTrnsMultiplier_[FluxTrns::BULK_VISCOSITY];
+    visc[0] *= fluxTrnsMultiplier_[FluxTrns::VISCOSITY];
+    visc[1] *= fluxTrnsMultiplier_[FluxTrns::BULK_VISCOSITY];
   }
 
   return;

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -524,14 +524,8 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeSourceTransportProperties(
   // std::cout << "max diff. vel: " << charSpeed << std::endl;
 }
 
-void ArgonMinimalTransport::GetViscosities(const Vector &conserved, const Vector &primitive, double &visc,
-                                           double &bulkVisc) {
-  GetViscosities(&conserved[0], &primitive[0], visc, bulkVisc);
-  return;
-}
-
 MFEM_HOST_DEVICE void ArgonMinimalTransport::GetViscosities(const double *conserved, const double *primitive,
-                                                            double &visc, double &bulkVisc) {
+                                                            double &visc, double &bulk_visc) {
   double n_sp[3], X_sp[3], Y_sp[3];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
   double nTotal = 0.0;
@@ -555,12 +549,12 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::GetViscosities(const double *conser
   speciesViscosity[electronIndex_] = 0.0;
 
   visc = linearAverage(X_sp, speciesViscosity);
-  bulkVisc = 0.0;
+  bulk_visc = 0.0;
 
   // Apply artificial multipliers.
   if (multiply_) {
     visc *= fluxTrnsMultiplier_[FluxTrns::VISCOSITY];
-    bulkVisc *= fluxTrnsMultiplier_[FluxTrns::BULK_VISCOSITY];
+    bulk_visc *= fluxTrnsMultiplier_[FluxTrns::BULK_VISCOSITY];
   }
 
   return;
@@ -1021,14 +1015,8 @@ MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeSourceTransportProperties(
   // std::cout << "max diff. vel: " << charSpeed << std::endl;
 }
 
-void ArgonMixtureTransport::GetViscosities(const Vector &conserved, const Vector &primitive, double &visc,
-                                           double &bulkVisc) {
-  GetViscosities(&conserved[0], &primitive[0], visc, bulkVisc);
-  return;
-}
-
 MFEM_HOST_DEVICE void ArgonMixtureTransport::GetViscosities(const double *conserved, const double *primitive,
-                                                            double &visc, double &bulkVisc) {
+                                                            double &visc, double &bulk_visc) {
   double n_sp[gpudata::MAXSPECIES], X_sp[gpudata::MAXSPECIES], Y_sp[gpudata::MAXSPECIES];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
   double nTotal = 0.0;
@@ -1046,12 +1034,12 @@ MFEM_HOST_DEVICE void ArgonMixtureTransport::GetViscosities(const double *conser
         viscosityFactor_ * sqrt(mw_[sp] * collInputs.Th) / collisionIntegral(sp, sp, 2, 2, collInputs);
   }
   visc = linearAverage(X_sp, speciesViscosity);
-  bulkVisc = 0.0;
+  bulk_visc = 0.0;
 
   // Apply artificial multipliers.
   if (multiply_) {
     visc *= fluxTrnsMultiplier_[FluxTrns::VISCOSITY];
-    bulkVisc *= fluxTrnsMultiplier_[FluxTrns::BULK_VISCOSITY];
+    bulk_visc *= fluxTrnsMultiplier_[FluxTrns::BULK_VISCOSITY];
   }
 
   return;

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -131,9 +131,8 @@ class ArgonMinimalTransport : public TransportProperties {
                                                                  double *diffusionVelocity, double *n_sp);
 
   // NOTE(kevin): only for AxisymmetricSource
-  virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);
   MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double &visc,
-                                       double &bulkVisc);
+                                       double &bulk_visc) override;
 
   // virtual double computeThirdOrderElectronThermalConductivity(const Vector &X_sp, const double debyeLength,
   //                                                             const double Te, const double nondimTe);
@@ -216,9 +215,8 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
                                                                  double *diffusionVelocity, double *n_sp);
 
   // NOTE(kevin): only for AxisymmetricSource
-  virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);
   MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double &visc,
-                                       double &bulkVisc);
+                                       double &bulk_visc) override;
 
   MFEM_HOST_DEVICE virtual double computeThirdOrderElectronThermalConductivity(const double *X_sp,
                                                                                const collisionInputs &collInputs);

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -131,8 +131,7 @@ class ArgonMinimalTransport : public TransportProperties {
                                                                  double *diffusionVelocity, double *n_sp);
 
   // NOTE(kevin): only for AxisymmetricSource
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double &visc,
-                                       double &bulk_visc) override;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
 
   // virtual double computeThirdOrderElectronThermalConductivity(const Vector &X_sp, const double debyeLength,
   //                                                             const double Te, const double nondimTe);
@@ -215,8 +214,7 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
                                                                  double *diffusionVelocity, double *n_sp);
 
   // NOTE(kevin): only for AxisymmetricSource
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double &visc,
-                                       double &bulk_visc) override;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
 
   MFEM_HOST_DEVICE virtual double computeThirdOrderElectronThermalConductivity(const double *X_sp,
                                                                                const collisionInputs &collInputs);

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -264,6 +264,9 @@ struct interiorFaceIntegrationData {
   /** Normal vector (oriented from elem 1 toward elem 2) for all interior face quadrature points */
   Vector normal;
 
+  /** Position in physical space for all interior face quadrature points */
+  Vector xyz;
+
   /** maps from element index to face indices
    *
    *  elemFaces[7*i] = number of faces for element i
@@ -299,6 +302,9 @@ struct boundaryFaceIntegrationData {
   /** Normal vector (outward pointing) for all boundary face quadrature points */
   Vector normal;
 
+  /** Position in physical space for all boundary face quadrature points */
+  Vector xyz;
+
   /** for each boundary face, index of corresponding element */
   Array<int> el;
 
@@ -328,6 +334,9 @@ struct sharedFaceIntegrationData {
 
   /** Normal vector (oriented from elem 1 toward elem 2) for all shared face quadrature points */
   Vector normal;
+
+  /** Position in physical space for all shared face quadrature points */
+  Vector xyz;
 
   /** for each shared face, index of element 1 */
   Array<int> el1;

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -642,10 +642,10 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
         gradUp2[gpudata::MAXDIM * gpudata::MAXEQUATIONS],         // gradUp2[3 * 5];
         nor[gpudata::MAXDIM];                                     // nor[3];
     double xyz[gpudata::MAXDIM];
-    double Rflux[gpudata::MAXEQUATIONS],                          // double Rflux[5];
-        vFlux1[gpudata::MAXDIM * gpudata::MAXEQUATIONS],          // vFlux1[3 * 5];
-        vFlux2[gpudata::MAXDIM * gpudata::MAXEQUATIONS];          // vFlux2[3 * 5];
-    int index_i[gpudata::MAXDOFS];                                // int index_i[216];
+    double Rflux[gpudata::MAXEQUATIONS],                  // double Rflux[5];
+        vFlux1[gpudata::MAXDIM * gpudata::MAXEQUATIONS],  // vFlux1[3 * 5];
+        vFlux2[gpudata::MAXDIM * gpudata::MAXEQUATIONS];  // vFlux2[3 * 5];
+    int index_i[gpudata::MAXDOFS];                        // int index_i[216];
 
     const int el1 = d_shared_elements_to_shared_faces[0 + el * 7];
     const int numFaces = d_shared_elements_to_shared_faces[1 + el * 7];

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -370,6 +370,14 @@ void DGNonLinearForm::evalFaceFlux_gpu() {
         }
       }
 
+      if (d_flux->isAxisymmetric()) {
+        const double radius = xyz[0];
+        for (int eq = 0; eq < num_equation; eq++) {
+          Rflux[eq] *= radius;
+        }
+      }
+
+
       // store
       for (int eq = 0; eq < num_equation; eq++) {
         d_f[eq + k * num_equation + iface * maxIntPoints * num_equation] = Rflux[eq];

--- a/src/fluxes.hpp
+++ b/src/fluxes.hpp
@@ -93,6 +93,8 @@ class Fluxes {
   // Compute the split fersion of the flux for SBP operations
   // Output matrices a_mat, c_mat need not have the right size
   void ComputeSplitFlux(const Vector &state, DenseMatrix &a_mat, DenseMatrix &c_mat);
+
+  MFEM_HOST_DEVICE bool isAxisymmetric() const { return axisymmetric_; }
 };
 
 #endif  // FLUXES_HPP_

--- a/src/forcing_terms.cpp
+++ b/src/forcing_terms.cpp
@@ -323,8 +323,10 @@ void AxisymmetricSource::updateTerms(Vector &in) {
       const double uz_z = gradUp[2 + 1 * neqn];
       const double ut_r = gradUp[3 + 0 * neqn];
 
-      double visc, bulkVisc;
-      d_trans->GetViscosities(U, Up, visc, bulkVisc);
+      double visc, bulkVisc, visc_vec[2];
+      d_trans->GetViscosities(U, Up, visc_vec);
+      visc = visc_vec[0];
+      bulkVisc = visc_vec[1];
       bulkVisc -= 2. / 3. * visc;
 
       if (alpha != NULL) {

--- a/src/lte_transport_properties.cpp
+++ b/src/lte_transport_properties.cpp
@@ -106,7 +106,7 @@ void LteTransport::ComputeSourceTransportProperties(const double *state, const d
   globalTransport[SrcTrns::ELECTRIC_CONDUCTIVITY] = 0.;
 }
 
-void LteTransport::GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc) {
+void LteTransport::GetViscosities(const double *conserved, const double *primitive, double &visc, double &bulkVisc) {
   const double rho = primitive[0];
   const double T = primitive[1 + nvel_];
 

--- a/src/lte_transport_properties.cpp
+++ b/src/lte_transport_properties.cpp
@@ -106,12 +106,12 @@ void LteTransport::ComputeSourceTransportProperties(const double *state, const d
   globalTransport[SrcTrns::ELECTRIC_CONDUCTIVITY] = 0.;
 }
 
-void LteTransport::GetViscosities(const double *conserved, const double *primitive, double &visc, double &bulkVisc) {
+void LteTransport::GetViscosities(const double *conserved, const double *primitive, double *visc) {
   const double rho = primitive[0];
   const double T = primitive[1 + nvel_];
 
-  visc = mu_table_->eval(T, rho);
-  bulkVisc = 0.;
+  visc[0] = mu_table_->eval(T, rho);
+  visc[1] = 0.;
 }
 
 #endif  // _GPU_

--- a/src/lte_transport_properties.hpp
+++ b/src/lte_transport_properties.hpp
@@ -79,7 +79,7 @@ class LteTransport : public TransportProperties {
                                                 const double *Efield, double *globalTransport, double *speciesTransport,
                                                 double *diffusionVelocity, double *n_sp);
 
-  void GetViscosities(const double *conserved, const double *primitive, double &visc, double &bulkVisc) override;
+  void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
 };
 
 #endif  // _GPU_

--- a/src/lte_transport_properties.hpp
+++ b/src/lte_transport_properties.hpp
@@ -79,7 +79,7 @@ class LteTransport : public TransportProperties {
                                                 const double *Efield, double *globalTransport, double *speciesTransport,
                                                 double *diffusionVelocity, double *n_sp);
 
-  virtual void GetViscosities(const Vector &conserved, const Vector &primitive, double &visc, double &bulkVisc);
+  void GetViscosities(const double *conserved, const double *primitive, double &visc, double &bulkVisc) override;
 };
 
 #endif  // _GPU_

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -1145,7 +1145,7 @@ void OutletBC::interpOutlet_gpu(const mfem::Vector &x, const elementIndexingData
     double shape[gpudata::MAXDOFS];  // double shape[216];
     double u1[gpudata::MAXEQUATIONS], u2[gpudata::MAXEQUATIONS], gradUp1[gpudata::MAXEQUATIONS * gpudata::MAXDIM],
         Rflux[gpudata::MAXEQUATIONS],
-        nor[gpudata::MAXDIM];       // double u1[5], u2[5], gradUp1[5 * 3], Rflux[5], nor[3];
+        nor[gpudata::MAXDIM];  // double u1[5], u2[5], gradUp1[5 * 3], Rflux[5], nor[3];
     double xyz[gpudata::MAXDIM];
     int index_i[gpudata::MAXDOFS];  // int index_i[216];
 

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -135,7 +135,7 @@ RHSoperator::RHSoperator(int &_iter, const int _dim, const int &_num_equation, c
 #endif
 
   if (config_.isAxisymmetric()) {
-    forcing.Append(new AxisymmetricSource(dim_, num_equation_, _order, mixture, transport_, eqSystem, intRuleType,
+    forcing.Append(new AxisymmetricSource(dim_, num_equation_, _order, d_mixture_, transport_, eqSystem, intRuleType,
                                           intRules, vfes, U_, Up, gradUp, spaceVaryViscMult, gpu_precomputed_data_,
                                           _config));
     const FiniteElementCollection *fec = vfes->FEColl();
@@ -411,7 +411,6 @@ void RHSoperator::Mult(const Vector &x, Vector &y) const {
       RHSoperator::multiPlyInvers_gpu(y, z, gpu_precomputed_data_, invMArray, posDofInvM, num_equation_, totDofs,
                                       h_num_elems_of_type[eltype], elemOffset, dof);
     }
-
   }
 
 #else

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -103,6 +103,7 @@ class RHSoperator : public TimeDependentOperator {
   Array<DenseMatrix *> Me_inv_rad;
 
   Vector invMArray;
+  Vector invMArray_rad;
   Array<int> posDofInvM;
 
   const bool &isSBP;

--- a/src/riemann_solver.hpp
+++ b/src/riemann_solver.hpp
@@ -75,6 +75,8 @@ class RiemannSolver {
 
   void Eval_LF(const Vector &state1, const Vector &state2, const Vector &nor, Vector &flux);
   MFEM_HOST_DEVICE void Eval_LF(const double *state1, const double *state2, const double *nor, double *flux) const;
+
+  MFEM_HOST_DEVICE bool isAxisymmetric() const { return axisymmetric_; }
 };
 
 #endif  // RIEMANN_SOLVER_HPP_

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -179,7 +179,7 @@ class DryAirTransport : public TransportProperties {
                                                                  double *globalTransport, double *speciesTransport,
                                                                  double *diffusionVelocity, double *n_sp) {}
 
-  MFEM_HOST_DEVICE virtual void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
 };
 
 MFEM_HOST_DEVICE inline void DryAirTransport::GetViscosities(const double *conserved, const double *primitive,

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -608,7 +608,6 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &e
           }
         }
 
-
         // store flux (TODO: change variable name)
         for (int eq = 0; eq < num_equation; eq++) {
           d_flux[eq + q * num_equation + n * maxIntPoints * num_equation] = Rflux[eq];

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -601,6 +601,14 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &e
           for (int d = 0; d < dim; d++) Rflux[eq] -= 0.5 * vF1[eq + d * num_equation] * nor[d];
         }
 
+        if (d_fluxclass->isAxisymmetric()) {
+          const double radius = xyz[0];
+          for (int eq = 0; eq < num_equation; eq++) {
+            Rflux[eq] *= radius;
+          }
+        }
+
+
         // store flux (TODO: change variable name)
         for (int eq = 0; eq < num_equation; eq++) {
           d_flux[eq + q * num_equation + n * maxIntPoints * num_equation] = Rflux[eq];

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -45,7 +45,8 @@ TESTS += cyl3d.gpu.test \
 	 argon_minimal.binary.test \
 	 diffusion_wall.test \
 	 reaction.test \
-	 inflow_outflow.test
+	 inflow_outflow.test \
+	 pipe.test
 
 if PYTHON_ENABLED
 TESTS += cyl3d.gpu.python.test

--- a/test/inputs/pipe.axisym.viscous.ini
+++ b/test/inputs/pipe.axisym.viscous.ini
@@ -24,6 +24,7 @@ enableRestart = True
 [time]
 cfl = 0.12
 integrator = rk3
+enableConstantTimestep = True
 
 [initialConditions]
 rho = 1.16

--- a/test/pipe.test
+++ b/test/pipe.test
@@ -7,7 +7,7 @@ RUNFILE="inputs/pipe.axisym.viscous.ini"
 setup() {
     SOLN_FILE=restart_output-pipe.sol.h5
     RSTRT_FILE=ref_solns/pipe.restart.sol.h5
-    REF_FILE=ref_solns/pipe.100100.sol.h5
+    REF_FILE=ref_solns/pipe.100100.dtconst.sol.h5
 }
 
 @test "[$TEST] verify axisymmetric tps output with input -> $RUNFILE" {

--- a/test/pipe.test
+++ b/test/pipe.test
@@ -22,5 +22,14 @@ setup() {
 
     test -s $SOLN_FILE
     test -s $REF_FILE
-    ./soln_differ -r $SOLN_FILE $REF_FILE
+
+    if [[ $HOSTNAME == "lassen"* ]]; then
+        h5diff -r --delta=2e-13 $SOLN_FILE $REF_FILE /solution/density || exit 1
+        h5diff -r --delta=2.2e-11 $SOLN_FILE $REF_FILE /solution/rho-u || exit 1
+        h5diff -r --delta=2.2e-11 $SOLN_FILE $REF_FILE /solution/rho-v || exit 1
+        h5diff -r --delta=2.2e-11 $SOLN_FILE $REF_FILE /solution/rho-w || exit 1
+        h5diff -r --relative=6e-14 $SOLN_FILE $REF_FILE /solution/rho-E || exit 1
+    else
+        ./soln_differ -r $SOLN_FILE $REF_FILE
+    fi
 }

--- a/test/ref_solns/.gitattributes
+++ b/test/ref_solns/.gitattributes
@@ -1,1 +1,2 @@
 coupled-3d.sol.h5 filter=lfs diff=lfs merge=lfs -text
+pipe.100100.dtconst.sol.h5 filter=lfs diff=lfs merge=lfs -text

--- a/test/ref_solns/pipe.100100.dtconst.sol.h5
+++ b/test/ref_solns/pipe.100100.dtconst.sol.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da3703197ca1c4cc35cf56b2117347ff16f31c4bca6ef06ae05f1f7984f2e2d2
+size 332632

--- a/test/test_argon_minimal.cpp
+++ b/test/test_argon_minimal.cpp
@@ -163,9 +163,11 @@ int main (int argc, char *argv[])
     DenseMatrix diffusionVelocity(numSpecies, dim);
     transport->ComputeFluxTransportProperties(conservedState, gradUp, Efield, transportBuffer, diffusionVelocity);
 
-    double visc, bulkVisc;
-    transport->GetViscosities(conservedState, primitiveState, visc, bulkVisc);
-    
+    double visc, bulkVisc, visc_vec[2];
+    transport->GetViscosities(conservedState, primitiveState, visc_vec);
+    visc = visc_vec[0];
+    bulkVisc = visc_vec[1];
+
     double visc_err = abs(visc - transportBuffer[FluxTrns::VISCOSITY]);
     double bulk_visc_err = abs(bulkVisc - transportBuffer[FluxTrns::BULK_VISCOSITY]);
     double consistencyThreshold = 1.0e-18;


### PR DESCRIPTION
This PR adds the axisymmetric flow solver mode to the `_GPU_` code path, which resolves #104.  Doing so required two primary updates:

1. Add the position to the precomputed information available on the faces (e.g., via `struct interiorFaceIntegrationData` ), which enables one to set the radius correctly at each quadrature point
2. Modify `AxisymmetricForcing::updateTerms` to do the main computation of the axisymmetric source terms on the gpu in the usual way (i.e., using `MFEM_FORALL`).

Various other minor updates were also required, none of which are very noteworthy, with the exception of the interesting behavior discovered for cuda when extending `TransportProperties::GetViscosities` to be a `__device__` function.  Very briefly, it seems that when a `__device__` `virtual` function calls another `__device__` `virtual` function, if the function signatures are similar enough, then `nvlink` thinks you may have a recursive function, and it fails to automatically size the stack appropriately.  This behavior can lead to problems unless one manually sizes the stack correctly, which `tps` does not presently do.  It appears this same problem was observed in #184 (which was avoided rather than resolved in #193) but was not understood at that time.  I think it is also responsible for nvidia linker warnings associated with deconstructing a derived class via the base class destructor.  For more discussion see 1cac8e69d7d1c4d81e178fe9bbbb3e92e078c19a.