### PR TITLE
Allow user to specify parameters for "dry air" model

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -2345,6 +2345,8 @@ void M2ulPhyS::parseFluidPreset() {
   tpsP->getInput("flow/fluid", fluidTypeStr, std::string("dry_air"));
   if (fluidTypeStr == "dry_air") {
     config.workFluid = DRY_AIR;
+    tpsP->getInput("flow/specific_heat_ratio", config.dryAirInput.specific_heat_ratio, 1.4);
+    tpsP->getInput("flow/gas_constant", config.dryAirInput.gas_constant, 287.058);
   } else if (fluidTypeStr == "user_defined") {
     config.workFluid = USER_DEFINED;
   } else if (fluidTypeStr == "lte_table") {

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -311,7 +311,8 @@ void M2ulPhyS::initVariables() {
 
       tpsGpuMalloc((void **)&transportPtr, sizeof(DryAirTransport));
       gpu::instantiateDeviceDryAirTransport<<<1, 1>>>(d_mixture, config.GetViscMult(), config.GetBulkViscMult(),
-                                                      transportPtr);
+                                                      config.sutherland_.C1, config.sutherland_.S0,
+                                                      config.sutherland_.Pr, transportPtr);
 #else
       transportPtr = new DryAirTransport(mixture, config);
 #endif
@@ -2177,6 +2178,11 @@ void M2ulPhyS::parseFlowOptions() {
   assert(config.numIters >= 0);
   assert(config.itersOut > 0);
   assert(config.refLength > 0);
+
+  // Sutherland inputs default to dry air values
+  tpsP->getInput("flow/SutherlandC1", config.sutherland_.C1, 1.458e-6);
+  tpsP->getInput("flow/SutherlandS0", config.sutherland_.S0, 110.4);
+  tpsP->getInput("flow/SutherlandPr", config.sutherland_.Pr, 0.71);
 }
 
 void M2ulPhyS::parseTimeIntegrationOptions() {

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -146,6 +146,12 @@ enum ThermalCondition {
   NONE_THMCND
 };
 
+struct SutherlandData {
+  double C1;
+  double S0;
+  double Pr;
+};
+
 // The following four keywords define two planes in which
 // a linearly varying viscosity can be defined between these two.
 // The planes are defined by the normal and one point being the

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -505,6 +505,9 @@ struct DryAirInput {
   double bulk_visc_mult;
 #else
 #endif
+
+  double specific_heat_ratio;
+  double gas_constant;
 };
 
 struct PerfectMixtureInput {

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -127,7 +127,10 @@ DryAir::DryAir(RunConfiguration &_runfile, int _dim, int nvel)
     // : DryAir(_runfile.workFluid, _runfile.GetEquationSystem(), _runfile.visc_mult, _runfile.bulk_visc, _dim, nvel) {}
     : DryAir(_runfile.dryAirInput, _dim, nvel) {}
 
-MFEM_HOST_DEVICE DryAir::DryAir(const DryAirInput inputs, int _dim, int nvel) : GasMixture(inputs.f, _dim, nvel) {
+MFEM_HOST_DEVICE DryAir::DryAir(const DryAirInput inputs, int _dim, int nvel)
+    : GasMixture(inputs.f, _dim, nvel),
+      specific_heat_ratio(inputs.specific_heat_ratio),
+      gas_constant(inputs.gas_constant) {
   numSpecies = (inputs.eq_sys == NS_PASSIVE) ? 2 : 1;
   ambipolar = false;
   twoTemperature_ = false;
@@ -138,9 +141,6 @@ MFEM_HOST_DEVICE DryAir::DryAir(const DryAirInput inputs, int _dim, int nvel) : 
   assert(nvel_ <= gpudata::MAXDIM);
   assert(numSpecies <= gpudata::MAXSPECIES);
 #endif
-
-  gas_constant = 287.058;
-  specific_heat_ratio = 1.4;
 
   // TODO(kevin): replace Nconservative/Nprimitive.
   // add extra equation for passive scalar

--- a/src/gpu_constructor.cpp
+++ b/src/gpu_constructor.cpp
@@ -51,8 +51,9 @@ __global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs
 }
 
 __global__ void instantiateDeviceDryAirTransport(GasMixture *mixture, const double viscosity_multiplier,
-                                                 const double bulk_viscosity, void *transport) {
-  transport = new (transport) DryAirTransport(mixture, viscosity_multiplier, bulk_viscosity);
+                                                 const double bulk_viscosity, const double C1, const double S0,
+                                                 const double Pr, void *transport) {
+  transport = new (transport) DryAirTransport(mixture, viscosity_multiplier, bulk_viscosity, C1, S0, Pr);
 }
 
 __global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const constantTransportData inputs,

--- a/src/gpu_constructor.hpp
+++ b/src/gpu_constructor.hpp
@@ -96,7 +96,8 @@ __global__ void instantiateDevicePerfectMixture(const PerfectMixtureInput inputs
 
 //! Instantiate DryAirTransport object on the device with placement new
 __global__ void instantiateDeviceDryAirTransport(GasMixture *mixture, const double viscosity_multiplier,
-                                                 const double bulk_viscosity, void *transport);
+                                                 const double bulk_viscosity, const double C1, const double S0,
+                                                 const double Pr, void *transport);
 
 //! Instantiate ConstantTransport object on the device with placement new
 __global__ void instantiateDeviceConstantTransport(GasMixture *mixture, const constantTransportData inputs,

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -143,6 +143,8 @@ class RunConfiguration {
   // the plane defined by point0.
   linearlyVaryingVisc linViscData;
 
+  SutherlandData sutherland_;
+
   SpongeZoneData* spongeData_;
   int numSpongeRegions_;
   void initSpongeData();

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -151,8 +151,12 @@ class DryAirTransport : public TransportProperties {
   double bulk_visc_mult;
   double thermalConductivity;
 
+  // Constants for Sutherland's law: mu = C1_ * T^1.5 / (T + S0_)
+  const double C1_;
+  const double S0_;
+
   // Prandtl number
-  double Pr;         // Prandtl number
+  const double Pr_;  // Prandtl number
   double cp_div_pr;  // cp divided by Pr (used in conductivity calculation)
 
   // Fick's law
@@ -160,8 +164,8 @@ class DryAirTransport : public TransportProperties {
 
  public:
   DryAirTransport(GasMixture *_mixture, RunConfiguration &_runfile);
-  MFEM_HOST_DEVICE DryAirTransport(GasMixture *_mixture, const double viscosity_multiplier,
-                                   const double bulk_viscosity);
+  MFEM_HOST_DEVICE DryAirTransport(GasMixture *_mixture, const double viscosity_multiplier, const double bulk_viscosity,
+                                   const double C1 = 1.458e-6, const double S = 110.4, const double Pr = 0.71);
 
   MFEM_HOST_DEVICE virtual ~DryAirTransport() {}
 
@@ -185,7 +189,7 @@ class DryAirTransport : public TransportProperties {
 MFEM_HOST_DEVICE inline void DryAirTransport::GetViscosities(const double *conserved, const double *primitive,
                                                              double *visc) {
   const double temp = primitive[1 + nvel_];
-  visc[0] = (1.458e-6 * visc_mult * pow(temp, 1.5) / (temp + 110.4));
+  visc[0] = (C1_ * visc_mult * pow(temp, 1.5) / (temp + S0_));
   visc[1] = bulk_visc_mult * visc[0];
 }
 


### PR DESCRIPTION
Specifically the gas constant, specific heat ratio, Sutherland's law parameters, and Prandtl number.  This allows "cold" simulations with fluids besides air.   The parameter values default to those previously hardcoded (i.e., air values) so no change is necessary to existing input files.