### PR TITLE
Add mpi4py support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,16 @@ if test ${enable_pybind11} == "yes" ; then
    fi
    AC_LANG_POP([C++])
 
+   # check for mpi4py
+   AC_MSG_CHECKING([if mpi4py is available])
+   AS_IF([$PYTHON -m mpi4py.bench helloworld >& /dev/null], [found_mpi4py=yes], [found_mpi4py=no])
+   if test "x${found_mpi4py}" = "xno" ; then
+      AC_MSG_RESULT([no])
+      # for now, just notify user, but in future this failure will be an error
+      #AC_MSG_ERROR([mpi4py not found. Please verify mpi4py is installed locally.])
+   else
+      AC_MSG_RESULT([yes])
+   fi
 fi
 AM_CONDITIONAL(PYTHON_ENABLED,test x$enable_pybind11 = xyes)
 

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -149,6 +149,9 @@ RUN yum -y install gsl-gnu9-ohpc
 
 RUN pip3 install "pybind11[global]"
 
+RUN . /etc/profile.d/lmod.sh \
+    && pip3 install mpi4py
+
 # Register new libs installed into /usr/local/lib with linker
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/class.conf
 RUN ldconfig

--- a/m4/snarf_mpi4py.py
+++ b/m4/snarf_mpi4py.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+import logging
+import mpi4py
+import mpi4py.MPI as MPI
+
+logging.basicConfig(format="%(message)s",level=logging.INFO,stream=sys.stdout)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--lib",     dest='get_lib',action='store_true',help="Get library")
+parser.add_argument("--include", dest='get_inc',action='store_true',help="Get include path")
+args = parser.parse_args()
+
+if args.get_lib and args.get_inc:
+    logging.error("[ERROR]: Options --lib and --inc cannot be run simultaneously.")
+    exit(1)
+
+if args.get_lib:
+    print(MPI.__file__)
+
+if args.get_inc:
+    print(mpi4py.get_include())


### PR DESCRIPTION
Add [mpi4py](https://github.com/mpi4py/mpi4py) to the default test container environment.  This addition is intended to support refactoring to enable `main` (the python main `tps.py` in this case) to own `MPI_Init`, as envisioned by #210.