### PR TITLE
Update testing on local runners

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,15 +89,15 @@ jobs:
       - name: MFEM Tree
         run: echo "MFEM_DIR=$MFEM_DIR"
       - name: Query modules loaded
-        run:  module restore tps-gpu; module list
+        run:  module restore tps-gpu-gnu9; module list
       - name: Bootstrap
-        run:  module restore tps-gpu; ./bootstrap
+        run:  module restore tps-gpu-gnu9; ./bootstrap
       - name: Configure
-        run: module restore tps-gpu; ./configure --enable-pybind11 --enable-gpu-cuda CUDA_ARCH=sm_75
+        run: module restore tps-gpu-gnu9; ./configure --enable-pybind11 --enable-gpu-cuda CUDA_ARCH=sm_75
       - name: Make
-        run: module restore tps-gpu; make -j 2
+        run: module restore tps-gpu-gnu9; make -j 2
       - name: Tests
-        run: module restore tps-gpu; make AM_COLOR_TESTS=yes check || (cat test/*.log; exit 1)
+        run: module restore tps-gpu-gnu9; make AM_COLOR_TESTS=yes check || (cat test/*.log; exit 1)
    build-hip:
     runs-on: [self-hosted, linux, x64, gpu, hip]
     name: Build/GPU (AMD/HIP)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -245,21 +245,21 @@ jobs:
        - name: MFEM Tree
          run:  echo "MFEM_INC=$MFEM_INC, MFEM_LIB=$MFEM_LIB"
        - name: Query modules loaded
-         run:  module restore tps-gpu; module list         
+         run:  module restore tps-gpu-gnu9; module list         
        - name: Configure
-         run:  cd tps-*; module restore tps-gpu; ./configure --enable-gpu-cuda CUDA_ARCH=sm_75
+         run:  cd tps-*; module restore tps-gpu-gnu9; ./configure --enable-gpu-cuda CUDA_ARCH=sm_75
        - name: Make
-         run:  cd tps-*; module restore tps-gpu; make -j 2
+         run:  cd tps-*; module restore tps-gpu-gnu9; make -j 2
        - name: TPS version
-         run:  cd tps-*; module restore tps-gpu; ./src/tps --version         
+         run:  cd tps-*; module restore tps-gpu-gnu9; ./src/tps --version         
        - name: Tests
-         run:  cd tps-*; module restore tps-gpu; make AM_COLOR_TESTS=yes check || (cat test/*.log; exit 1)
+         run:  cd tps-*; module restore tps-gpu-gnu9; make AM_COLOR_TESTS=yes check || (cat test/*.log; exit 1)
        - name: Distclean
          run:  cd tps-*; make distclean
        - name: VPATH configure
-         run:  cd tps-*; mkdir build; cd build; module restore tps-gpu; ../configure --enable-gpu-cuda CUDA_ARCH=sm_75
+         run:  cd tps-*; mkdir build; cd build; module restore tps-gpu-gnu9; ../configure --enable-gpu-cuda CUDA_ARCH=sm_75
        - name: VPATH Make
-         run:  cd tps-*; cd build; module restore tps-gpu; make -j 2
+         run:  cd tps-*; cd build; module restore tps-gpu-gnu9; make -j 2
        - name: VPATH Tests
-         run:  cd tps-*; cd build; module restore tps-gpu; make AM_COLOR_TESTS=yes check || (cat test/*.log; exit 1)
+         run:  cd tps-*; cd build; module restore tps-gpu-gnu9; make AM_COLOR_TESTS=yes check || (cat test/*.log; exit 1)
  

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,12 +102,12 @@ jobs:
     runs-on: [self-hosted, linux, x64, gpu, hip]
     name: Build/GPU (AMD/HIP)
     env:
-      MFEM_DIR: /home/karl/sw/mfem-hip-4.3
+      MFEM_DIR: /home/oliver/sw/mfem-4.5.2-hip
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.11.0
         with:
-          access_token: ${{ github.token }}    
+          access_token: ${{ github.token }}
       - name: Checkout code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -133,6 +133,8 @@ jobs:
    build-gpu-cpu:
     runs-on: [self-hosted, linux, x64, gpu, hip]
     name: Build/GPU-CPU
+    env:
+      MFEM_DIR: /home/oliver/sw/mfem-4.5.2-cpu
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -142,6 +144,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           lfs: true
+      - name: MFEM Tree
+        run: echo "MFEM_DIR=$MFEM_DIR"
       - name: Query modules loaded
         run:  module restore tps-gpu-cpu; module list
       - name: Bootstrap

--- a/configure.ac
+++ b/configure.ac
@@ -107,39 +107,6 @@ AM_CONDITIONAL(SLURM_ENABLED,test x$ENABLE_SLURM = xyes)
 
 
 
-#-- GSLIB support in MFEM?
-AC_MSG_CHECKING([if GSLIB is available])
-
-ENABLE_GSLIB=no
-
-AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-#include <mfem/config/config.hpp>
-#ifndef MFEM_USE_GSLIB
-# error macro not defined
-#endif
-]])], [found_gslib_support="yes"], [found_gslib_support="no"])
-
-
-AH_TEMPLATE([HAVE_GSLIB],[Enable GSLIB support])
-if test "x$found_gslib_support" != "xno" ; then
-   AC_CHECK_HEADER([gslib.h],[found_gslib_header=yes],[found_gslib_header=no])
-
-   if test "x${found_gslib_header}" = "xyes" ; then
-      AC_CHECK_LIB([gs],gslib_findpts_3,[found_gslib_library=yes],[found_gslib_library=no],[-lm])
-      if test "x${found_gslib_library}" = "xyes" ; then
-         AC_DEFINE([HAVE_GSLIB])
-         ENABLE_GSLIB=yes
-      fi
-   fi
-fi
-
-if test "x$ENABLE_GSLIB" = "xno" ; then
-   AC_MSG_RESULT([no])
-else
-   AC_MSG_RESULT([yes])
-fi
-
-AM_CONDITIONAL(GSLIB_ENABLED,test x$ENABLE_GSLIB = xyes)
 
 AH_TEMPLATE([_GPU_], [Build in GPU support])
 AH_TEMPLATE([_CUDA_],[CUDA backend])
@@ -231,6 +198,38 @@ fi
 
 
 AX_PATH_MFEM([4.3],  [yes])
+
+#-- GSLIB support in MFEM?
+AC_MSG_CHECKING([if GSLIB is available in mfem])
+
+ENABLE_GSLIB=no
+
+AC_LANG_PUSH([C++])
+cxxflags_save=$CXXFLAGS
+CXXFLAGS="$CXXFLAGS $MFEM_CXXFLAGS"
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+#include <mfem/config/config.hpp>
+#ifndef MFEM_USE_GSLIB
+# error macro not defined
+#endif
+]])], [found_gslib_support="yes"], [found_gslib_support="no"])
+CXXFLAGS=$cxxflags_save
+AC_LANG_POP([C++])
+
+AH_TEMPLATE([HAVE_GSLIB],[Enable GSLIB support])
+
+if test "x$found_gslib_support" = "xyes" ; then
+   AC_DEFINE([HAVE_GSLIB])
+   ENABLE_GSLIB=yes
+fi
+
+if test "x$ENABLE_GSLIB" = "xno" ; then
+   AC_MSG_RESULT([no])
+else
+   AC_MSG_RESULT([yes])
+fi
+
+AM_CONDITIONAL(GSLIB_ENABLED,test x$ENABLE_GSLIB = xyes)
 
 
 # -------------------------------------------------------------

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -41,6 +41,11 @@ ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixture, RunConfigurat
 
 MFEM_HOST_DEVICE ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixture, const ArgonTransportInput &inputs)
     : TransportProperties(_mixture) {
+  viscosityFactor_ = 5. / 16. * sqrt(PI_ * kB_);
+  kOverEtaFactor_ = 15. / 4. * kB_;
+  diffusivityFactor_ = 3. / 16. * sqrt(2.0 * PI_ * kB_) / AVOGADRONUMBER;
+  mfFreqFactor_ = 4. / 3. * AVOGADRONUMBER * sqrt(8. * kB_ / PI_);
+
   // if (!ambipolar) {
   //   grvy_printf(GRVY_ERROR, "\nArgon ternary transport currently supports ambipolar condition only. Set
   //   plasma_models/ambipolar = true.\n"); exit(ERROR);
@@ -109,7 +114,12 @@ MFEM_HOST_DEVICE ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixtu
   setArtificialMultipliers(inputs);
 }
 
-MFEM_HOST_DEVICE ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixture) : TransportProperties(_mixture) {}
+MFEM_HOST_DEVICE ArgonMinimalTransport::ArgonMinimalTransport(GasMixture *_mixture) : TransportProperties(_mixture) {
+  viscosityFactor_ = 5. / 16. * sqrt(PI_ * kB_);
+  kOverEtaFactor_ = 15. / 4. * kB_;
+  diffusivityFactor_ = 3. / 16. * sqrt(2.0 * PI_ * kB_) / AVOGADRONUMBER;
+  mfFreqFactor_ = 4. / 3. * AVOGADRONUMBER * sqrt(8. * kB_ / PI_);
+}
 
 // void ArgonMinimalTransport::computeEffectiveMass(const Vector &mw, DenseSymmetricMatrix &muw) {
 MFEM_HOST_DEVICE void ArgonMinimalTransport::computeEffectiveMass(const double *mw, double *muw) {

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -50,7 +50,7 @@
 #include "transport_properties.hpp"
 
 using namespace mfem;
-using namespace std;
+// using namespace std;
 // using namespace charged;
 // using namespace argon;
 
@@ -74,10 +74,11 @@ class ArgonMinimalTransport : public TransportProperties {
   const double qeOverkB_ = qe_ / kB_;
 
   // standard Chapman-Enskog coefficients
-  const double viscosityFactor_ = 5. / 16. * sqrt(PI_ * kB_);
-  const double kOverEtaFactor_ = 15. / 4. * kB_;
-  const double diffusivityFactor_ = 3. / 16. * sqrt(2.0 * PI_ * kB_) / AVOGADRONUMBER;
-  const double mfFreqFactor_ = 4. / 3. * AVOGADRONUMBER * sqrt(8. * kB_ / PI_);
+  // evaluated in ctor to avoid confusing hip about sqrt
+  double viscosityFactor_;
+  double kOverEtaFactor_;
+  double diffusivityFactor_;
+  double mfFreqFactor_;
 
   // molecular mass per each particle. [kg^-1]
   double mw_[gpudata::MAXSPECIES];


### PR DESCRIPTION
Our local runner environments have been upgraded to use the gnu12 stack from ohpc by default.  This PR updates the github actions CI to run the tests with the new environment, including

* Updating mfem paths where necessary (to use an up-to-date mfem, built with gnu12 stack)
* Fixing the gslib check in `configure.ac` (changes in test env uncovered fact that previous check was broken)
* For the cuda build, force gnu9, since our existing cuda installation doesn't support gnu12