### PR TITLE
Mixing length turbulence model

### DIFF
--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -42,7 +42,8 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
                            GasMixture *d_mixture, Fluxes *_fluxClass, ParGridFunction *_Up, ParGridFunction *_gradUp,
                            const boundaryFaceIntegrationData &boundary_face_data, const int _dim,
                            const int _num_equation, double &_max_char_speed, RunConfiguration &_runFile,
-                           Array<int> &local_attr, const int &_maxIntPoints, const int &_maxDofs, ParGridFunction *distance)
+                           Array<int> &local_attr, const int &_maxIntPoints, const int &_maxDofs,
+                           ParGridFunction *distance)
     : groupsMPI(_groupsMPI),
       config(_runFile),
       rsolver(rsolver_),
@@ -225,10 +226,12 @@ void BCintegrator::computeBdrFlux(const int attr, Vector &normal, Vector &stateI
   std::unordered_map<int, BoundaryCondition *>::const_iterator obc = outletBCmap.find(attr);
   std::unordered_map<int, BoundaryCondition *>::const_iterator wbc = wallBCmap.find(attr);
 
-  if (ibc != inletBCmap.end()) ibc->second->computeBdrFlux(normal, stateIn, gradState, transip, delta, distance, bdrFlux);
+  if (ibc != inletBCmap.end())
+    ibc->second->computeBdrFlux(normal, stateIn, gradState, transip, delta, distance, bdrFlux);
   if (obc != outletBCmap.end())
     obc->second->computeBdrFlux(normal, stateIn, gradState, transip, delta, distance, bdrFlux);
-  if (wbc != wallBCmap.end()) wbc->second->computeBdrFlux(normal, stateIn, gradState, transip, delta, distance, bdrFlux);
+  if (wbc != wallBCmap.end())
+    wbc->second->computeBdrFlux(normal, stateIn, gradState, transip, delta, distance, bdrFlux);
 
   //   BCmap[attr]->computeBdrFlux(normal, stateIn, gradState, radius, bdrFlux);
 }
@@ -341,7 +344,6 @@ void BCintegrator::AssembleFaceVector(const FiniteElement &el1, const FiniteElem
     dist.SetSize(dofs.Size());
     distance_->GetSubVector(dofs, dist);
   }
-
 
   // Integration order calculation from DGTraceIntegrator
   int intorder;

--- a/src/BCintegrator.hpp
+++ b/src/BCintegrator.hpp
@@ -84,8 +84,8 @@ class BCintegrator : public NonlinearFormIntegrator {
   std::unordered_map<int, BoundaryCondition *> wallBCmap;
 
   // void calcMeanState();
-  void computeBdrFlux(const int attr, Vector &normal, Vector &stateIn, DenseMatrix &gradState,
-                      Vector transip, double delta, double distance, Vector &bdrFlux);
+  void computeBdrFlux(const int attr, Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
+                      double delta, double distance, Vector &bdrFlux);
 
  public:
   BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules,

--- a/src/BCintegrator.hpp
+++ b/src/BCintegrator.hpp
@@ -69,6 +69,8 @@ class BCintegrator : public NonlinearFormIntegrator {
 
   ParGridFunction *gradUp;
 
+  ParGridFunction *distance_;
+
   const boundaryFaceIntegrationData &boundary_face_data_;
 
   const int dim;
@@ -82,15 +84,15 @@ class BCintegrator : public NonlinearFormIntegrator {
   std::unordered_map<int, BoundaryCondition *> wallBCmap;
 
   // void calcMeanState();
-  void computeBdrFlux(const int attr, Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius,
-                      Vector transip, double delta, Vector &bdrFlux);
+  void computeBdrFlux(const int attr, Vector &normal, Vector &stateIn, DenseMatrix &gradState,
+                      Vector transip, double delta, double distance, Vector &bdrFlux);
 
  public:
   BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules,
                RiemannSolver *rsolver_, double &_dt, GasMixture *mixture, GasMixture *d_mixture, Fluxes *_fluxClass,
                ParGridFunction *_Up, ParGridFunction *_gradUp, const boundaryFaceIntegrationData &boundary_face_data,
                const int _dim, const int _num_equation, double &_max_char_speed, RunConfiguration &_runFile,
-               Array<int> &local_bdr_attr, const int &_maxIntPoints, const int &_maxDofs);
+               Array<int> &local_bdr_attr, const int &_maxIntPoints, const int &_maxDofs, ParGridFunction *distance_);
   ~BCintegrator();
 
   virtual void AssembleFaceVector(const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &Tr,

--- a/src/BoundaryCondition.hpp
+++ b/src/BoundaryCondition.hpp
@@ -73,8 +73,8 @@ class BoundaryCondition {
                     const int _patchNumber, const double _refLength, bool axisym);
   virtual ~BoundaryCondition();
 
-  virtual void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                              double delta, double distance, Vector &bdrFlux) = 0;
+  virtual void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                              double distance, Vector &bdrFlux) = 0;
 
   // holding function for any miscellaneous items needed to initialize BCs
   // prior to use (and require MPI)

--- a/src/BoundaryCondition.hpp
+++ b/src/BoundaryCondition.hpp
@@ -73,8 +73,8 @@ class BoundaryCondition {
                     const int _patchNumber, const double _refLength, bool axisym);
   virtual ~BoundaryCondition();
 
-  virtual void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector transip,
-                              double delta, Vector &bdrFlux) = 0;
+  virtual void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
+                              double delta, double distance, Vector &bdrFlux) = 0;
 
   // holding function for any miscellaneous items needed to initialize BCs
   // prior to use (and require MPI)

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -569,7 +569,7 @@ void M2ulPhyS::initVariables() {
     //    if( basisType==1 && intRuleType==1 ) useLinearIntegration = true;
 
     faceIntegrator = new FaceIntegrator(intRules, rsolver, d_fluxClass, vfes, useLinearIntegration, dim, num_equation,
-                                        gradUp, gradUpfes, max_char_speed, config.isAxisymmetric());
+                                        gradUp, gradUpfes, max_char_speed, config.isAxisymmetric(), distance_);
   }
   A->AddInteriorFaceIntegrator(faceIntegrator);
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -35,21 +35,21 @@
 
 #include "M2ulPhyS.hpp"
 
-M2ulPhyS::M2ulPhyS(TPS::Tps *tps):
-  groupsMPI( new MPI_Groups(tps->getTPSCommWorld()) ),
-  nprocs_(groupsMPI->getTPSWorldSize()),
-  rank_(groupsMPI->getTPSWorldRank()),
-  rank0_(groupsMPI->isWorldRoot()),
-  tpsP(tps) {
+M2ulPhyS::M2ulPhyS(TPS::Tps *tps)
+    : groupsMPI(new MPI_Groups(tps->getTPSCommWorld())),
+      nprocs_(groupsMPI->getTPSWorldSize()),
+      rank_(groupsMPI->getTPSWorldRank()),
+      rank0_(groupsMPI->isWorldRoot()),
+      tpsP(tps) {
   parseSolverOptions2();
 }
 
-M2ulPhyS::M2ulPhyS(string &inputFileName, TPS::Tps *tps) :
-  groupsMPI( new MPI_Groups(tps->getTPSCommWorld()) ),
-  nprocs_(groupsMPI->getTPSWorldSize()),
-  rank_(groupsMPI->getTPSWorldRank()),
-  rank0_(groupsMPI->isWorldRoot()),
-  tpsP(tps) {
+M2ulPhyS::M2ulPhyS(string &inputFileName, TPS::Tps *tps)
+    : groupsMPI(new MPI_Groups(tps->getTPSCommWorld())),
+      nprocs_(groupsMPI->getTPSWorldSize()),
+      rank_(groupsMPI->getTPSWorldRank()),
+      rank0_(groupsMPI->isWorldRoot()),
+      tpsP(tps) {
   // koomie TODO: refactor order so we can use standard parseSolverOptions call from Solver base class
 #define NEWPARSER
 #ifdef NEWPARSER
@@ -2426,7 +2426,8 @@ void M2ulPhyS::parsePlasmaModels() {
   } else if (transportModelStr == "constant") {
     config.transportModel = CONSTANT;
   }
-  printf("config.transportModel = %s\n", transportModelStr.c_str()); fflush(stdout);
+  printf("config.transportModel = %s\n", transportModelStr.c_str());
+  fflush(stdout);
   // } else {
   //   grvy_printf(GRVY_ERROR, "\nUnknown transport_model -> %s", transportModelStr.c_str());
   //   exit(ERROR);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -3610,7 +3610,7 @@ void M2ulPhyS::updateVisualizationVariables() {
       double diffVel[gpudata::MAXSPECIES * gpudata::MAXDIM];
       double distance = 0;
       if (distance_ != NULL) distance = (*distance_)[n];
-      in_transport->ComputeFluxTransportProperties(state, gradUpn, Efield, distance, fluxTrns, diffVel);
+      in_transport->ComputeFluxTransportProperties(state, gradUpn, Efield, -1, distance, fluxTrns, diffVel);
       for (int t = 0; t < FluxTrns::NUM_FLUX_TRANS; t++) {
         dataVis[visualIdxs.FluxTrns + t][n] = fluxTrns[t];
       }

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1037,7 +1037,10 @@ void M2ulPhyS::initIndirectionArrays() {
   vfes->ExchangeFaceNbrData();
   gradUpfes->ExchangeFaceNbrData();
 
-  distance_->ExchangeFaceNbrData();
+  if (distance_ != NULL) {
+    distance_->ParFESpace()->ExchangeFaceNbrData();
+    distance_->ExchangeFaceNbrData();
+  }
 
   if (Nshared > 0) {
     shared_face_data.elem2_dofs.SetSize(Nshared * num_equation * maxDofs);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -555,7 +555,7 @@ void M2ulPhyS::initVariables() {
   if (local_attr.Size() > 0) {
     bcIntegrator = new BCintegrator(groupsMPI, mesh, vfes, intRules, rsolver, dt, mixture, d_mixture, d_fluxClass, Up,
                                     gradUp, gpu_precomputed_data_.boundary_face_data, dim, num_equation, max_char_speed,
-                                    config, local_attr, maxIntPoints, maxDofs);
+                                    config, local_attr, maxIntPoints, maxDofs, distance_);
   }
 
   // A->SetAssemblyLevel(AssemblyLevel::PARTIAL);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -3614,7 +3614,15 @@ void M2ulPhyS::updateVisualizationVariables() {
       double diffVel[gpudata::MAXSPECIES * gpudata::MAXDIM];
       double distance = 0;
       if (distance_ != NULL) distance = (*distance_)[n];
-      in_transport->ComputeFluxTransportProperties(state, gradUpn, Efield, -1, distance, fluxTrns, diffVel);
+
+      double radius = -1;
+      if (config.isAxisymmetric()) {
+        ParGridFunction *xyz = new ParGridFunction(dfes);
+        mesh->GetNodes(*xyz);
+        radius = (*xyz)[n + 0 * ndofs];
+      }
+
+      in_transport->ComputeFluxTransportProperties(state, gradUpn, Efield, radius, distance, fluxTrns, diffVel);
       for (int t = 0; t < FluxTrns::NUM_FLUX_TRANS; t++) {
         dataVis[visualIdxs.FluxTrns + t][n] = fluxTrns[t];
       }

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -3621,7 +3621,8 @@ void M2ulPhyS::updateVisualizationVariables() {
       // update source transport properties.
       double srcTrns[SrcTrns::NUM_SRC_TRANS];
       double speciesTrns[gpudata::MAXSPECIES * SpeciesTrns::NUM_SPECIES_COEFFS];
-      in_transport->ComputeSourceTransportProperties(state, prim, gradUpn, Efield, distance, srcTrns, speciesTrns, diffVel, nsp);
+      in_transport->ComputeSourceTransportProperties(state, prim, gradUpn, Efield, distance, srcTrns, speciesTrns,
+                                                     diffVel, nsp);
       for (int t = 0; t < SrcTrns::NUM_SRC_TRANS; t++) {
         dataVis[visualIdxs.SrcTrns + t][n] = srcTrns[t];
       }

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -616,7 +616,7 @@ void M2ulPhyS::initVariables() {
       new RHSoperator(iter, dim, num_equation, order, eqSystem, max_char_speed, intRules, intRuleType, d_fluxClass,
                       mixture, d_mixture, chemistry_, transportPtr, radiation_, vfes, fes, gpu_precomputed_data_,
                       maxIntPoints, maxDofs, A, Aflux, mesh, spaceVaryViscMult, U, Up, gradUp, gradUpfes, gradUp_A,
-                      bcIntegrator, config, plasma_conductivity_, joule_heating_);
+                      bcIntegrator, config, plasma_conductivity_, joule_heating_, distance_);
 
   CFL = config.GetCFLNumber();
   rhsOperator->SetTime(time);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -217,6 +217,9 @@ void M2ulPhyS::initVariables() {
     }
     // Done with serial_distance
     delete serial_distance;
+
+    distance_->ParFESpace()->ExchangeFaceNbrData();
+    distance_->ExchangeFaceNbrData();
   }
 
   // only need serial mesh if on rank 0 and using single restart file option

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -3608,7 +3608,9 @@ void M2ulPhyS::updateVisualizationVariables() {
       // update flux transport properties.
       double fluxTrns[FluxTrns::NUM_FLUX_TRANS];
       double diffVel[gpudata::MAXSPECIES * gpudata::MAXDIM];
-      in_transport->ComputeFluxTransportProperties(state, gradUpn, Efield, fluxTrns, diffVel);
+      double distance = 0;
+      if (distance_ != NULL) distance = (*distance_)[n];
+      in_transport->ComputeFluxTransportProperties(state, gradUpn, Efield, distance, fluxTrns, diffVel);
       for (int t = 0; t < FluxTrns::NUM_FLUX_TRANS; t++) {
         dataVis[visualIdxs.FluxTrns + t][n] = fluxTrns[t];
       }
@@ -3619,7 +3621,7 @@ void M2ulPhyS::updateVisualizationVariables() {
       // update source transport properties.
       double srcTrns[SrcTrns::NUM_SRC_TRANS];
       double speciesTrns[gpudata::MAXSPECIES * SpeciesTrns::NUM_SPECIES_COEFFS];
-      in_transport->ComputeSourceTransportProperties(state, prim, gradUpn, Efield, srcTrns, speciesTrns, diffVel, nsp);
+      in_transport->ComputeSourceTransportProperties(state, prim, gradUpn, Efield, distance, srcTrns, speciesTrns, diffVel, nsp);
       for (int t = 0; t < SrcTrns::NUM_SRC_TRANS; t++) {
         dataVis[visualIdxs.SrcTrns + t][n] = srcTrns[t];
       }

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -67,6 +67,7 @@ class Tps;
 #include "logger.hpp"
 #include "lte_mixture.hpp"
 #include "lte_transport_properties.hpp"
+#include "mixing_length_transport.hpp"
 #include "mpi_groups.hpp"
 #include "radiation.hpp"
 #include "rhs_operator.hpp"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,7 +36,7 @@ cxx_sources          = averaging_and_rms.cpp faceGradientIntegration.cpp M2ulPhy
 		       dgNonlinearForm.cpp gradients.cpp gradNonLinearForm.cpp quasimagnetostatic.cpp tps.cpp chemistry.cpp \
                        reaction.cpp collision_integrals.cpp argon_transport.cpp source_term.cpp gpu_constructor.cpp \
                        independent_coupling.cpp cycle_avg_joule_coupling.cpp table.cpp radiation.cpp lte_mixture.cpp \
-                       lte_transport_properties.cpp
+                       lte_transport_properties.cpp mixing_length_transport.cpp
 
 mfem_extra_sources   = ../utils/mfem_extras/pfem_extras.cpp
 
@@ -48,7 +48,7 @@ headers              = averaging_and_rms.hpp equation_of_state.hpp transport_pro
 		       quasimagnetostatic.hpp gradients.hpp logger.hpp solver.hpp tps.hpp chemistry.hpp reaction.hpp \
 	               collision_integrals.hpp argon_transport.hpp source_term.hpp tps_mfem_wrap.hpp gpu_constructor.hpp \
                        independent_coupling.hpp cycle_avg_joule_coupling.hpp table.hpp radiation.hpp lte_mixture.hpp \
-                       lte_transport_properties.hpp
+                       lte_transport_properties.hpp mixing_length_transport.hpp
 
 mfem_extra_headers   = ../utils/mfem_extras/pfem_extras.hpp
 

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -170,11 +170,12 @@ MFEM_HOST_DEVICE collisionInputs ArgonMinimalTransport::computeCollisionInputs(c
 }
 
 void ArgonMinimalTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp,
-                                                           const Vector &Efield, double distance, Vector &transportBuffer,
-                                                           DenseMatrix &diffusionVelocity) {
+                                                           const Vector &Efield, double distance,
+                                                           Vector &transportBuffer, DenseMatrix &diffusionVelocity) {
   transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   diffusionVelocity.SetSize(numSpecies, nvel_);
-  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0], diffusionVelocity.Write());
+  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0],
+                                 diffusionVelocity.Write());
 }
 
 MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
@@ -424,7 +425,8 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::computeMixtureAverageDiffusivity(co
 
 void ArgonMinimalTransport::ComputeSourceTransportProperties(const Vector &state, const Vector &Up,
                                                              const DenseMatrix &gradUp, const Vector &Efield,
-                                                             double distance, Vector &globalTransport, DenseMatrix &speciesTransport,
+                                                             double distance, Vector &globalTransport,
+                                                             DenseMatrix &speciesTransport,
                                                              DenseMatrix &diffusionVelocity, Vector &n_sp) {
   globalTransport.SetSize(SrcTrns::NUM_SRC_TRANS);
   speciesTransport.SetSize(numSpecies, SpeciesTrns::NUM_SPECIES_COEFFS);
@@ -791,11 +793,12 @@ MFEM_HOST_DEVICE double ArgonMixtureTransport::collisionIntegral(const int _spI,
 }
 
 void ArgonMixtureTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp,
-                                                           const Vector &Efield, double distance, Vector &transportBuffer,
-                                                           DenseMatrix &diffusionVelocity) {
+                                                           const Vector &Efield, double distance,
+                                                           Vector &transportBuffer, DenseMatrix &diffusionVelocity) {
   transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   diffusionVelocity.SetSize(numSpecies, nvel_);
-  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0], diffusionVelocity.Write());
+  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0],
+                                 diffusionVelocity.Write());
 }
 
 MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
@@ -925,7 +928,8 @@ MFEM_HOST_DEVICE double ArgonMixtureTransport::computeThirdOrderElectronThermalC
 
 void ArgonMixtureTransport::ComputeSourceTransportProperties(const Vector &state, const Vector &Up,
                                                              const DenseMatrix &gradUp, const Vector &Efield,
-                                                             double distance, Vector &globalTransport, DenseMatrix &speciesTransport,
+                                                             double distance, Vector &globalTransport,
+                                                             DenseMatrix &speciesTransport,
                                                              DenseMatrix &diffusionVelocity, Vector &n_sp) {
   globalTransport.SetSize(SrcTrns::NUM_SRC_TRANS);
   speciesTransport.SetSize(numSpecies, SpeciesTrns::NUM_SPECIES_COEFFS);
@@ -936,8 +940,8 @@ void ArgonMixtureTransport::ComputeSourceTransportProperties(const Vector &state
 }
 
 MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeSourceTransportProperties(
-    const double *state, const double *Up, const double *gradUp, const double *Efield, double distance, double *globalTransport,
-    double *speciesTransport, double *diffusionVelocity, double *n_sp) {
+    const double *state, const double *Up, const double *gradUp, const double *Efield, double distance,
+    double *globalTransport, double *speciesTransport, double *diffusionVelocity, double *n_sp) {
   for (int p = 0; p < SrcTrns::NUM_SRC_TRANS; p++) globalTransport[p] = 0.0;
   for (int p = 0; p < SpeciesTrns::NUM_SPECIES_COEFFS; p++)
     for (int sp = 0; sp < numSpecies; sp++) speciesTransport[sp + p * numSpecies] = 0.0;

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -536,8 +536,7 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeSourceTransportProperties(
   // std::cout << "max diff. vel: " << charSpeed << std::endl;
 }
 
-MFEM_HOST_DEVICE void ArgonMinimalTransport::GetViscosities(const double *conserved, const double *primitive,
-                                                            double distance, double *visc) {
+MFEM_HOST_DEVICE void ArgonMinimalTransport::GetViscosities(const double *conserved, const double *primitive, double *visc) {
   double n_sp[3], X_sp[3], Y_sp[3];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
   double nTotal = 0.0;
@@ -1027,8 +1026,7 @@ MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeSourceTransportProperties(
   // std::cout << "max diff. vel: " << charSpeed << std::endl;
 }
 
-MFEM_HOST_DEVICE void ArgonMixtureTransport::GetViscosities(const double *conserved, const double *primitive,
-                                                            double distance, double *visc) {
+MFEM_HOST_DEVICE void ArgonMixtureTransport::GetViscosities(const double *conserved, const double *primitive, double *visc) {
   double n_sp[gpudata::MAXSPECIES], X_sp[gpudata::MAXSPECIES], Y_sp[gpudata::MAXSPECIES];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
   double nTotal = 0.0;

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -170,15 +170,15 @@ MFEM_HOST_DEVICE collisionInputs ArgonMinimalTransport::computeCollisionInputs(c
 }
 
 void ArgonMinimalTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp,
-                                                           const Vector &Efield, Vector &transportBuffer,
+                                                           const Vector &Efield, double distance, Vector &transportBuffer,
                                                            DenseMatrix &diffusionVelocity) {
   transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   diffusionVelocity.SetSize(numSpecies, nvel_);
-  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], &transportBuffer[0], diffusionVelocity.Write());
+  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0], diffusionVelocity.Write());
 }
 
 MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                                            const double *Efield,
+                                                                            const double *Efield, double distance,
                                                                             double *transportBuffer,
                                                                             double *diffusionVelocity) {
   // transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
@@ -424,19 +424,19 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::computeMixtureAverageDiffusivity(co
 
 void ArgonMinimalTransport::ComputeSourceTransportProperties(const Vector &state, const Vector &Up,
                                                              const DenseMatrix &gradUp, const Vector &Efield,
-                                                             Vector &globalTransport, DenseMatrix &speciesTransport,
+                                                             double distance, Vector &globalTransport, DenseMatrix &speciesTransport,
                                                              DenseMatrix &diffusionVelocity, Vector &n_sp) {
   globalTransport.SetSize(SrcTrns::NUM_SRC_TRANS);
   speciesTransport.SetSize(numSpecies, SpeciesTrns::NUM_SPECIES_COEFFS);
   diffusionVelocity.SetSize(numSpecies, nvel_);
   n_sp.SetSize(3);
-  ComputeSourceTransportProperties(&state[0], &Up[0], gradUp.Read(), &Efield[0], &globalTransport[0],
+  ComputeSourceTransportProperties(&state[0], &Up[0], gradUp.Read(), &Efield[0], distance, &globalTransport[0],
                                    speciesTransport.Write(), diffusionVelocity.Write(), &n_sp[0]);
 }
 
 MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeSourceTransportProperties(
-    const double *state, const double *Up, const double *gradUp, const double *Efield, double *globalTransport,
-    double *speciesTransport, double *diffusionVelocity, double *n_sp) {
+    const double *state, const double *Up, const double *gradUp, const double *Efield, double distance,
+    double *globalTransport, double *speciesTransport, double *diffusionVelocity, double *n_sp) {
   for (int p = 0; p < SrcTrns::NUM_SRC_TRANS; p++) globalTransport[p] = 0.0;
   for (int p = 0; p < SpeciesTrns::NUM_SPECIES_COEFFS; p++)
     for (int sp = 0; sp < numSpecies; sp++) speciesTransport[sp + p * numSpecies] = 0.0;
@@ -535,7 +535,7 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeSourceTransportProperties(
 }
 
 MFEM_HOST_DEVICE void ArgonMinimalTransport::GetViscosities(const double *conserved, const double *primitive,
-                                                            double *visc) {
+                                                            double distance, double *visc) {
   double n_sp[3], X_sp[3], Y_sp[3];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
   double nTotal = 0.0;
@@ -791,15 +791,15 @@ MFEM_HOST_DEVICE double ArgonMixtureTransport::collisionIntegral(const int _spI,
 }
 
 void ArgonMixtureTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp,
-                                                           const Vector &Efield, Vector &transportBuffer,
+                                                           const Vector &Efield, double distance, Vector &transportBuffer,
                                                            DenseMatrix &diffusionVelocity) {
   transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   diffusionVelocity.SetSize(numSpecies, nvel_);
-  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], &transportBuffer[0], diffusionVelocity.Write());
+  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0], diffusionVelocity.Write());
 }
 
 MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                                            const double *Efield,
+                                                                            const double *Efield, double distance,
                                                                             double *transportBuffer,
                                                                             double *diffusionVelocity) {
   for (int p = 0; p < FluxTrns::NUM_FLUX_TRANS; p++) transportBuffer[p] = 0.0;
@@ -925,18 +925,18 @@ MFEM_HOST_DEVICE double ArgonMixtureTransport::computeThirdOrderElectronThermalC
 
 void ArgonMixtureTransport::ComputeSourceTransportProperties(const Vector &state, const Vector &Up,
                                                              const DenseMatrix &gradUp, const Vector &Efield,
-                                                             Vector &globalTransport, DenseMatrix &speciesTransport,
+                                                             double distance, Vector &globalTransport, DenseMatrix &speciesTransport,
                                                              DenseMatrix &diffusionVelocity, Vector &n_sp) {
   globalTransport.SetSize(SrcTrns::NUM_SRC_TRANS);
   speciesTransport.SetSize(numSpecies, SpeciesTrns::NUM_SPECIES_COEFFS);
   diffusionVelocity.SetSize(numSpecies, nvel_);
   n_sp.SetSize(numSpecies);
-  ComputeSourceTransportProperties(&state[0], &Up[0], gradUp.Read(), &Efield[0], &globalTransport[0],
+  ComputeSourceTransportProperties(&state[0], &Up[0], gradUp.Read(), &Efield[0], distance, &globalTransport[0],
                                    speciesTransport.Write(), diffusionVelocity.Write(), &n_sp[0]);
 }
 
 MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeSourceTransportProperties(
-    const double *state, const double *Up, const double *gradUp, const double *Efield, double *globalTransport,
+    const double *state, const double *Up, const double *gradUp, const double *Efield, double distance, double *globalTransport,
     double *speciesTransport, double *diffusionVelocity, double *n_sp) {
   for (int p = 0; p < SrcTrns::NUM_SRC_TRANS; p++) globalTransport[p] = 0.0;
   for (int p = 0; p < SpeciesTrns::NUM_SPECIES_COEFFS; p++)
@@ -1024,7 +1024,7 @@ MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeSourceTransportProperties(
 }
 
 MFEM_HOST_DEVICE void ArgonMixtureTransport::GetViscosities(const double *conserved, const double *primitive,
-                                                            double *visc) {
+                                                            double distance, double *visc) {
   double n_sp[gpudata::MAXSPECIES], X_sp[gpudata::MAXSPECIES], Y_sp[gpudata::MAXSPECIES];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
   double nTotal = 0.0;

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -536,7 +536,8 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeSourceTransportProperties(
   // std::cout << "max diff. vel: " << charSpeed << std::endl;
 }
 
-MFEM_HOST_DEVICE void ArgonMinimalTransport::GetViscosities(const double *conserved, const double *primitive, double *visc) {
+MFEM_HOST_DEVICE void ArgonMinimalTransport::GetViscosities(const double *conserved, const double *primitive,
+                                                            double *visc) {
   double n_sp[3], X_sp[3], Y_sp[3];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
   double nTotal = 0.0;
@@ -1026,7 +1027,8 @@ MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeSourceTransportProperties(
   // std::cout << "max diff. vel: " << charSpeed << std::endl;
 }
 
-MFEM_HOST_DEVICE void ArgonMixtureTransport::GetViscosities(const double *conserved, const double *primitive, double *visc) {
+MFEM_HOST_DEVICE void ArgonMixtureTransport::GetViscosities(const double *conserved, const double *primitive,
+                                                            double *visc) {
   double n_sp[gpudata::MAXSPECIES], X_sp[gpudata::MAXSPECIES], Y_sp[gpudata::MAXSPECIES];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
   double nTotal = 0.0;

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -170,17 +170,17 @@ MFEM_HOST_DEVICE collisionInputs ArgonMinimalTransport::computeCollisionInputs(c
 }
 
 void ArgonMinimalTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp,
-                                                           const Vector &Efield, double distance,
+                                                           const Vector &Efield, double radius, double distance,
                                                            Vector &transportBuffer, DenseMatrix &diffusionVelocity) {
   transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   diffusionVelocity.SetSize(numSpecies, nvel_);
-  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0],
+  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], radius, distance, &transportBuffer[0],
                                  diffusionVelocity.Write());
 }
 
 MFEM_HOST_DEVICE void ArgonMinimalTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                                            const double *Efield, double distance,
-                                                                            double *transportBuffer,
+                                                                            const double *Efield, double radius,
+                                                                            double distance, double *transportBuffer,
                                                                             double *diffusionVelocity) {
   // transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   for (int p = 0; p < FluxTrns::NUM_FLUX_TRANS; p++) transportBuffer[p] = 0.0;
@@ -793,17 +793,17 @@ MFEM_HOST_DEVICE double ArgonMixtureTransport::collisionIntegral(const int _spI,
 }
 
 void ArgonMixtureTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp,
-                                                           const Vector &Efield, double distance,
+                                                           const Vector &Efield, double radius, double distance,
                                                            Vector &transportBuffer, DenseMatrix &diffusionVelocity) {
   transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   diffusionVelocity.SetSize(numSpecies, nvel_);
-  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0],
+  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], radius, distance, &transportBuffer[0],
                                  diffusionVelocity.Write());
 }
 
 MFEM_HOST_DEVICE void ArgonMixtureTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                                            const double *Efield, double distance,
-                                                                            double *transportBuffer,
+                                                                            const double *Efield, double radius,
+                                                                            double distance, double *transportBuffer,
                                                                             double *diffusionVelocity) {
   for (int p = 0; p < FluxTrns::NUM_FLUX_TRANS; p++) transportBuffer[p] = 0.0;
 

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -114,9 +114,9 @@ class ArgonMinimalTransport : public TransportProperties {
   // TODO(kevin): need to discuss whether to reuse computed primitive variables in flux evaluation,
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double radius, double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double distance,
+                                                               const double *Efield, double radius, double distance,
                                                                double *transportBuffer, double *diffusionVelocity);
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
@@ -198,9 +198,9 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
   // TODO(kevin): need to discuss whether to reuse computed primitive variables in flux evaluation,
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double radius, double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double distance,
+                                                               const double *Efield, double radius, double distance,
                                                                double *transportBuffer, double *diffusionVelocity);
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -133,8 +133,7 @@ class ArgonMinimalTransport : public TransportProperties {
                                                                  double *n_sp);
 
   // NOTE(kevin): only for AxisymmetricSource
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance,
-                                       double *visc) override;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
 
   // virtual double computeThirdOrderElectronThermalConductivity(const Vector &X_sp, const double debyeLength,
   //                                                             const double Te, const double nondimTe);
@@ -218,8 +217,7 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
                                                                  double *n_sp);
 
   // NOTE(kevin): only for AxisymmetricSource
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance,
-                                       double *visc) override;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
 
   MFEM_HOST_DEVICE virtual double computeThirdOrderElectronThermalConductivity(const double *X_sp,
                                                                                const collisionInputs &collInputs);

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -116,8 +116,8 @@ class ArgonMinimalTransport : public TransportProperties {
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double distance, double *transportBuffer,
-                                                               double *diffusionVelocity);
+                                                               const double *Efield, double distance,
+                                                               double *transportBuffer, double *diffusionVelocity);
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
@@ -128,12 +128,13 @@ class ArgonMinimalTransport : public TransportProperties {
                                                 Vector &n_sp);
   MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
                                                                  const double *gradUp, const double *Efield,
-                                                                 double distance, 
-                                                                 double *globalTransport, double *speciesTransport,
-                                                                 double *diffusionVelocity, double *n_sp);
+                                                                 double distance, double *globalTransport,
+                                                                 double *speciesTransport, double *diffusionVelocity,
+                                                                 double *n_sp);
 
   // NOTE(kevin): only for AxisymmetricSource
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) override;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance,
+                                       double *visc) override;
 
   // virtual double computeThirdOrderElectronThermalConductivity(const Vector &X_sp, const double debyeLength,
   //                                                             const double Te, const double nondimTe);
@@ -200,8 +201,8 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double distance, double *transportBuffer,
-                                                               double *diffusionVelocity);
+                                                               const double *Efield, double distance,
+                                                               double *transportBuffer, double *diffusionVelocity);
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
@@ -212,11 +213,13 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
                                                 Vector &n_sp);
   MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
                                                                  const double *gradUp, const double *Efield,
-                                                                 double distance, double *globalTransport, double *speciesTransport,
-                                                                 double *diffusionVelocity, double *n_sp);
+                                                                 double distance, double *globalTransport,
+                                                                 double *speciesTransport, double *diffusionVelocity,
+                                                                 double *n_sp);
 
   // NOTE(kevin): only for AxisymmetricSource
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) override;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance,
+                                       double *visc) override;
 
   MFEM_HOST_DEVICE virtual double computeThirdOrderElectronThermalConductivity(const double *X_sp,
                                                                                const collisionInputs &collInputs);

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -114,7 +114,8 @@ class ArgonMinimalTransport : public TransportProperties {
   // TODO(kevin): need to discuss whether to reuse computed primitive variables in flux evaluation,
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              double radius, double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double radius, double distance, Vector &transportBuffer,
+                                              DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
                                                                const double *Efield, double radius, double distance,
                                                                double *transportBuffer, double *diffusionVelocity);
@@ -198,7 +199,8 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
   // TODO(kevin): need to discuss whether to reuse computed primitive variables in flux evaluation,
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              double radius, double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double radius, double distance, Vector &transportBuffer,
+                                              DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
                                                                const double *Efield, double radius, double distance,
                                                                double *transportBuffer, double *diffusionVelocity);

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -114,25 +114,26 @@ class ArgonMinimalTransport : public TransportProperties {
   // TODO(kevin): need to discuss whether to reuse computed primitive variables in flux evaluation,
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double *transportBuffer,
+                                                               const double *Efield, double distance, double *transportBuffer,
                                                                double *diffusionVelocity);
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
   // If this routine evaluate additional primitive variables, can return them just as the routine above.
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
-                                                const Vector &Efield, Vector &globalTransport,
+                                                const Vector &Efield, double distance, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp);
   MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
                                                                  const double *gradUp, const double *Efield,
+                                                                 double distance, 
                                                                  double *globalTransport, double *speciesTransport,
                                                                  double *diffusionVelocity, double *n_sp);
 
   // NOTE(kevin): only for AxisymmetricSource
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) override;
 
   // virtual double computeThirdOrderElectronThermalConductivity(const Vector &X_sp, const double debyeLength,
   //                                                             const double Te, const double nondimTe);
@@ -197,25 +198,25 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
   // TODO(kevin): need to discuss whether to reuse computed primitive variables in flux evaluation,
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double *transportBuffer,
+                                                               const double *Efield, double distance, double *transportBuffer,
                                                                double *diffusionVelocity);
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
   // If this routine evaluate additional primitive variables, can return them just as the routine above.
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
-                                                const Vector &Efield, Vector &globalTransport,
+                                                const Vector &Efield, double distance, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp);
   MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
                                                                  const double *gradUp, const double *Efield,
-                                                                 double *globalTransport, double *speciesTransport,
+                                                                 double distance, double *globalTransport, double *speciesTransport,
                                                                  double *diffusionVelocity, double *n_sp);
 
   // NOTE(kevin): only for AxisymmetricSource
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) override;
 
   MFEM_HOST_DEVICE virtual double computeThirdOrderElectronThermalConductivity(const double *X_sp,
                                                                                const collisionInputs &collInputs);

--- a/src/cycle_avg_joule_coupling.cpp
+++ b/src/cycle_avg_joule_coupling.cpp
@@ -35,13 +35,9 @@
 #include "em_options.hpp"
 #include "quasimagnetostatic.hpp"
 
-CycleAvgJouleCoupling::CycleAvgJouleCoupling(string &inputFileName, TPS::Tps *tps, int max_out,
-                                             bool axisym, double input_power, double initial_input_power)
-    : em_opt_(),
-      max_outer_iters_(max_out),
-      input_power_(input_power),
-      initial_input_power_(initial_input_power) {
-
+CycleAvgJouleCoupling::CycleAvgJouleCoupling(string &inputFileName, TPS::Tps *tps, int max_out, bool axisym,
+                                             double input_power, double initial_input_power)
+    : em_opt_(), max_outer_iters_(max_out), input_power_(input_power), initial_input_power_(initial_input_power) {
   MPI_Comm_size(tps->getTPSCommWorld(), &nprocs_);
   MPI_Comm_rank(tps->getTPSCommWorld(), &rank_);
   if (rank_ == 0)

--- a/src/cycle_avg_joule_coupling.hpp
+++ b/src/cycle_avg_joule_coupling.hpp
@@ -71,8 +71,8 @@ class CycleAvgJouleCoupling : public TPS::Solver {
   bool rank0_;
 
  public:
-  CycleAvgJouleCoupling(string &inputFileName, TPS::Tps *tps, int max_out, bool axisym,
-                        double input_power = -1., double initial_input_power = -1.);
+  CycleAvgJouleCoupling(string &inputFileName, TPS::Tps *tps, int max_out, bool axisym, double input_power = -1.,
+                        double initial_input_power = -1.);
   ~CycleAvgJouleCoupling();
 
   void initializeInterpolationData();

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -296,6 +296,12 @@ struct interiorFaceIntegrationData {
 
   /** Mesh spacing for element 2 on each interior face */
   Vector delta_el2;
+
+  /** Distance function from element 1 */
+  Vector dist1;
+
+  /** Distance function from element 2 */
+  Vector dist2;
 };
 
 /** @brief Data for boundary face integral calculations
@@ -388,6 +394,12 @@ struct sharedFaceIntegrationData {
 
   /** Mesh spacing for element 2 on each shared face */
   Vector delta_el2;
+
+  /** Distance function from element 1 */
+  Vector dist1;
+
+  /** Distance function from element 2 */
+  Vector dist2;
 };
 
 /** @brief Storage for data used in the _GPU_ code path

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -70,7 +70,7 @@ enum WorkingFluid { DRY_AIR, USER_DEFINED, LTE_FLUID };
 // These are the type of EquationOfState.
 enum GasModel { /* PERFECT_SINGLE, */ PERFECT_MIXTURE, /* CANTERA, */ NUM_GASMODEL };
 
-enum TransportModel { ARGON_MINIMAL, ARGON_MIXTURE, CONSTANT, LTE_TRANSPORT, NUM_TRANSPORTMODEL };
+enum TransportModel { ARGON_MINIMAL, ARGON_MIXTURE, CONSTANT, LTE_TRANSPORT, MIXING_LENGTH, NUM_TRANSPORTMODEL };
 
 enum ChemistryModel { /* CANTERA, */ NUM_CHEMISTRYMODEL };
 
@@ -440,6 +440,13 @@ struct constantTransportData {
   double mtFreq[gpudata::MAXSPECIES];  // momentum transfer frequency
 
   int electronIndex;
+};
+
+struct mixingLengthTransportData {
+  // for turbulent transport calculations
+  double max_mixing_length_;  // user-specifed mixing length
+  double Prt_;                // eddy Prandtl number
+  double Let_;                // eddy Lewis number
 };
 
 struct collisionInputs {

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -357,8 +357,8 @@ void DGNonLinearForm::evalFaceFlux_gpu() {
                          d_normal + offset + k * dim,
                          Rflux);
 
-      d_flux->ComputeViscousFluxes(u1, gradUp1, xyz, d_delta1[iface], vFlux1);
-      d_flux->ComputeViscousFluxes(u2, gradUp2, xyz, d_delta2[iface], vFlux2);
+      d_flux->ComputeViscousFluxes(u1, gradUp1, xyz, d_delta1[iface], -1, vFlux1);
+      d_flux->ComputeViscousFluxes(u2, gradUp2, xyz, d_delta2[iface], -1, vFlux2);
 
       for (int d = 0; d < dim; d++) {
         for (int eq = 0; eq < num_equation; eq++) {
@@ -720,8 +720,8 @@ void DGNonLinearForm::sharedFaceInterpolation_gpu(const Vector &x) {
 
         // evaluate flux
         d_rsolver->Eval_LF(u1, u2, nor, Rflux);
-        d_flux->ComputeViscousFluxes(u1, gradUp1, xyz, d_delta_el1[f], vFlux1);
-        d_flux->ComputeViscousFluxes(u2, gradUp2, xyz, d_delta_el2[f], vFlux2);
+        d_flux->ComputeViscousFluxes(u1, gradUp1, xyz, d_delta_el1[f], -1, vFlux1);
+        d_flux->ComputeViscousFluxes(u2, gradUp2, xyz, d_delta_el2[f], -1, vFlux2);
 
         for (int eq = 0; eq < num_equation; eq++) {
           for (int d = 0; d < dim; d++)

--- a/src/face_integrator.cpp
+++ b/src/face_integrator.cpp
@@ -159,8 +159,8 @@ void FaceIntegrator::getElementsGrads_gpu(const ParGridFunction *gradUp, ParFini
   }
 }
 
-void FaceIntegrator::getDistanceDofs(FaceElementTransformations &Tr, const FiniteElement &el1,
-                                     const FiniteElement &el2, Vector &dist1, Vector &dist2) {
+void FaceIntegrator::getDistanceDofs(FaceElementTransformations &Tr, const FiniteElement &el1, const FiniteElement &el2,
+                                     Vector &dist1, Vector &dist2) {
   assert(distance_ != NULL);
 
   const ParFiniteElementSpace *pfes = distance_->ParFESpace();
@@ -185,7 +185,6 @@ void FaceIntegrator::getDistanceDofs(FaceElementTransformations &Tr, const Finit
     distance_->GetSubVector(dofs2, dist2);
   }
 }
-
 
 void FaceIntegrator::AssembleFaceVector(const FiniteElement &el1, const FiniteElement &el2,
                                         FaceElementTransformations &Tr, const Vector &elfun, Vector &elvect) {

--- a/src/face_integrator.hpp
+++ b/src/face_integrator.hpp
@@ -105,7 +105,6 @@ class FaceIntegrator : public NonlinearFormIntegrator {
   void getDistanceDofs(FaceElementTransformations &Tr, const FiniteElement &el1, const FiniteElement &el2,
                        Vector &dist1, Vector &dist2);
 
-
  public:
   FaceIntegrator(IntegrationRules *_intRules, RiemannSolver *rsolver_, Fluxes *_fluxClass, ParFiniteElementSpace *_vfes,
                  bool _useLinear, const int _dim, const int _num_equation, ParGridFunction *_gradUp,

--- a/src/face_integrator.hpp
+++ b/src/face_integrator.hpp
@@ -64,6 +64,8 @@ class FaceIntegrator : public NonlinearFormIntegrator {
   const ParGridFunction *gradUp;
   const ParFiniteElementSpace *gradUpfes;
 
+  const ParGridFunction *distance_;
+
   IntegrationRules *intRules;
 
   DenseMatrix *faceMassMatrix1, *faceMassMatrix2;
@@ -100,10 +102,14 @@ class FaceIntegrator : public NonlinearFormIntegrator {
   void NonLinearFaceIntegration(const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &Tr,
                                 const Vector &elfun, Vector &elvect);
 
+  void getDistanceDofs(FaceElementTransformations &Tr, const FiniteElement &el1, const FiniteElement &el2,
+                       Vector &dist1, Vector &dist2);
+
+
  public:
   FaceIntegrator(IntegrationRules *_intRules, RiemannSolver *rsolver_, Fluxes *_fluxClass, ParFiniteElementSpace *_vfes,
                  bool _useLinear, const int _dim, const int _num_equation, ParGridFunction *_gradUp,
-                 ParFiniteElementSpace *_gradUpfes, double &_max_char_speed, bool axisym);
+                 ParFiniteElementSpace *_gradUpfes, double &_max_char_speed, bool axisym, ParGridFunction *distance);
   ~FaceIntegrator();
 
   virtual void AssembleFaceVector(const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &Tr,

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -318,13 +318,13 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
 }
 
 void Fluxes::ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gradUp, Vector transip, double delta,
-                                     const BoundaryViscousFluxData &bcFlux, Vector &normalFlux) {
+                                     double distance, const BoundaryViscousFluxData &bcFlux, Vector &normalFlux) {
   normalFlux.SetSize(num_equation);
-  ComputeBdrViscousFluxes(state.GetData(), gradUp.GetData(), transip.GetData(), delta, bcFlux, normalFlux.GetData());
+  ComputeBdrViscousFluxes(state.GetData(), gradUp.GetData(), transip.GetData(), delta, distance, bcFlux, normalFlux.GetData());
 }
 
 MFEM_HOST_DEVICE void Fluxes::ComputeBdrViscousFluxes(const double *state, const double *gradUp, double *transip,
-                                                      double delta, const BoundaryViscousFluxData &bcFlux,
+                                                      double delta, double distance, const BoundaryViscousFluxData &bcFlux,
                                                       double *normalFlux) {
   // normalFlux.SetSize(num_equation);
   for (int eq = 0; eq < num_equation; eq++) normalFlux[eq] = 0.;

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -202,7 +202,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
   // NOTE(kevin): in flux, only dim-components of diffusionVelocity will be used.
   double diffusionVelocity[gpudata::MAXSPECIES * gpudata::MAXDIM];
 
-  transport->ComputeFluxTransportProperties(state, gradUp, Efield, distance, transportBuffer, diffusionVelocity);
+  transport->ComputeFluxTransportProperties(state, gradUp, Efield, radius, distance, transportBuffer, diffusionVelocity);
   double visc = transportBuffer[FluxTrns::VISCOSITY];
   double bulkViscosity = transportBuffer[FluxTrns::BULK_VISCOSITY];
   bulkViscosity -= 2. / 3. * visc;
@@ -355,7 +355,8 @@ MFEM_HOST_DEVICE void Fluxes::ComputeBdrViscousFluxes(const double *state, const
   double transportBuffer[FluxTrns::NUM_FLUX_TRANS];
   // NOTE(kevin): in flux, only dim-components of diffusionVelocity will be used.
   double diffusionVelocity[gpudata::MAXSPECIES * gpudata::MAXDIM];
-  transport->ComputeFluxTransportProperties(state, gradUp, Efield, distance, transportBuffer, diffusionVelocity);
+
+  transport->ComputeFluxTransportProperties(state, gradUp, Efield, radius, distance, transportBuffer, diffusionVelocity);
   double visc = transportBuffer[FluxTrns::VISCOSITY];
   double bulkViscosity = transportBuffer[FluxTrns::BULK_VISCOSITY];
   bulkViscosity -= 2. / 3. * visc;

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -201,7 +201,8 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
   double transportBuffer[FluxTrns::NUM_FLUX_TRANS];
   // NOTE(kevin): in flux, only dim-components of diffusionVelocity will be used.
   double diffusionVelocity[gpudata::MAXSPECIES * gpudata::MAXDIM];
-  transport->ComputeFluxTransportProperties(state, gradUp, Efield, transportBuffer, diffusionVelocity);
+
+  transport->ComputeFluxTransportProperties(state, gradUp, Efield, distance, transportBuffer, diffusionVelocity);
   double visc = transportBuffer[FluxTrns::VISCOSITY];
   double bulkViscosity = transportBuffer[FluxTrns::BULK_VISCOSITY];
   bulkViscosity -= 2. / 3. * visc;
@@ -354,7 +355,7 @@ MFEM_HOST_DEVICE void Fluxes::ComputeBdrViscousFluxes(const double *state, const
   double transportBuffer[FluxTrns::NUM_FLUX_TRANS];
   // NOTE(kevin): in flux, only dim-components of diffusionVelocity will be used.
   double diffusionVelocity[gpudata::MAXSPECIES * gpudata::MAXDIM];
-  transport->ComputeFluxTransportProperties(state, gradUp, Efield, transportBuffer, diffusionVelocity);
+  transport->ComputeFluxTransportProperties(state, gradUp, Efield, distance, transportBuffer, diffusionVelocity);
   double visc = transportBuffer[FluxTrns::VISCOSITY];
   double bulkViscosity = transportBuffer[FluxTrns::BULK_VISCOSITY];
   bulkViscosity -= 2. / 3. * visc;

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -161,13 +161,13 @@ MFEM_HOST_DEVICE void Fluxes::ComputeConvectiveFluxes(const double *state, doubl
 }
 
 // TODO(kevin): check/complete axisymmetric setting for multi-component flow.
-void Fluxes::ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp, Vector transip, double delta,
+void Fluxes::ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp, Vector transip, double delta, double distance,
                                   DenseMatrix &flux) {
-  ComputeViscousFluxes(state.GetData(), gradUp.GetData(), transip.GetData(), delta, flux.GetData());
+  ComputeViscousFluxes(state.GetData(), gradUp.GetData(), transip.GetData(), delta, distance, flux.GetData());
 }
 
 MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const double *gradUp, double *transip,
-                                                   double delta, double *flux) {
+                                                   double delta, double distance, double *flux) {
   for (int d = 0; d < dim; d++) {
     for (int eq = 0; eq < num_equation; eq++) {
       flux[eq + d * num_equation] = 0.;

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -202,7 +202,8 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
   // NOTE(kevin): in flux, only dim-components of diffusionVelocity will be used.
   double diffusionVelocity[gpudata::MAXSPECIES * gpudata::MAXDIM];
 
-  transport->ComputeFluxTransportProperties(state, gradUp, Efield, radius, distance, transportBuffer, diffusionVelocity);
+  transport->ComputeFluxTransportProperties(state, gradUp, Efield, radius, distance, transportBuffer,
+                                            diffusionVelocity);
   double visc = transportBuffer[FluxTrns::VISCOSITY];
   double bulkViscosity = transportBuffer[FluxTrns::BULK_VISCOSITY];
   bulkViscosity -= 2. / 3. * visc;
@@ -321,7 +322,8 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
 void Fluxes::ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gradUp, Vector transip, double delta,
                                      double distance, const BoundaryViscousFluxData &bcFlux, Vector &normalFlux) {
   normalFlux.SetSize(num_equation);
-  ComputeBdrViscousFluxes(state.GetData(), gradUp.GetData(), transip.GetData(), delta, distance, bcFlux, normalFlux.GetData());
+  ComputeBdrViscousFluxes(state.GetData(), gradUp.GetData(), transip.GetData(), delta, distance, bcFlux,
+                          normalFlux.GetData());
 }
 
 MFEM_HOST_DEVICE void Fluxes::ComputeBdrViscousFluxes(const double *state, const double *gradUp, double *transip,
@@ -356,7 +358,8 @@ MFEM_HOST_DEVICE void Fluxes::ComputeBdrViscousFluxes(const double *state, const
   // NOTE(kevin): in flux, only dim-components of diffusionVelocity will be used.
   double diffusionVelocity[gpudata::MAXSPECIES * gpudata::MAXDIM];
 
-  transport->ComputeFluxTransportProperties(state, gradUp, Efield, radius, distance, transportBuffer, diffusionVelocity);
+  transport->ComputeFluxTransportProperties(state, gradUp, Efield, radius, distance, transportBuffer,
+                                            diffusionVelocity);
   double visc = transportBuffer[FluxTrns::VISCOSITY];
   double bulkViscosity = transportBuffer[FluxTrns::BULK_VISCOSITY];
   bulkViscosity -= 2. / 3. * visc;

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -161,8 +161,8 @@ MFEM_HOST_DEVICE void Fluxes::ComputeConvectiveFluxes(const double *state, doubl
 }
 
 // TODO(kevin): check/complete axisymmetric setting for multi-component flow.
-void Fluxes::ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp, Vector transip, double delta, double distance,
-                                  DenseMatrix &flux) {
+void Fluxes::ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp, Vector transip, double delta,
+                                  double distance, DenseMatrix &flux) {
   ComputeViscousFluxes(state.GetData(), gradUp.GetData(), transip.GetData(), delta, distance, flux.GetData());
 }
 
@@ -327,8 +327,8 @@ void Fluxes::ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gra
 }
 
 MFEM_HOST_DEVICE void Fluxes::ComputeBdrViscousFluxes(const double *state, const double *gradUp, double *transip,
-                                                      double delta, double distance, const BoundaryViscousFluxData &bcFlux,
-                                                      double *normalFlux) {
+                                                      double delta, double distance,
+                                                      const BoundaryViscousFluxData &bcFlux, double *normalFlux) {
   // normalFlux.SetSize(num_equation);
   for (int eq = 0; eq < num_equation; eq++) normalFlux[eq] = 0.;
   if (eqSystem == EULER) {

--- a/src/fluxes.hpp
+++ b/src/fluxes.hpp
@@ -108,11 +108,11 @@ class Fluxes {
   MFEM_HOST_DEVICE void viscSpongePlanar(double *x, double &wgt);
 
   // Compute viscous flux with prescribed boundary flux.
-  void ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gradUp, Vector transip, double delta,
+  void ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gradUp, Vector transip, double delta, double distance,
                                const BoundaryViscousFluxData &bcFlux, Vector &normalFlux);
 
   MFEM_HOST_DEVICE void ComputeBdrViscousFluxes(const double *state, const double *gradUp, double *transip,
-                                                double delta, const BoundaryViscousFluxData &bcFlux,
+                                                double delta, double distance, const BoundaryViscousFluxData &bcFlux,
                                                 double *normalFlux);
 
   MFEM_HOST_DEVICE bool isAxisymmetric() const { return axisymmetric_; }

--- a/src/fluxes.hpp
+++ b/src/fluxes.hpp
@@ -94,10 +94,10 @@ class Fluxes {
   void ComputeConvectiveFluxes(const Vector &state, DenseMatrix &flux);
   MFEM_HOST_DEVICE void ComputeConvectiveFluxes(const double *state, double *flux) const;
 
-  void ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp, Vector transip, double delta,
+  void ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp, Vector transip, double delta, double distance,
                             DenseMatrix &flux);
 
-  MFEM_HOST_DEVICE void ComputeViscousFluxes(const double *state, const double *gradUp, double *transip, double delta,
+  MFEM_HOST_DEVICE void ComputeViscousFluxes(const double *state, const double *gradUp, double *transip, double delta, double distance,
                                              double *flux);
 
   void sgsSmag(const Vector &state, const DenseMatrix &gradUp, double delta, double &mu_sgs);

--- a/src/fluxes.hpp
+++ b/src/fluxes.hpp
@@ -94,11 +94,11 @@ class Fluxes {
   void ComputeConvectiveFluxes(const Vector &state, DenseMatrix &flux);
   MFEM_HOST_DEVICE void ComputeConvectiveFluxes(const double *state, double *flux) const;
 
-  void ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp, Vector transip, double delta, double distance,
-                            DenseMatrix &flux);
+  void ComputeViscousFluxes(const Vector &state, const DenseMatrix &gradUp, Vector transip, double delta,
+                            double distance, DenseMatrix &flux);
 
-  MFEM_HOST_DEVICE void ComputeViscousFluxes(const double *state, const double *gradUp, double *transip, double delta, double distance,
-                                             double *flux);
+  MFEM_HOST_DEVICE void ComputeViscousFluxes(const double *state, const double *gradUp, double *transip, double delta,
+                                             double distance, double *flux);
 
   void sgsSmag(const Vector &state, const DenseMatrix &gradUp, double delta, double &mu_sgs);
   MFEM_HOST_DEVICE void sgsSmag(const double *state, const double *gradUp, double delta, double &mu_sgs);
@@ -108,8 +108,8 @@ class Fluxes {
   MFEM_HOST_DEVICE void viscSpongePlanar(double *x, double &wgt);
 
   // Compute viscous flux with prescribed boundary flux.
-  void ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gradUp, Vector transip, double delta, double distance,
-                               const BoundaryViscousFluxData &bcFlux, Vector &normalFlux);
+  void ComputeBdrViscousFluxes(const Vector &state, const DenseMatrix &gradUp, Vector transip, double delta,
+                               double distance, const BoundaryViscousFluxData &bcFlux, Vector &normalFlux);
 
   MFEM_HOST_DEVICE void ComputeBdrViscousFluxes(const double *state, const double *gradUp, double *transip,
                                                 double delta, double distance, const BoundaryViscousFluxData &bcFlux,

--- a/src/forcing_terms.cpp
+++ b/src/forcing_terms.cpp
@@ -336,7 +336,7 @@ void AxisymmetricSource::updateTerms(Vector &in) {
       double dist = 0;
       if (d_dist != NULL) dist = d_dist[n];
 
-      d_trans->GetViscosities(U, Up, dist, visc_vec);
+      d_trans->GetViscosities(U, Up, gradUp, dist, visc_vec);
       visc = visc_vec[0];
       bulkVisc = visc_vec[1];
       bulkVisc -= 2. / 3. * visc;

--- a/src/forcing_terms.cpp
+++ b/src/forcing_terms.cpp
@@ -336,7 +336,7 @@ void AxisymmetricSource::updateTerms(Vector &in) {
       double dist = 0;
       if (d_dist != NULL) dist = d_dist[n];
 
-      d_trans->GetViscosities(U, Up, gradUp, dist, visc_vec);
+      d_trans->GetViscosities(U, Up, gradUp, radius, dist, visc_vec);
       visc = visc_vec[0];
       bulkVisc = visc_vec[1];
       bulkVisc -= 2. / 3. * visc;

--- a/src/forcing_terms.cpp
+++ b/src/forcing_terms.cpp
@@ -323,7 +323,8 @@ void AxisymmetricSource::updateTerms(Vector &in) {
       const double ut_r = gradUp[3 + 0 * neqn];
 
       double visc, bulkVisc, visc_vec[2];
-      d_trans->GetViscosities(U, Up, visc_vec);
+      // TODO: Get distance
+      d_trans->GetViscosities(U, Up, -1, visc_vec);
       visc = visc_vec[0];
       bulkVisc = visc_vec[1];
       bulkVisc -= 2. / 3. * visc;

--- a/src/forcing_terms.hpp
+++ b/src/forcing_terms.hpp
@@ -116,14 +116,15 @@ class AxisymmetricSource : public ForcingTerms {
   TransportProperties *transport_;
   const Equations &eqSystem;
   ParGridFunction *space_vary_viscosity_mult_;
+  ParGridFunction *distance_;
 
  public:
   AxisymmetricSource(const int &_dim, const int &_num_equation, const int &_order, GasMixture *_mixture,
-
                      TransportProperties *_transport, const Equations &_eqSystem, const int &_intRuleType,
                      IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U,
                      ParGridFunction *_Up, ParGridFunction *_gradUp, ParGridFunction *spaceVaryViscMult,
-                     const precomputedIntegrationData &gpu_precomputed_data, RunConfiguration &_config);
+                     const precomputedIntegrationData &gpu_precomputed_data, RunConfiguration &_config,
+                     ParGridFunction *distance);
   virtual ~AxisymmetricSource() {}
 
   virtual void updateTerms(Vector &in);

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -435,8 +435,8 @@ void InletBC::initBoundaryU(ParGridFunction *Up) {
   boundaryU.Read();
 }
 
-void InletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector transip,
-                             double delta, Vector &bdrFlux) {
+void InletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
+                             double delta, double distance, Vector &bdrFlux) {
   switch (inletType_) {
     case SUB_DENS_VEL:
       subsonicReflectingDensityVelocity(normal, stateIn, bdrFlux);

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -435,8 +435,8 @@ void InletBC::initBoundaryU(ParGridFunction *Up) {
   boundaryU.Read();
 }
 
-void InletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                             double delta, double distance, Vector &bdrFlux) {
+void InletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                             double distance, Vector &bdrFlux) {
   switch (inletType_) {
     case SUB_DENS_VEL:
       subsonicReflectingDensityVelocity(normal, stateIn, bdrFlux);

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -96,8 +96,8 @@ class InletBC : public BoundaryCondition {
           const Array<double> &_inputData, const int &_maxIntPoints, const int &maxDofs, bool axisym);
   ~InletBC();
 
-  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector transip,
-                      double delta, Vector &bdrFlux);
+  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
+                      double delta, double distance, Vector &bdrFlux);
 
   virtual void initBCs();
 

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -96,8 +96,8 @@ class InletBC : public BoundaryCondition {
           const Array<double> &_inputData, const int &_maxIntPoints, const int &maxDofs, bool axisym);
   ~InletBC();
 
-  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                      double delta, double distance, Vector &bdrFlux);
+  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                      double distance, Vector &bdrFlux);
 
   virtual void initBCs();
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -37,7 +37,7 @@
 #include "utils.hpp"
 
 void M2ulPhyS::restart_files_hdf5(string mode, string inputFileName) {
-MPI_Comm TPSCommWorld = this->groupsMPI->getTPSCommWorld();
+  MPI_Comm TPSCommWorld = this->groupsMPI->getTPSCommWorld();
 #ifdef HAVE_GRVY
   grvy_timer_begin(__func__);
 #endif

--- a/src/lte_transport_properties.cpp
+++ b/src/lte_transport_properties.cpp
@@ -65,7 +65,8 @@ LteTransport::~LteTransport() {
 }
 
 void LteTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                                  double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity) {
+                                                  double distance, Vector &transportBuffer,
+                                                  DenseMatrix &diffusionVelocity) {
   const double rho = state[0];
   const double T = mixture->ComputeTemperature(state);
 

--- a/src/lte_transport_properties.cpp
+++ b/src/lte_transport_properties.cpp
@@ -107,7 +107,7 @@ void LteTransport::ComputeSourceTransportProperties(const double *state, const d
   globalTransport[SrcTrns::ELECTRIC_CONDUCTIVITY] = 0.;
 }
 
-void LteTransport::GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) {
+void LteTransport::GetViscosities(const double *conserved, const double *primitive, double *visc) {
   const double rho = primitive[0];
   const double T = primitive[1 + nvel_];
 

--- a/src/lte_transport_properties.cpp
+++ b/src/lte_transport_properties.cpp
@@ -65,7 +65,7 @@ LteTransport::~LteTransport() {
 }
 
 void LteTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                                  Vector &transportBuffer, DenseMatrix &diffusionVelocity) {
+                                                  double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity) {
   const double rho = state[0];
   const double T = mixture->ComputeTemperature(state);
 
@@ -81,7 +81,7 @@ void LteTransport::ComputeFluxTransportProperties(const Vector &state, const Den
 }
 
 void LteTransport::ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
-                                                    const Vector &Efield, Vector &globalTransport,
+                                                    const Vector &Efield, double distance, Vector &globalTransport,
                                                     DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                     Vector &n_sp) {
   globalTransport.SetSize(SrcTrns::NUM_SRC_TRANS);
@@ -101,12 +101,12 @@ void LteTransport::ComputeSourceTransportProperties(const Vector &state, const V
 }
 
 void LteTransport::ComputeSourceTransportProperties(const double *state, const double *Up, const double *gradUp,
-                                                    const double *Efield, double *globalTransport,
+                                                    const double *Efield, double distance, double *globalTransport,
                                                     double *speciesTransport, double *diffusionVelocity, double *n_sp) {
   globalTransport[SrcTrns::ELECTRIC_CONDUCTIVITY] = 0.;
 }
 
-void LteTransport::GetViscosities(const double *conserved, const double *primitive, double *visc) {
+void LteTransport::GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) {
   const double rho = primitive[0];
   const double T = primitive[1 + nvel_];
 

--- a/src/lte_transport_properties.cpp
+++ b/src/lte_transport_properties.cpp
@@ -65,7 +65,7 @@ LteTransport::~LteTransport() {
 }
 
 void LteTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                                  double distance, Vector &transportBuffer,
+                                                  double radius, double distance, Vector &transportBuffer,
                                                   DenseMatrix &diffusionVelocity) {
   const double rho = state[0];
   const double T = mixture->ComputeTemperature(state);

--- a/src/lte_transport_properties.hpp
+++ b/src/lte_transport_properties.hpp
@@ -66,9 +66,11 @@ class LteTransport : public TransportProperties {
   virtual ~LteTransport();
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              double radius, double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double radius, double distance, Vector &transportBuffer,
+                                              DenseMatrix &diffusionVelocity);
   virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-                                              double radius, double distance, double *transportBuffer, double *diffusionVelocity) {
+                                              double radius, double distance, double *transportBuffer,
+                                              double *diffusionVelocity) {
     mfem_error("This variant of LteTransport::ComputeFluxTransportProperties is not implemented\n");
   }
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,

--- a/src/lte_transport_properties.hpp
+++ b/src/lte_transport_properties.hpp
@@ -76,8 +76,8 @@ class LteTransport : public TransportProperties {
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp);
   virtual void ComputeSourceTransportProperties(const double *state, const double *Up, const double *gradUp,
-                                                const double *Efield, double distance, double *globalTransport, double *speciesTransport,
-                                                double *diffusionVelocity, double *n_sp);
+                                                const double *Efield, double distance, double *globalTransport,
+                                                double *speciesTransport, double *diffusionVelocity, double *n_sp);
 
   void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) override;
 };

--- a/src/lte_transport_properties.hpp
+++ b/src/lte_transport_properties.hpp
@@ -79,7 +79,7 @@ class LteTransport : public TransportProperties {
                                                 const double *Efield, double distance, double *globalTransport,
                                                 double *speciesTransport, double *diffusionVelocity, double *n_sp);
 
-  void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) override;
+  void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
 };
 
 #endif  // _GPU_

--- a/src/lte_transport_properties.hpp
+++ b/src/lte_transport_properties.hpp
@@ -66,9 +66,9 @@ class LteTransport : public TransportProperties {
   virtual ~LteTransport();
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double radius, double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-                                              double distance, double *transportBuffer, double *diffusionVelocity) {
+                                              double radius, double distance, double *transportBuffer, double *diffusionVelocity) {
     mfem_error("This variant of LteTransport::ComputeFluxTransportProperties is not implemented\n");
   }
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,

--- a/src/lte_transport_properties.hpp
+++ b/src/lte_transport_properties.hpp
@@ -66,20 +66,20 @@ class LteTransport : public TransportProperties {
   virtual ~LteTransport();
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
-                                              double *transportBuffer, double *diffusionVelocity) {
+                                              double distance, double *transportBuffer, double *diffusionVelocity) {
     mfem_error("This variant of LteTransport::ComputeFluxTransportProperties is not implemented\n");
   }
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
-                                                const Vector &Efield, Vector &globalTransport,
+                                                const Vector &Efield, double distance, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp);
   virtual void ComputeSourceTransportProperties(const double *state, const double *Up, const double *gradUp,
-                                                const double *Efield, double *globalTransport, double *speciesTransport,
+                                                const double *Efield, double distance, double *globalTransport, double *speciesTransport,
                                                 double *diffusionVelocity, double *n_sp);
 
-  void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
+  void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) override;
 };
 
 #endif  // _GPU_

--- a/src/mixing_length_transport.cpp
+++ b/src/mixing_length_transport.cpp
@@ -30,17 +30,24 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // -----------------------------------------------------------------------------------el-
 
-#include <math.h>
 #include "mixing_length_transport.hpp"
+
+#include <math.h>
 
 using namespace std;
 using namespace mfem;
 
-MixingLengthTransport::MixingLengthTransport(GasMixture *mix, RunConfiguration &runfile, TransportProperties *molecular_transport)
+MixingLengthTransport::MixingLengthTransport(GasMixture *mix, RunConfiguration &runfile,
+                                             TransportProperties *molecular_transport)
     : MixingLengthTransport(mix, runfile.mix_length_trans_input_, molecular_transport) {}
 
-MFEM_HOST_DEVICE MixingLengthTransport::MixingLengthTransport(GasMixture *mix, const mixingLengthTransportData &inputs, TransportProperties *molecular_transport)
-    : TransportProperties(mix), max_mixing_length_(inputs.max_mixing_length_), Prt_(inputs.Prt_), Let_(inputs.Let_), molecular_transport_(molecular_transport) {}
+MFEM_HOST_DEVICE MixingLengthTransport::MixingLengthTransport(GasMixture *mix, const mixingLengthTransportData &inputs,
+                                                              TransportProperties *molecular_transport)
+    : TransportProperties(mix),
+      max_mixing_length_(inputs.max_mixing_length_),
+      Prt_(inputs.Prt_),
+      Let_(inputs.Let_),
+      molecular_transport_(molecular_transport) {}
 
 void MixingLengthTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp,
                                                            const Vector &Efield, double radius, double distance,
@@ -102,7 +109,7 @@ MFEM_HOST_DEVICE void MixingLengthTransport::ComputeFluxTransportProperties(cons
     double Szx = 0.5 * ut_r;
     if (radius > 0) Szx -= 0.5 * ut / radius;
     const double Szy = 0.5 * ut_z;
-    double Szz = - divV / 3.;
+    double Szz = -divV / 3.;
     if (radius > 0) Szz += ur / radius;
 
     S += 2 * (2 * Szx * Szx + 2 * Szy * Szy + Szz * Szz);

--- a/src/mixing_length_transport.cpp
+++ b/src/mixing_length_transport.cpp
@@ -1,0 +1,148 @@
+// -----------------------------------------------------------------------------------bl-
+// BSD 3-Clause License
+//
+// Copyright (c) 2020-2022, The PECOS Development Team, University of Texas at Austin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// -----------------------------------------------------------------------------------el-
+
+#include <math.h>
+#include "mixing_length_transport.hpp"
+
+using namespace std;
+using namespace mfem;
+
+MixingLengthTransport::MixingLengthTransport(GasMixture *mix, RunConfiguration &runfile, TransportProperties *molecular_transport)
+    : MixingLengthTransport(mix, runfile.mix_length_trans_input_, molecular_transport) {}
+
+MFEM_HOST_DEVICE MixingLengthTransport::MixingLengthTransport(GasMixture *mix, const mixingLengthTransportData &inputs, TransportProperties *molecular_transport)
+    : TransportProperties(mix), max_mixing_length_(inputs.max_mixing_length_), Prt_(inputs.Prt_), Let_(inputs.Let_), molecular_transport_(molecular_transport) {}
+
+void MixingLengthTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp,
+                                                       const Vector &Efield, Vector &transportBuffer,
+                                                       DenseMatrix &diffusionVelocity) {
+  transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
+  diffusionVelocity.SetSize(numSpecies, nvel_);
+  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], &transportBuffer[0], diffusionVelocity.Write());
+}
+
+MFEM_HOST_DEVICE void MixingLengthTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
+                                                                        const double *Efield, double *transportBuffer,
+                                                                        double *diffusionVelocity) {
+  molecular_transport_->ComputeFluxTransportProperties(state, gradUp, Efield, transportBuffer, diffusionVelocity);
+
+  // Add mixing length model results to computed molecular transport
+  //
+  // double primitiveState[gpudata::MAXEQUATIONS];
+  // mixture->GetPrimitivesFromConservatives(state, primitiveState);
+
+  // const double rho = state[0];
+  // const double Th = primitiveState[nvel_ + 1];
+
+  // // eddy viscosity
+  // double S = 0;
+  // for (int i = 0; i < dim; i++) {
+  //   for (int j = 0; j < dim; j++) {
+  //     const double u_x = gradUp[(1 + i) + j * num_equation];
+  //     S += 2 * u_x * u_x; // todo: subtract divergence part
+  //   }
+  // }
+  // S = sqrt(S);
+
+  // //const double mut = rho * mixing_length_ * mixing_length_ * S;
+
+  // // eddy thermal conductivity
+  // //const double kappat = mut * cp / Prt_;
+
+  // // TODO(trevilo): Evaluate molecular transport
+
+}
+
+void MixingLengthTransport::ComputeSourceTransportProperties(const Vector &state, const Vector &Up,
+                                                         const DenseMatrix &gradUp, const Vector &Efield,
+                                                         Vector &globalTransport, DenseMatrix &speciesTransport,
+                                                         DenseMatrix &diffusionVelocity, Vector &n_sp) {
+  globalTransport.SetSize(SrcTrns::NUM_SRC_TRANS);
+  speciesTransport.SetSize(numSpecies, SpeciesTrns::NUM_SPECIES_COEFFS);
+  n_sp.SetSize(numSpecies);
+  diffusionVelocity.SetSize(numSpecies, nvel_);
+  ComputeSourceTransportProperties(&state[0], &Up[0], gradUp.Read(), &Efield[0], &globalTransport[0],
+                                   speciesTransport.Write(), diffusionVelocity.Write(), &n_sp[0]);
+
+  for (int sp = 0; sp < numSpecies; sp++) {
+    for (int d = 0; d < nvel_; d++) {
+      if (std::isnan(diffusionVelocity(sp, d))) {
+        grvy_printf(GRVY_ERROR, "\nDiffusion velocity of species %d is NaN! -> %f\n", sp, diffusionVelocity(sp, d));
+        exit(-1);
+      }
+    }
+  }
+}
+
+MFEM_HOST_DEVICE void MixingLengthTransport::ComputeSourceTransportProperties(const double *state, const double *Up,
+                                                                          const double *gradUp, const double *Efield,
+                                                                          double *globalTransport,
+                                                                          double *speciesTransport,
+                                                                          double *diffusionVelocity, double *n_sp) {
+  molecular_transport_->ComputeSourceTransportProperties(state, Up, gradUp, Efield, globalTransport, speciesTransport,
+                                                        diffusionVelocity, n_sp);
+
+  // Add mixing length model results to computed molecular transport
+  //
+  // for (int i = 0; i < SrcTrns::NUM_SRC_TRANS; i++) globalTransport[i] = 0.0;
+  // for (int c = 0; c < SpeciesTrns::NUM_SPECIES_COEFFS; c++)
+  //   for (int sp = 0; sp < numSpecies; sp++) speciesTransport[sp + c * numSpecies] = 0.0;
+  // for (int sp = 0; sp < numSpecies; sp++) n_sp[sp] = 0.0;
+
+  // // NOTE: diffusion has nvel components, as E-field can have azimuthal component.
+  // // diffusionVelocity.SetSize(numSpecies, nvel_);
+  // for (int v = 0; v < nvel_; v++)
+  //   for (int sp = 0; sp < numSpecies; sp++) diffusionVelocity[sp + v * numSpecies] = 0.0;
+
+  // double primitiveState[gpudata::MAXEQUATIONS];
+  // mixture->GetPrimitivesFromConservatives(state, primitiveState);
+
+  // const double rho = state[0];
+  // const double Th = primitiveState[nvel_ + 1];
+
+  // // eddy viscosity
+  // double S = 0;
+  // for (int i = 0; i < dim; i++) {
+  //   for (int j = 0; j < dim; j++) {
+  //     const double u_x = gradUp[(1 + i) + j * num_equation];
+  //     S += 2 * u_x * u_x; // todo: subtract divergence part
+  //   }
+  // }
+  // S = sqrt(S);
+
+  // //const double mut = rho * mixing_length_ * mixing_length_ * S;
+
+  // // eddy thermal conductivity
+  // //const double kappat = mut * cp / Prt_;
+
+  // // TODO(trevilo): Call molecular transport
+}

--- a/src/mixing_length_transport.cpp
+++ b/src/mixing_length_transport.cpp
@@ -37,6 +37,7 @@
 using namespace std;
 using namespace mfem;
 
+#if !defined(_CUDA_) && !defined(_HIP_)
 MixingLengthTransport::MixingLengthTransport(GasMixture *mix, RunConfiguration &runfile,
                                              TransportProperties *molecular_transport)
     : MixingLengthTransport(mix, runfile.mix_length_trans_input_, molecular_transport) {}
@@ -191,3 +192,4 @@ MFEM_HOST_DEVICE void MixingLengthTransport::ComputeSourceTransportProperties(
 
   // // TODO(trevilo): Call molecular transport
 }
+#endif

--- a/src/mixing_length_transport.cpp
+++ b/src/mixing_length_transport.cpp
@@ -77,7 +77,7 @@ MFEM_HOST_DEVICE void MixingLengthTransport::ComputeFluxTransportProperties(cons
   // If axisymmetric
   double ur = 0;
   if (nvel_ != dim) {
-    ur =  primitiveState[1];
+    ur = primitiveState[1];
     divV += ur / radius;
   }
 

--- a/src/mixing_length_transport.cpp
+++ b/src/mixing_length_transport.cpp
@@ -43,18 +43,20 @@ MFEM_HOST_DEVICE MixingLengthTransport::MixingLengthTransport(GasMixture *mix, c
     : TransportProperties(mix), max_mixing_length_(inputs.max_mixing_length_), Prt_(inputs.Prt_), Let_(inputs.Let_), molecular_transport_(molecular_transport) {}
 
 void MixingLengthTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp,
-                                                           const Vector &Efield, double distance, Vector &transportBuffer,
-                                                           DenseMatrix &diffusionVelocity) {
+                                                           const Vector &Efield, double distance,
+                                                           Vector &transportBuffer, DenseMatrix &diffusionVelocity) {
   transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   diffusionVelocity.SetSize(numSpecies, nvel_);
-  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0], diffusionVelocity.Write());
+  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0],
+                                 diffusionVelocity.Write());
 }
 
 MFEM_HOST_DEVICE void MixingLengthTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
                                                                             const double *Efield, double distance,
                                                                             double *transportBuffer,
                                                                             double *diffusionVelocity) {
-  molecular_transport_->ComputeFluxTransportProperties(state, gradUp, Efield, distance, transportBuffer, diffusionVelocity);
+  molecular_transport_->ComputeFluxTransportProperties(state, gradUp, Efield, distance, transportBuffer,
+                                                       diffusionVelocity);
 
   // Add mixing length model results to computed molecular transport
   //
@@ -85,7 +87,8 @@ MFEM_HOST_DEVICE void MixingLengthTransport::ComputeFluxTransportProperties(cons
 
 void MixingLengthTransport::ComputeSourceTransportProperties(const Vector &state, const Vector &Up,
                                                              const DenseMatrix &gradUp, const Vector &Efield,
-                                                             double distance, Vector &globalTransport, DenseMatrix &speciesTransport,
+                                                             double distance, Vector &globalTransport,
+                                                             DenseMatrix &speciesTransport,
                                                              DenseMatrix &diffusionVelocity, Vector &n_sp) {
   globalTransport.SetSize(SrcTrns::NUM_SRC_TRANS);
   speciesTransport.SetSize(numSpecies, SpeciesTrns::NUM_SPECIES_COEFFS);
@@ -105,10 +108,10 @@ void MixingLengthTransport::ComputeSourceTransportProperties(const Vector &state
 }
 
 MFEM_HOST_DEVICE void MixingLengthTransport::ComputeSourceTransportProperties(
-    const double *state, const double *Up, const double *gradUp, const double *Efield, double distance, double *globalTransport,
-    double *speciesTransport, double *diffusionVelocity, double *n_sp) {
-  molecular_transport_->ComputeSourceTransportProperties(state, Up, gradUp, Efield, distance, globalTransport, speciesTransport,
-                                                         diffusionVelocity, n_sp);
+    const double *state, const double *Up, const double *gradUp, const double *Efield, double distance,
+    double *globalTransport, double *speciesTransport, double *diffusionVelocity, double *n_sp) {
+  molecular_transport_->ComputeSourceTransportProperties(state, Up, gradUp, Efield, distance, globalTransport,
+                                                         speciesTransport, diffusionVelocity, n_sp);
 
   // Add mixing length model results to computed molecular transport
   //

--- a/src/mixing_length_transport.cpp
+++ b/src/mixing_length_transport.cpp
@@ -78,7 +78,7 @@ MFEM_HOST_DEVICE void MixingLengthTransport::ComputeFluxTransportProperties(cons
   double ur = 0;
   if (nvel_ != dim) {
     ur = primitiveState[1];
-    divV += ur / radius;
+    if (radius > 0) divV += ur / radius;
   }
 
   // eddy viscosity
@@ -99,11 +99,13 @@ MFEM_HOST_DEVICE void MixingLengthTransport::ComputeFluxTransportProperties(cons
     const double ut_r = gradUp[3 + 0 * num_equation];
     const double ut_z = gradUp[3 + 1 * num_equation];
 
-    const double Szx = 0.5 * (ut_r - ut / radius);
+    double Szx = 0.5 * ut_r;
+    if (radius > 0) Szx -= 0.5 * ut / radius;
     const double Szy = 0.5 * ut_z;
-    const double Szz = ur / radius;
+    double Szz = - divV / 3.;
+    if (radius > 0) Szz += ur / radius;
 
-    S += 2 * (2 * Szx * Szx + 2 * Szy * Szy + Szz);
+    S += 2 * (2 * Szx * Szx + 2 * Szy * Szy + Szz * Szz);
   }
 
   S = sqrt(S);

--- a/src/mixing_length_transport.cpp
+++ b/src/mixing_length_transport.cpp
@@ -58,7 +58,8 @@ MFEM_HOST_DEVICE void MixingLengthTransport::ComputeFluxTransportProperties(cons
   molecular_transport_->ComputeFluxTransportProperties(state, gradUp, Efield, distance, transportBuffer,
                                                        diffusionVelocity);
 
-  const double cp_over_Pr = transportBuffer[FluxTrns::HEAVY_THERMAL_CONDUCTIVITY] / transportBuffer[FluxTrns::VISCOSITY];
+  const double cp_over_Pr =
+      transportBuffer[FluxTrns::HEAVY_THERMAL_CONDUCTIVITY] / transportBuffer[FluxTrns::VISCOSITY];
 
   // Add mixing length model results to computed molecular transport
   double primitiveState[gpudata::MAXEQUATIONS];
@@ -72,7 +73,7 @@ MFEM_HOST_DEVICE void MixingLengthTransport::ComputeFluxTransportProperties(cons
   for (int i = 0; i < dim; i++) {
     for (int j = 0; j < dim; j++) {
       const double u_x = gradUp[(1 + i) + j * num_equation];
-      S += 2 * u_x * u_x; // todo: subtract divergence part
+      S += 2 * u_x * u_x;  // todo: subtract divergence part
     }
   }
   S = sqrt(S);
@@ -83,7 +84,7 @@ MFEM_HOST_DEVICE void MixingLengthTransport::ComputeFluxTransportProperties(cons
   transportBuffer[FluxTrns::VISCOSITY] += mut;
 
   // eddy thermal conductivity
-  const double Pr_over_Prt = Prt_; // FIXME: change varaible name
+  const double Pr_over_Prt = Prt_;  // FIXME: change varaible name
   const double kappat = mut * cp_over_Pr * Pr_over_Prt;
   transportBuffer[FluxTrns::HEAVY_THERMAL_CONDUCTIVITY] += kappat;
 }

--- a/src/mixing_length_transport.cpp
+++ b/src/mixing_length_transport.cpp
@@ -43,17 +43,18 @@ MFEM_HOST_DEVICE MixingLengthTransport::MixingLengthTransport(GasMixture *mix, c
     : TransportProperties(mix), max_mixing_length_(inputs.max_mixing_length_), Prt_(inputs.Prt_), Let_(inputs.Let_), molecular_transport_(molecular_transport) {}
 
 void MixingLengthTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp,
-                                                       const Vector &Efield, Vector &transportBuffer,
-                                                       DenseMatrix &diffusionVelocity) {
+                                                           const Vector &Efield, double distance, Vector &transportBuffer,
+                                                           DenseMatrix &diffusionVelocity) {
   transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   diffusionVelocity.SetSize(numSpecies, nvel_);
-  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], &transportBuffer[0], diffusionVelocity.Write());
+  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0], diffusionVelocity.Write());
 }
 
 MFEM_HOST_DEVICE void MixingLengthTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                                        const double *Efield, double *transportBuffer,
-                                                                        double *diffusionVelocity) {
-  molecular_transport_->ComputeFluxTransportProperties(state, gradUp, Efield, transportBuffer, diffusionVelocity);
+                                                                            const double *Efield, double distance,
+                                                                            double *transportBuffer,
+                                                                            double *diffusionVelocity) {
+  molecular_transport_->ComputeFluxTransportProperties(state, gradUp, Efield, distance, transportBuffer, diffusionVelocity);
 
   // Add mixing length model results to computed molecular transport
   //
@@ -83,14 +84,14 @@ MFEM_HOST_DEVICE void MixingLengthTransport::ComputeFluxTransportProperties(cons
 }
 
 void MixingLengthTransport::ComputeSourceTransportProperties(const Vector &state, const Vector &Up,
-                                                         const DenseMatrix &gradUp, const Vector &Efield,
-                                                         Vector &globalTransport, DenseMatrix &speciesTransport,
-                                                         DenseMatrix &diffusionVelocity, Vector &n_sp) {
+                                                             const DenseMatrix &gradUp, const Vector &Efield,
+                                                             double distance, Vector &globalTransport, DenseMatrix &speciesTransport,
+                                                             DenseMatrix &diffusionVelocity, Vector &n_sp) {
   globalTransport.SetSize(SrcTrns::NUM_SRC_TRANS);
   speciesTransport.SetSize(numSpecies, SpeciesTrns::NUM_SPECIES_COEFFS);
   n_sp.SetSize(numSpecies);
   diffusionVelocity.SetSize(numSpecies, nvel_);
-  ComputeSourceTransportProperties(&state[0], &Up[0], gradUp.Read(), &Efield[0], &globalTransport[0],
+  ComputeSourceTransportProperties(&state[0], &Up[0], gradUp.Read(), &Efield[0], distance, &globalTransport[0],
                                    speciesTransport.Write(), diffusionVelocity.Write(), &n_sp[0]);
 
   for (int sp = 0; sp < numSpecies; sp++) {
@@ -103,13 +104,11 @@ void MixingLengthTransport::ComputeSourceTransportProperties(const Vector &state
   }
 }
 
-MFEM_HOST_DEVICE void MixingLengthTransport::ComputeSourceTransportProperties(const double *state, const double *Up,
-                                                                          const double *gradUp, const double *Efield,
-                                                                          double *globalTransport,
-                                                                          double *speciesTransport,
-                                                                          double *diffusionVelocity, double *n_sp) {
-  molecular_transport_->ComputeSourceTransportProperties(state, Up, gradUp, Efield, globalTransport, speciesTransport,
-                                                        diffusionVelocity, n_sp);
+MFEM_HOST_DEVICE void MixingLengthTransport::ComputeSourceTransportProperties(
+    const double *state, const double *Up, const double *gradUp, const double *Efield, double distance, double *globalTransport,
+    double *speciesTransport, double *diffusionVelocity, double *n_sp) {
+  molecular_transport_->ComputeSourceTransportProperties(state, Up, gradUp, Efield, distance, globalTransport, speciesTransport,
+                                                         diffusionVelocity, n_sp);
 
   // Add mixing length model results to computed molecular transport
   //

--- a/src/mixing_length_transport.hpp
+++ b/src/mixing_length_transport.hpp
@@ -61,18 +61,20 @@ class MixingLengthTransport : public TransportProperties {
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double distance, double *transportBuffer,
-                                                               double *diffusionVelocity);
+                                                               const double *Efield, double distance,
+                                                               double *transportBuffer, double *diffusionVelocity);
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                                 const Vector &Efield, double distance, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp);
   MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
                                                                  const double *gradUp, const double *Efield,
-                                                                 double distance, double *globalTransport, double *speciesTransport,
-                                                                 double *diffusionVelocity, double *n_sp);
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) override;
+                                                                 double distance, double *globalTransport,
+                                                                 double *speciesTransport, double *diffusionVelocity,
+                                                                 double *n_sp);
 
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance,
+                                       double *visc) override;
 };
 
 MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double *conserved, const double *primitive,

--- a/src/mixing_length_transport.hpp
+++ b/src/mixing_length_transport.hpp
@@ -76,15 +76,16 @@ class MixingLengthTransport : public TransportProperties {
   MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
   MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, const double *gradUp,
                                        double distance, double *visc) override;
-
 };
 
-MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double *conserved, const double *primitive, double *visc) {
+MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double *conserved, const double *primitive,
+                                                                   double *visc) {
   assert(false);
 }
 
 MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double *conserved, const double *primitive,
-                                                                   const double *gradUp, double distance, double *visc) {
+                                                                   const double *gradUp, double distance,
+                                                                   double *visc) {
   molecular_transport_->GetViscosities(conserved, primitive, visc);
 
   const double rho = primitive[0];
@@ -94,7 +95,7 @@ MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double 
   for (int i = 0; i < dim; i++) {
     for (int j = 0; j < dim; j++) {
       const double u_x = gradUp[(1 + i) + j * num_equation];
-      S += 2 * u_x * u_x; // todo: subtract divergence part
+      S += 2 * u_x * u_x;  // todo: subtract divergence part
     }
   }
   S = sqrt(S);

--- a/src/mixing_length_transport.hpp
+++ b/src/mixing_length_transport.hpp
@@ -59,7 +59,8 @@ class MixingLengthTransport : public TransportProperties {
   MFEM_HOST_DEVICE virtual ~MixingLengthTransport() { delete molecular_transport_; }
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              double radius, double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double radius, double distance, Vector &transportBuffer,
+                                              DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
                                                                const double *Efield, double radius, double distance,
                                                                double *transportBuffer, double *diffusionVelocity);
@@ -102,7 +103,7 @@ MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double 
 
   const double mixing_length = std::min(0.41 * distance, max_mixing_length_);
   const double mut = rho * mixing_length * mixing_length * S;
-  //const double mut = 0.0;
+  // const double mut = 0.0;
 
   visc[0] += mut;
 }

--- a/src/mixing_length_transport.hpp
+++ b/src/mixing_length_transport.hpp
@@ -125,7 +125,7 @@ MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double 
     double Szx = 0.5 * ut_r;
     if (radius > 0) Szx -= 0.5 * ut / radius;
     const double Szy = 0.5 * ut_z;
-    double Szz = - divV / 3.;
+    double Szz = -divV / 3.;
     if (radius > 0) Szz += ur / radius;
 
     S += 2 * (2 * Szx * Szx + 2 * Szy * Szy + Szz * Szz);
@@ -138,6 +138,5 @@ MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double 
 
   visc[0] += mut;
 }
-
 
 #endif  // MIXING_LENGTH_TRANSPORT_HPP_

--- a/src/mixing_length_transport.hpp
+++ b/src/mixing_length_transport.hpp
@@ -41,6 +41,7 @@
 using namespace std;
 using namespace mfem;
 
+#if !defined(_CUDA_) && !defined(_HIP_)
 class MixingLengthTransport : public TransportProperties {
  protected:
   // for turbulent transport calculations
@@ -138,5 +139,5 @@ MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double 
 
   visc[0] += mut;
 }
-
+#endif
 #endif  // MIXING_LENGTH_TRANSPORT_HPP_

--- a/src/mixing_length_transport.hpp
+++ b/src/mixing_length_transport.hpp
@@ -1,0 +1,82 @@
+// -----------------------------------------------------------------------------------bl-
+// BSD 3-Clause License
+//
+// Copyright (c) 2020-2022, The PECOS Development Team, University of Texas at Austin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// -----------------------------------------------------------------------------------el-
+#ifndef MIXING_LENGTH_TRANSPORT_HPP_
+#define MIXING_LENGTH_TRANSPORT_HPP_
+
+#include "dataStructures.hpp"
+#include "equation_of_state.hpp"
+#include "run_configuration.hpp"
+#include "tps_mfem_wrap.hpp"
+#include "transport_properties.hpp"
+
+using namespace std;
+using namespace mfem;
+
+class MixingLengthTransport : public TransportProperties {
+ protected:
+  // for turbulent transport calculations
+  const double max_mixing_length_;  // user-specifed maximum mixing length
+  const double Prt_;                // eddy Prandtl number
+  const double Let_;                // eddy Lewis number
+
+  // for molecular transport (owned)
+  TransportProperties *molecular_transport_;
+
+ public:
+  MixingLengthTransport(GasMixture *mix, RunConfiguration &runfile, TransportProperties *molecular_transport);
+  MFEM_HOST_DEVICE MixingLengthTransport(GasMixture *mix, const mixingLengthTransportData &inputs,
+                                         TransportProperties *molecular_transport);
+
+  MFEM_HOST_DEVICE virtual ~MixingLengthTransport() { delete molecular_transport_; }
+
+  virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
+                                              Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
+                                                               const double *Efield, double *transportBuffer,
+                                                               double *diffusionVelocity);
+  virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
+                                                const Vector &Efield, Vector &globalTransport,
+                                                DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
+                                                Vector &n_sp);
+  MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
+                                                                 const double *gradUp, const double *Efield,
+                                                                 double *globalTransport, double *speciesTransport,
+                                                                 double *diffusionVelocity, double *n_sp);
+
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
+};
+
+MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double *conserved, const double *primitive, double *visc) {
+  molecular_transport_->GetViscosities(conserved, primitive, visc);
+}
+
+#endif  // MIXING_LENGTH_TRANSPORT_HPP_

--- a/src/mixing_length_transport.hpp
+++ b/src/mixing_length_transport.hpp
@@ -59,24 +59,26 @@ class MixingLengthTransport : public TransportProperties {
   MFEM_HOST_DEVICE virtual ~MixingLengthTransport() { delete molecular_transport_; }
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double *transportBuffer,
+                                                               const double *Efield, double distance, double *transportBuffer,
                                                                double *diffusionVelocity);
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
-                                                const Vector &Efield, Vector &globalTransport,
+                                                const Vector &Efield, double distance, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp);
   MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
                                                                  const double *gradUp, const double *Efield,
-                                                                 double *globalTransport, double *speciesTransport,
+                                                                 double distance, double *globalTransport, double *speciesTransport,
                                                                  double *diffusionVelocity, double *n_sp);
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) override;
 
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
 };
 
-MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double *conserved, const double *primitive, double *visc) {
-  molecular_transport_->GetViscosities(conserved, primitive, visc);
+MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double *conserved, const double *primitive,
+                                                                   double distance, double *visc) {
+  molecular_transport_->GetViscosities(conserved, primitive, distance, visc);
 }
+
 
 #endif  // MIXING_LENGTH_TRANSPORT_HPP_

--- a/src/mixing_length_transport.hpp
+++ b/src/mixing_length_transport.hpp
@@ -59,9 +59,9 @@ class MixingLengthTransport : public TransportProperties {
   MFEM_HOST_DEVICE virtual ~MixingLengthTransport() { delete molecular_transport_; }
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double radius, double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double distance,
+                                                               const double *Efield, double radius, double distance,
                                                                double *transportBuffer, double *diffusionVelocity);
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                                 const Vector &Efield, double distance, Vector &globalTransport,
@@ -100,8 +100,9 @@ MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double 
   }
   S = sqrt(S);
 
-  const double mixing_length = std::max(0.41 * distance, max_mixing_length_);
+  const double mixing_length = std::min(0.41 * distance, max_mixing_length_);
   const double mut = rho * mixing_length * mixing_length * S;
+  //const double mut = 0.0;
 
   visc[0] += mut;
 }

--- a/src/mpi_groups.hpp
+++ b/src/mpi_groups.hpp
@@ -68,9 +68,7 @@ class MPI_Groups {
 
   int isWorldRoot() { return this->getTPSWorldRank() == 0; }
 
-
-  [[deprecated("Use getTPSCommWorld")]]
-  MPI_Comm getSession() { return TPSCommWorld_; }
+  [[deprecated("Use getTPSCommWorld")]] MPI_Comm getSession() { return TPSCommWorld_; }
 
   MPI_Comm getTPSCommWorld() { return TPSCommWorld_; }
 

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -298,8 +298,8 @@ void OutletBC::initBCs() {
   }
 }
 
-void OutletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                              double delta, double distance, Vector &bdrFlux) {
+void OutletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                              double distance, Vector &bdrFlux) {
   switch (outletType_) {
     case SUB_P:
       subsonicReflectingPressure(normal, stateIn, bdrFlux);

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -298,8 +298,8 @@ void OutletBC::initBCs() {
   }
 }
 
-void OutletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector transip,
-                              double delta, Vector &bdrFlux) {
+void OutletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
+                              double delta, double distance, Vector &bdrFlux) {
   switch (outletType_) {
     case SUB_P:
       subsonicReflectingPressure(normal, stateIn, bdrFlux);

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -103,8 +103,8 @@ class OutletBC : public BoundaryCondition {
            const Array<double> &_inputData, const int &_maxIntPoints, const int &maxDofs, bool axisym);
   ~OutletBC();
 
-  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector transip,
-                      double delta, Vector &bdrFlux);
+  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
+                      double delta, double distance, Vector &bdrFlux);
 
   virtual void initBCs();
 

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -103,8 +103,8 @@ class OutletBC : public BoundaryCondition {
            const Array<double> &_inputData, const int &_maxIntPoints, const int &maxDofs, bool axisym);
   ~OutletBC();
 
-  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                      double delta, double distance, Vector &bdrFlux);
+  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                      double distance, Vector &bdrFlux);
 
   virtual void initBCs();
 

--- a/src/quasimagnetostatic.cpp
+++ b/src/quasimagnetostatic.cpp
@@ -43,10 +43,8 @@ using namespace mfem::common;
 static Vector axis(3);
 void JFun(const Vector &x, Vector &f);
 
-QuasiMagnetostaticSolverBase::QuasiMagnetostaticSolverBase(ElectromagneticOptions em_opts,
-                                                           TPS::Tps *tps)
+QuasiMagnetostaticSolverBase::QuasiMagnetostaticSolverBase(ElectromagneticOptions em_opts, TPS::Tps *tps)
     : em_opts_(em_opts), offsets_(3) {
-
   MPI_Comm_size(tps->getTPSCommWorld(), &nprocs_);
   MPI_Comm_rank(tps->getTPSCommWorld(), &rank_);
   if (rank_ == 0)
@@ -695,8 +693,7 @@ static double radius(const Vector &x) { return x[0]; }
 
 static double oneOverRadius(const Vector &x) { return 1.0 / x[0]; }
 
-QuasiMagnetostaticSolverAxiSym::QuasiMagnetostaticSolverAxiSym(ElectromagneticOptions em_opts,
-                                                               TPS::Tps *tps)
+QuasiMagnetostaticSolverAxiSym::QuasiMagnetostaticSolverAxiSym(ElectromagneticOptions em_opts, TPS::Tps *tps)
     : QuasiMagnetostaticSolverBase(em_opts, tps) {
   h1_ = NULL;
   Atheta_space_ = NULL;

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -524,7 +524,7 @@ void RHSoperator::GetFlux(const Vector &x, DenseTensor &flux) const {
 
     if (eqSystem != EULER) {
       DenseMatrix fvisc(num_equation_, dim);
-      fluxClass->ComputeViscousFluxes(state, gradUpi, xyz, delta, fvisc);
+      fluxClass->ComputeViscousFluxes(state, gradUpi, xyz, delta, -1, fvisc);
       f -= fvisc;
     }
 
@@ -581,7 +581,7 @@ void RHSoperator::GetFlux_gpu(const Vector &x, DenseTensor &flux) const {
     double xyz[3];
     for (int d = 0; d < dim; d++) xyz[d] = d_coord[n + d * dof];
 
-    d_fluxClass->ComputeViscousFluxes(Un, gradUpn, xyz, d_elSize[n], fvisc);
+    d_fluxClass->ComputeViscousFluxes(Un, gradUpn, xyz, d_elSize[n], -1, fvisc);
 
     for (int eq = 0; eq < num_equation; eq++) {
       for (int d = 0; d < dim; d++) {

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -115,6 +115,7 @@ class RHSoperator : public TimeDependentOperator {
   ParGridFunction *Up;
   ParGridFunction *plasma_conductivity_;
   ParGridFunction *joule_heating_;
+  ParGridFunction *distance_;
 
   // gradients of primitives and associated forms&FE space
   ParGridFunction *gradUp;
@@ -151,7 +152,7 @@ class RHSoperator : public TimeDependentOperator {
               DGNonLinearForm *_A, MixedBilinearForm *_Aflux, ParMesh *_mesh, ParGridFunction *_spaceVaryViscMult,
               ParGridFunction *U, ParGridFunction *_Up, ParGridFunction *_gradUp, ParFiniteElementSpace *_gradUpfes,
               GradNonLinearForm *_gradUp_A, BCintegrator *_bcIntegrator, RunConfiguration &_config, ParGridFunction *pc,
-              ParGridFunction *jh);
+              ParGridFunction *jh, ParGridFunction *distance);
 
   virtual void Mult(const Vector &x, Vector &y) const;
   void updatePrimitives(const Vector &x) const;

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -247,8 +247,12 @@ class RunConfiguration {
   // flag for using third-order electron thermal conductivity
   bool thirdOrderkElectron;
 
+  // flag to use mixing length model
+  bool use_mixing_length;
+
   // data structure for constant transport property class
   constantTransportData constantTransport;
+  mixingLengthTransportData mix_length_trans_input_;
 
   // Use MMS
   bool use_mms_;

--- a/src/source_term.cpp
+++ b/src/source_term.cpp
@@ -129,7 +129,9 @@ void SourceTerm::updateTerms(mfem::Vector &in) {
     for (int v = 0; v < _nvel; v++)
       for (int sp = 0; sp < _numSpecies; sp++) diffusionVelocity[sp + v * _numSpecies] = 0.0;
     double ns[gpudata::MAXSPECIES];
-    _transport->ComputeSourceTransportProperties(Un, upn, gradUpn, Efield, globalTransport, speciesTransport,
+
+    // TODO: Get distance
+    _transport->ComputeSourceTransportProperties(Un, upn, gradUpn, Efield, -1, globalTransport, speciesTransport,
                                                  diffusionVelocity, ns);
 
     for (int eq = 0; eq < _num_equation; eq++) srcTerm[eq] = 0.0;

--- a/src/source_term.cpp
+++ b/src/source_term.cpp
@@ -130,7 +130,7 @@ void SourceTerm::updateTerms(mfem::Vector &in) {
       for (int sp = 0; sp < _numSpecies; sp++) diffusionVelocity[sp + v * _numSpecies] = 0.0;
     double ns[gpudata::MAXSPECIES];
 
-    // TODO: Get distance
+    // TODO(trevilo): Get distance
     _transport->ComputeSourceTransportProperties(Un, upn, gradUpn, Efield, -1, globalTransport, speciesTransport,
                                                  diffusionVelocity, ns);
 

--- a/src/source_term.hpp
+++ b/src/source_term.hpp
@@ -80,13 +80,14 @@ class SourceTerm : public ForcingTerms {
   Chemistry *chemistry_ = NULL;
   Radiation *radiation_ = NULL;
   ParGridFunction *plasma_conductivity_;
+  ParGridFunction *distance_;
 
  public:
   SourceTerm(const int &_dim, const int &_num_equation, const int &_order, const int &_intRuleType,
              IntegrationRules *_intRules, ParFiniteElementSpace *_vfes, ParGridFunction *U, ParGridFunction *_Up,
              ParGridFunction *_gradUp, const precomputedIntegrationData &gpuArrays, RunConfiguration &_config,
              GasMixture *mixture, GasMixture *d_mixture, TransportProperties *transport, Chemistry *chemistry,
-             Radiation *radiation, ParGridFunction *pc);
+             Radiation *radiation, ParGridFunction *pc, ParGridFunction *distance);
   ~SourceTerm();
 
   // Terms do not need updating

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -56,7 +56,6 @@
 #include "cycle_avg_joule_coupling.hpp"
 #include "independent_coupling.hpp"
 
-
 namespace TPS {
 
 /** \brief Constructs default Tps object.
@@ -65,7 +64,7 @@ namespace TPS {
  * call input parsing functions, choose solver, and initialize to set
  * information for simulation.  For an example, see main.cpp.
  */
-Tps::Tps(MPI_Comm world): TPSCommWorld_(world) {
+Tps::Tps(MPI_Comm world) : TPSCommWorld_(world) {
   MPI_Comm_size(world, &nprocs_);
   MPI_Comm_rank(world, &rank_);
   if (rank_ == 0)
@@ -475,35 +474,35 @@ namespace py = pybind11;
 /*! Return a TPS::Tps from mpi4py communicator object.
 Anonimous function for pybind interface
  */
-TPS::Tps * createTpsFromPythonComm(py::object py_comm) {
+TPS::Tps *createTpsFromPythonComm(py::object py_comm) {
   auto comm_ptr = PyMPIComm_Get(py_comm.ptr());
 
-  if (!comm_ptr)
-    throw py::error_already_set();
+  if (!comm_ptr) throw py::error_already_set();
 
   return new TPS::Tps(*comm_ptr);
 }
 #endif
 
 PYBIND11_MODULE(libtps, m) {
-  #ifdef HAVE_MPI4PY
+#ifdef HAVE_MPI4PY
   // initialize mpi4py's C-API
   if (import_mpi4py() < 0) {
     // mpi4py calls the Python C API
     // we let pybind11 give us the detailed traceback
     throw py::error_already_set();
   }
-  #endif
+#endif
 
   m.doc() = "TPS Python Interface";
   py::class_<TPS::Tps>(m, "Tps")
       .def(py::init<>())
-      #ifdef HAVE_MPI4PY
+#ifdef HAVE_MPI4PY
       .def(py::init([](py::object py_comm) {
         auto comm_ptr = PyMPIComm_Get(py_comm.ptr());
-        if (!comm_ptr)  throw py::error_already_set();
-        return new TPS::Tps(*comm_ptr); }) )
-      #endif
+        if (!comm_ptr) throw py::error_already_set();
+        return new TPS::Tps(*comm_ptr);
+      }))
+#endif
       .def("chooseDevices", &TPS::Tps::chooseDevices)
       .def("chooseSolver", &TPS::Tps::chooseSolver)
       .def("getStatus", &TPS::Tps::getStatus)

--- a/src/tps.hpp
+++ b/src/tps.hpp
@@ -100,7 +100,7 @@ class Tps {
   bool isVisualizationMode_;
 
  public:
-  Tps(): Tps(MPI_COMM_WORLD) {}
+  Tps() : Tps(MPI_COMM_WORLD) {}
   Tps(MPI_Comm world);
   ~Tps();
   GRVY::GRVY_Input_Class iparse_;  ///< runtime input parser (from libgrvy)
@@ -162,8 +162,7 @@ class Tps {
   void parseInputFile(std::string iFile);
   void closeInputFile() { iparse_.Close(); }
 
-  [[deprecated("Use getTPSCommWorld")]]
-  MPI_Comm getMPISession() { return TPSCommWorld_; }
+  [[deprecated("Use getTPSCommWorld")]] MPI_Comm getMPISession() { return TPSCommWorld_; }
 
   MPI_Comm getTPSCommWorld() { return TPSCommWorld_; }
 

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -260,7 +260,8 @@ void DryAirTransport::ComputeFluxTransportProperties(const Vector &state, const 
 }
 
 MFEM_HOST_DEVICE void DryAirTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                                      const double *Efield, double distance, double *transportBuffer,
+                                                                      const double *Efield, double distance,
+                                                                      double *transportBuffer,
                                                                       double *diffusionVelocity) {
   double p = mixture->ComputePressure(state);
   double temp = p / gas_constant / state[0];
@@ -374,7 +375,8 @@ void ConstantTransport::ComputeFluxTransportProperties(const Vector &state, cons
                                                        DenseMatrix &diffusionVelocity) {
   transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   diffusionVelocity.SetSize(numSpecies, nvel_);
-  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0], diffusionVelocity.Write());
+  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0],
+                                 diffusionVelocity.Write());
   // transportBuffer[FluxTrns::VISCOSITY] = viscosity_;
   // transportBuffer[FluxTrns::BULK_VISCOSITY] = bulkViscosity_;
   // transportBuffer[FluxTrns::HEAVY_THERMAL_CONDUCTIVITY] = thermalConductivity_;
@@ -423,7 +425,8 @@ void ConstantTransport::ComputeFluxTransportProperties(const Vector &state, cons
 }
 
 MFEM_HOST_DEVICE void ConstantTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                                        const double *Efield, double distance, double *transportBuffer,
+                                                                        const double *Efield, double distance,
+                                                                        double *transportBuffer,
                                                                         double *diffusionVelocity) {
   // transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   transportBuffer[FluxTrns::VISCOSITY] = viscosity_;
@@ -480,8 +483,9 @@ MFEM_HOST_DEVICE void ConstantTransport::ComputeFluxTransportProperties(const do
 
 void ConstantTransport::ComputeSourceTransportProperties(const Vector &state, const Vector &Up,
                                                          const DenseMatrix &gradUp, const Vector &Efield,
-                                                         double distance, Vector &globalTransport, DenseMatrix &speciesTransport,
-                                                         DenseMatrix &diffusionVelocity, Vector &n_sp) {
+                                                         double distance, Vector &globalTransport,
+                                                         DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
+                                                         Vector &n_sp) {
   globalTransport.SetSize(SrcTrns::NUM_SRC_TRANS);
   speciesTransport.SetSize(numSpecies, SpeciesTrns::NUM_SPECIES_COEFFS);
   n_sp.SetSize(numSpecies);

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -222,8 +222,8 @@ MFEM_HOST_DEVICE DryAirTransport::DryAirTransport(GasMixture *_mixture, const do
 }
 
 void DryAirTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp,
-                                                     const Vector &Efield, double distance, Vector &transportBuffer,
-                                                     DenseMatrix &diffusionVelocity) {
+                                                     const Vector &Efield, double radius, double distance,
+                                                     Vector &transportBuffer, DenseMatrix &diffusionVelocity) {
   double p = mixture->ComputePressure(state);
   double temp = p / gas_constant / state[0];
 
@@ -260,8 +260,8 @@ void DryAirTransport::ComputeFluxTransportProperties(const Vector &state, const 
 }
 
 MFEM_HOST_DEVICE void DryAirTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                                      const double *Efield, double distance,
-                                                                      double *transportBuffer,
+                                                                      const double *Efield, double radius,
+                                                                      double distance, double *transportBuffer,
                                                                       double *diffusionVelocity) {
   double p = mixture->ComputePressure(state);
   double temp = p / gas_constant / state[0];
@@ -371,11 +371,11 @@ MFEM_HOST_DEVICE ConstantTransport::ConstantTransport(GasMixture *_mixture, cons
 }
 
 void ConstantTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp,
-                                                       const Vector &Efield, double distance, Vector &transportBuffer,
-                                                       DenseMatrix &diffusionVelocity) {
+                                                       const Vector &Efield, double radius, double distance,
+                                                       Vector &transportBuffer, DenseMatrix &diffusionVelocity) {
   transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   diffusionVelocity.SetSize(numSpecies, nvel_);
-  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0],
+  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], radius, distance, &transportBuffer[0],
                                  diffusionVelocity.Write());
   // transportBuffer[FluxTrns::VISCOSITY] = viscosity_;
   // transportBuffer[FluxTrns::BULK_VISCOSITY] = bulkViscosity_;
@@ -425,8 +425,8 @@ void ConstantTransport::ComputeFluxTransportProperties(const Vector &state, cons
 }
 
 MFEM_HOST_DEVICE void ConstantTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                                        const double *Efield, double distance,
-                                                                        double *transportBuffer,
+                                                                        const double *Efield, double radius,
+                                                                        double distance, double *transportBuffer,
                                                                         double *diffusionVelocity) {
   // transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   transportBuffer[FluxTrns::VISCOSITY] = viscosity_;

--- a/src/transport_properties.cpp
+++ b/src/transport_properties.cpp
@@ -222,7 +222,7 @@ MFEM_HOST_DEVICE DryAirTransport::DryAirTransport(GasMixture *_mixture, const do
 }
 
 void DryAirTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp,
-                                                     const Vector &Efield, Vector &transportBuffer,
+                                                     const Vector &Efield, double distance, Vector &transportBuffer,
                                                      DenseMatrix &diffusionVelocity) {
   double p = mixture->ComputePressure(state);
   double temp = p / gas_constant / state[0];
@@ -260,7 +260,7 @@ void DryAirTransport::ComputeFluxTransportProperties(const Vector &state, const 
 }
 
 MFEM_HOST_DEVICE void DryAirTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                                      const double *Efield, double *transportBuffer,
+                                                                      const double *Efield, double distance, double *transportBuffer,
                                                                       double *diffusionVelocity) {
   double p = mixture->ComputePressure(state);
   double temp = p / gas_constant / state[0];
@@ -370,11 +370,11 @@ MFEM_HOST_DEVICE ConstantTransport::ConstantTransport(GasMixture *_mixture, cons
 }
 
 void ConstantTransport::ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp,
-                                                       const Vector &Efield, Vector &transportBuffer,
+                                                       const Vector &Efield, double distance, Vector &transportBuffer,
                                                        DenseMatrix &diffusionVelocity) {
   transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   diffusionVelocity.SetSize(numSpecies, nvel_);
-  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], &transportBuffer[0], diffusionVelocity.Write());
+  ComputeFluxTransportProperties(&state[0], gradUp.Read(), &Efield[0], distance, &transportBuffer[0], diffusionVelocity.Write());
   // transportBuffer[FluxTrns::VISCOSITY] = viscosity_;
   // transportBuffer[FluxTrns::BULK_VISCOSITY] = bulkViscosity_;
   // transportBuffer[FluxTrns::HEAVY_THERMAL_CONDUCTIVITY] = thermalConductivity_;
@@ -423,7 +423,7 @@ void ConstantTransport::ComputeFluxTransportProperties(const Vector &state, cons
 }
 
 MFEM_HOST_DEVICE void ConstantTransport::ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                                        const double *Efield, double *transportBuffer,
+                                                                        const double *Efield, double distance, double *transportBuffer,
                                                                         double *diffusionVelocity) {
   // transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
   transportBuffer[FluxTrns::VISCOSITY] = viscosity_;
@@ -480,13 +480,13 @@ MFEM_HOST_DEVICE void ConstantTransport::ComputeFluxTransportProperties(const do
 
 void ConstantTransport::ComputeSourceTransportProperties(const Vector &state, const Vector &Up,
                                                          const DenseMatrix &gradUp, const Vector &Efield,
-                                                         Vector &globalTransport, DenseMatrix &speciesTransport,
+                                                         double distance, Vector &globalTransport, DenseMatrix &speciesTransport,
                                                          DenseMatrix &diffusionVelocity, Vector &n_sp) {
   globalTransport.SetSize(SrcTrns::NUM_SRC_TRANS);
   speciesTransport.SetSize(numSpecies, SpeciesTrns::NUM_SPECIES_COEFFS);
   n_sp.SetSize(numSpecies);
   diffusionVelocity.SetSize(numSpecies, nvel_);
-  ComputeSourceTransportProperties(&state[0], &Up[0], gradUp.Read(), &Efield[0], &globalTransport[0],
+  ComputeSourceTransportProperties(&state[0], &Up[0], gradUp.Read(), &Efield[0], distance, &globalTransport[0],
                                    speciesTransport.Write(), diffusionVelocity.Write(), &n_sp[0]);
   // globalTransport = 0.0;
   // speciesTransport.SetSize(numSpecies, SpeciesTrns::NUM_SPECIES_COEFFS);
@@ -540,7 +540,7 @@ void ConstantTransport::ComputeSourceTransportProperties(const Vector &state, co
 
 MFEM_HOST_DEVICE void ConstantTransport::ComputeSourceTransportProperties(const double *state, const double *Up,
                                                                           const double *gradUp, const double *Efield,
-                                                                          double *globalTransport,
+                                                                          double distance, double *globalTransport,
                                                                           double *speciesTransport,
                                                                           double *diffusionVelocity, double *n_sp) {
   for (int i = 0; i < SrcTrns::NUM_SRC_TRANS; i++) globalTransport[i] = 0.0;

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -192,7 +192,8 @@ class DryAirTransport : public TransportProperties {
   MFEM_HOST_DEVICE virtual ~DryAirTransport() {}
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              double radius, double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double radius, double distance, Vector &transportBuffer,
+                                              DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
                                                                const double *Efield, double radius, double distance,
                                                                double *transportBuffer, double *diffusionVelocity);

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -85,21 +85,21 @@ class TransportProperties {
   // but do not return it as output.
   // TODO(kevin): need to discuss whether to reuse computed primitive variables in flux evaluation,
   // or in general evaluation of primitive variables.
-  virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
+  virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield, double distance,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity) = 0;
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double *transportBuffer,
+                                                               const double *Efield, double distance, double *transportBuffer,
                                                                double *diffusionVelocity) = 0;
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
   // If this routine evaluate additional primitive variables, can return them just as the routine above.
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
-                                                const Vector &Efield, Vector &globalTransport,
+                                                const Vector &Efield, double distance, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp) = 0;
   MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
-                                                                 const double *gradUp, const double *Efield,
+                                                                 const double *gradUp, const double *Efield, double distance,
                                                                  double *globalTransport, double *speciesTransport,
                                                                  double *diffusionVelocity, double *n_sp) = 0;
 
@@ -114,7 +114,7 @@ class TransportProperties {
    * @param primitive Pointer to primitive state vector
    * @param visc      Pointer to viscosities (visc[0] = dynamic viscosity, visc[1] = bulk viscosity)
    */
-  MFEM_HOST_DEVICE virtual void GetViscosities(const double *conserved, const double *primitive, double *visc) = 0;
+  MFEM_HOST_DEVICE virtual void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) = 0;
 
   // For mixture-averaged diffusion, correct for mass conservation.
   void correctMassDiffusionFlux(const Vector &Y_sp, DenseMatrix &diffusionVelocity);
@@ -169,25 +169,25 @@ class DryAirTransport : public TransportProperties {
 
   MFEM_HOST_DEVICE virtual ~DryAirTransport() {}
 
-  virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
+  virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield, double distance,
                                               Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double *transportBuffer,
+                                                               const double *Efield, double distance, double *transportBuffer,
                                                                double *diffusionVelocity);
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
-                                                const Vector &Efield, Vector &globalTransport,
+                                                const Vector &Efield, double distance, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp) {}
   MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
-                                                                 const double *gradUp, const double *Efield,
+                                                                 const double *gradUp, const double *Efield, double distance,
                                                                  double *globalTransport, double *speciesTransport,
                                                                  double *diffusionVelocity, double *n_sp) {}
 
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) override;
 };
 
 MFEM_HOST_DEVICE inline void DryAirTransport::GetViscosities(const double *conserved, const double *primitive,
-                                                             double *visc) {
+                                                             double distance, double *visc) {
   const double temp = primitive[1 + nvel_];
   visc[0] = (C1_ * visc_mult * pow(temp, 1.5) / (temp + S0_));
   visc[1] = bulk_visc_mult * visc[0];
@@ -216,24 +216,24 @@ class ConstantTransport : public TransportProperties {
   MFEM_HOST_DEVICE virtual ~ConstantTransport() {}
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double *transportBuffer,
+                                                               const double *Efield, double distance, double *transportBuffer,
                                                                double *diffusionVelocity);
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
-                                                const Vector &Efield, Vector &globalTransport,
+                                                const Vector &Efield, double distance, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp);
   MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
-                                                                 const double *gradUp, const double *Efield,
+                                                                 const double *gradUp, const double *Efield, double distance,
                                                                  double *globalTransport, double *speciesTransport,
                                                                  double *diffusionVelocity, double *n_sp);
 
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) override;
 };
 
 MFEM_HOST_DEVICE inline void ConstantTransport::GetViscosities(const double *conserved, const double *primitive,
-                                                               double *visc) {
+                                                               double distance, double *visc) {
   visc[0] = viscosity_;
   visc[1] = bulkViscosity_;
 }

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -86,10 +86,10 @@ class TransportProperties {
   // TODO(kevin): need to discuss whether to reuse computed primitive variables in flux evaluation,
   // or in general evaluation of primitive variables.
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              double distance, Vector &transportBuffer,
+                                              double radius, double distance, Vector &transportBuffer,
                                               DenseMatrix &diffusionVelocity) = 0;
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double distance,
+                                                               const double *Efield, double radius, double distance,
                                                                double *transportBuffer, double *diffusionVelocity) = 0;
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
@@ -192,9 +192,9 @@ class DryAirTransport : public TransportProperties {
   MFEM_HOST_DEVICE virtual ~DryAirTransport() {}
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double radius, double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double distance,
+                                                               const double *Efield, double radius, double distance,
                                                                double *transportBuffer, double *diffusionVelocity);
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                                 const Vector &Efield, double distance, Vector &globalTransport,
@@ -239,9 +239,10 @@ class ConstantTransport : public TransportProperties {
   MFEM_HOST_DEVICE virtual ~ConstantTransport() {}
 
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+                                              double radius, double distance, Vector &transportBuffer,
+                                              DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double distance,
+                                                               const double *Efield, double radius, double distance,
                                                                double *transportBuffer, double *diffusionVelocity);
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                                 const Vector &Efield, double distance, Vector &globalTransport,

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -134,7 +134,7 @@ class TransportProperties {
    * @param visc      Pointer to viscosities (visc[0] = dynamic viscosity, visc[1] = bulk viscosity)
    */
   MFEM_HOST_DEVICE virtual void GetViscosities(const double *conserved, const double *primitive, const double *gradUp,
-                                               double distance, double *visc) {
+                                               double radius, double distance, double *visc) {
     GetViscosities(conserved, primitive, visc);
   }
 

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -85,11 +85,12 @@ class TransportProperties {
   // but do not return it as output.
   // TODO(kevin): need to discuss whether to reuse computed primitive variables in flux evaluation,
   // or in general evaluation of primitive variables.
-  virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield, double distance,
-                                              Vector &transportBuffer, DenseMatrix &diffusionVelocity) = 0;
+  virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
+                                              double distance, Vector &transportBuffer,
+                                              DenseMatrix &diffusionVelocity) = 0;
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double distance, double *transportBuffer,
-                                                               double *diffusionVelocity) = 0;
+                                                               const double *Efield, double distance,
+                                                               double *transportBuffer, double *diffusionVelocity) = 0;
 
   // Source term will be constructed using ForcingTerms, which have pointers to primitive variables.
   // So we can use them in evaluating transport properties.
@@ -99,9 +100,10 @@ class TransportProperties {
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp) = 0;
   MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
-                                                                 const double *gradUp, const double *Efield, double distance,
-                                                                 double *globalTransport, double *speciesTransport,
-                                                                 double *diffusionVelocity, double *n_sp) = 0;
+                                                                 const double *gradUp, const double *Efield,
+                                                                 double distance, double *globalTransport,
+                                                                 double *speciesTransport, double *diffusionVelocity,
+                                                                 double *n_sp) = 0;
 
   /** @brief Evaluate viscosity and bulk viscosity
    *
@@ -114,7 +116,8 @@ class TransportProperties {
    * @param primitive Pointer to primitive state vector
    * @param visc      Pointer to viscosities (visc[0] = dynamic viscosity, visc[1] = bulk viscosity)
    */
-  MFEM_HOST_DEVICE virtual void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) = 0;
+  MFEM_HOST_DEVICE virtual void GetViscosities(const double *conserved, const double *primitive, double distance,
+                                               double *visc) = 0;
 
   // For mixture-averaged diffusion, correct for mass conservation.
   void correctMassDiffusionFlux(const Vector &Y_sp, DenseMatrix &diffusionVelocity);
@@ -169,21 +172,23 @@ class DryAirTransport : public TransportProperties {
 
   MFEM_HOST_DEVICE virtual ~DryAirTransport() {}
 
-  virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield, double distance,
-                                              Vector &transportBuffer, DenseMatrix &diffusionVelocity);
+  virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
+                                              double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double distance, double *transportBuffer,
-                                                               double *diffusionVelocity);
+                                                               const double *Efield, double distance,
+                                                               double *transportBuffer, double *diffusionVelocity);
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                                 const Vector &Efield, double distance, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp) {}
   MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
-                                                                 const double *gradUp, const double *Efield, double distance,
-                                                                 double *globalTransport, double *speciesTransport,
-                                                                 double *diffusionVelocity, double *n_sp) {}
+                                                                 const double *gradUp, const double *Efield,
+                                                                 double distance, double *globalTransport,
+                                                                 double *speciesTransport, double *diffusionVelocity,
+                                                                 double *n_sp) {}
 
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) override;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance,
+                                       double *visc) override;
 };
 
 MFEM_HOST_DEVICE inline void DryAirTransport::GetViscosities(const double *conserved, const double *primitive,
@@ -218,18 +223,20 @@ class ConstantTransport : public TransportProperties {
   virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                               double distance, Vector &transportBuffer, DenseMatrix &diffusionVelocity);
   MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double distance, double *transportBuffer,
-                                                               double *diffusionVelocity);
+                                                               const double *Efield, double distance,
+                                                               double *transportBuffer, double *diffusionVelocity);
   virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                                 const Vector &Efield, double distance, Vector &globalTransport,
                                                 DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                                 Vector &n_sp);
   MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
-                                                                 const double *gradUp, const double *Efield, double distance,
-                                                                 double *globalTransport, double *speciesTransport,
-                                                                 double *diffusionVelocity, double *n_sp);
+                                                                 const double *gradUp, const double *Efield,
+                                                                 double distance, double *globalTransport,
+                                                                 double *speciesTransport, double *diffusionVelocity,
+                                                                 double *n_sp);
 
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance, double *visc) override;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double distance,
+                                       double *visc) override;
 };
 
 MFEM_HOST_DEVICE inline void ConstantTransport::GetViscosities(const double *conserved, const double *primitive,

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -118,7 +118,6 @@ class TransportProperties {
    */
   MFEM_HOST_DEVICE virtual void GetViscosities(const double *conserved, const double *primitive, double *visc) = 0;
 
-
   /** @brief Evaluate viscosity and bulk viscosity
    *
    * Evaluate the viscosity and bulk viscosity.  This is only used to
@@ -134,11 +133,10 @@ class TransportProperties {
    * @param distance  Distance to the nearest no-slip wall
    * @param visc      Pointer to viscosities (visc[0] = dynamic viscosity, visc[1] = bulk viscosity)
    */
-  MFEM_HOST_DEVICE virtual void GetViscosities(const double *conserved, const double *primitive,
-                                               const double *gradUp, double distance, double *visc) {
+  MFEM_HOST_DEVICE virtual void GetViscosities(const double *conserved, const double *primitive, const double *gradUp,
+                                               double distance, double *visc) {
     GetViscosities(conserved, primitive, visc);
   }
-
 
   // For mixture-averaged diffusion, correct for mass conservation.
   void correctMassDiffusionFlux(const Vector &Y_sp, DenseMatrix &diffusionVelocity);
@@ -211,7 +209,8 @@ class DryAirTransport : public TransportProperties {
   MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
 };
 
-MFEM_HOST_DEVICE inline void DryAirTransport::GetViscosities(const double *conserved, const double *primitive, double *visc) {
+MFEM_HOST_DEVICE inline void DryAirTransport::GetViscosities(const double *conserved, const double *primitive,
+                                                             double *visc) {
   const double temp = primitive[1 + nvel_];
   visc[0] = (C1_ * visc_mult * pow(temp, 1.5) / (temp + S0_));
   visc[1] = bulk_visc_mult * visc[0];
@@ -257,7 +256,8 @@ class ConstantTransport : public TransportProperties {
   MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
 };
 
-MFEM_HOST_DEVICE inline void ConstantTransport::GetViscosities(const double *conserved, const double *primitive, double *visc) {
+MFEM_HOST_DEVICE inline void ConstantTransport::GetViscosities(const double *conserved, const double *primitive,
+                                                               double *visc) {
   visc[0] = viscosity_;
   visc[1] = bulkViscosity_;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -56,8 +56,8 @@
 bool slurm_job_almost_done_mpi(MPI_Comm comm, int threshold);
 
 // check if the amount of time left in SLURM job is less than desired threshold
-[[deprecated("Use slurm_job_almost_done(MPI_Comm comm, int threshold) instead")]]
-bool slurm_job_almost_done(int threshold, int rank) {
+[[deprecated("Use slurm_job_almost_done(MPI_Comm comm, int threshold) instead")]] bool slurm_job_almost_done(
+    int threshold, int rank) {
   return slurm_job_almost_done_mpi(MPI_COMM_WORLD, threshold);
 }
 

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -200,8 +200,8 @@ void WallBC::buildWallElemsArray() {
   wallElems.ReadWrite();
 }
 
-void WallBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                            double delta, double distance, Vector &bdrFlux) {
+void WallBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                            double distance, Vector &bdrFlux) {
   switch (wallType_) {
       /*
       case INV:
@@ -245,8 +245,8 @@ void WallBC::integrationBC(Vector &y, const Vector &x, const elementIndexingData
                      x, elem_index_data, boundary_face_data, maxDofs);
 }
 
-void WallBC::computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                                double delta, double distance, Vector &bdrFlux) {
+void WallBC::computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                                double distance, Vector &bdrFlux) {
   Vector vel(nvel_);
   for (int d = 0; d < nvel_; d++) vel[d] = stateIn[1 + d] / stateIn[0];
 
@@ -312,8 +312,8 @@ void WallBC::computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gr
 Inviscid slip boundary condition.  Finds interior velocity in wall-coordinates, flips normal
 component (mirror state), transforms back to global, send to riemann
 */
-void WallBC::computeSlipWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                                 double delta, Vector &bdrFlux) {
+void WallBC::computeSlipWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                                 Vector &bdrFlux) {
   Vector prim(num_equation_);
   mixture->GetPrimitivesFromConservatives(stateIn, prim);
   double wallT = prim[dim_ + 1];
@@ -402,8 +402,8 @@ void WallBC::computeSlipWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &g
   rsolver->Eval(stateIn, state2, normal, bdrFlux);
 }
 
-void WallBC::computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState,
-                                      Vector transip, double delta, Vector &bdrFlux) {
+void WallBC::computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
+                                      double delta, Vector &bdrFlux) {
   Vector wallState(num_equation_);
   mixture->computeStagnationState(stateIn, wallState);
 
@@ -443,8 +443,8 @@ void WallBC::computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatr
   }
 }
 
-void WallBC::computeIsothermalWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState,
-                                       Vector transip, double delta, Vector &bdrFlux) {
+void WallBC::computeIsothermalWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
+                                       double delta, Vector &bdrFlux) {
   Vector wallState(num_equation_);
   mixture->computeStagnantStateWithTemp(stateIn, wallTemp_, wallState);
   // TODO(kevin): set stangant state with two separate temperature.
@@ -477,8 +477,8 @@ void WallBC::computeIsothermalWallFlux(Vector &normal, Vector &stateIn, DenseMat
   }
 }
 
-void WallBC::computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState,
-                                    Vector transip, double delta, Vector &bdrFlux) {
+void WallBC::computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
+                                    double delta, Vector &bdrFlux) {
   Vector wallState(num_equation_);
   mixture->modifyStateFromPrimitive(stateIn, bcState_, wallState);
 

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -279,7 +279,7 @@ void WallBC::computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gr
     // the axis... but... should implement this separately
 
     // incoming visc flux
-    fluxClass->ComputeViscousFluxes(stateIn, gradState, transip, delta, viscF);
+    fluxClass->ComputeViscousFluxes(stateIn, gradState, transip, delta, -1, viscF);
 
     // modify gradients so that wall is adibatic
     Vector unitNorm = normal;
@@ -294,11 +294,11 @@ void WallBC::computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gr
     DenseMatrix viscFw(num_equation_, dim_);
 
     // evaluate viscous fluxes at the wall
-    fluxClass->ComputeViscousFluxes(stateMirror, gradState, transip, delta, viscFw);
+    fluxClass->ComputeViscousFluxes(stateMirror, gradState, transip, delta, -1, viscFw);
     viscFw.Mult(normal, wallViscF);
 
     // evaluate internal viscous fluxes
-    fluxClass->ComputeViscousFluxes(stateIn, gradState, transip, delta, viscF);
+    fluxClass->ComputeViscousFluxes(stateIn, gradState, transip, delta, -1, viscF);
   }
 
   // Add visc fluxes (we skip density eq.)
@@ -413,7 +413,7 @@ void WallBC::computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatr
 
   // incoming visc flux
   DenseMatrix viscF(num_equation_, dim_);
-  fluxClass->ComputeViscousFluxes(stateIn, gradState, transip, delta, viscF);
+  fluxClass->ComputeViscousFluxes(stateIn, gradState, transip, delta, 0.0, viscF);
 
   // modify gradients so that wall is adibatic
   Vector unitNorm = normal;
@@ -468,7 +468,7 @@ void WallBC::computeIsothermalWallFlux(Vector &normal, Vector &stateIn, DenseMat
 
   // evaluate internal viscous fluxes
   DenseMatrix viscF(num_equation_, dim_);
-  fluxClass->ComputeViscousFluxes(stateIn, gradState, transip, delta, viscF);
+  fluxClass->ComputeViscousFluxes(stateIn, gradState, transip, delta, 0.0, viscF);
 
   // Add visc fluxes (we skip density eq.)
   for (int eq = 1; eq < num_equation_; eq++) {
@@ -501,7 +501,7 @@ void WallBC::computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix
 
   // evaluate internal viscous fluxes
   DenseMatrix viscF(num_equation_, dim_);
-  fluxClass->ComputeViscousFluxes(stateIn, gradState, transip, delta, viscF);
+  fluxClass->ComputeViscousFluxes(stateIn, gradState, transip, delta, 0.0, viscF);
 
   // Add visc fluxes (we skip density eq.)
   for (int eq = 1; eq < num_equation_; eq++) {
@@ -718,7 +718,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &e
         d_rsolver->Eval_LF(u1, u2, nor, Rflux);
 
         if (type != WallType::SLIP) {
-          d_fluxclass->ComputeViscousFluxes(u1, gradUp1, xyz, d_delta[el_bdry], vF1);
+          d_fluxclass->ComputeViscousFluxes(u1, gradUp1, xyz, d_delta[el_bdry], 0.0, vF1);
           d_fluxclass->ComputeBdrViscousFluxes(u2, gradUp1, xyz, d_delta[el_bdry], bcFlux, vF2);
           for (int eq = 0; eq < num_equation; eq++) vF2[eq] *= sqrt(normN);
 

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -288,7 +288,7 @@ void WallBC::computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gr
     unitNorm *= 1. / sqrt(normN);
 
     for (int d = 0; d < dim_; d++) bcFlux_.normal[d] = unitNorm[d];
-    fluxClass->ComputeBdrViscousFluxes(stateMirror, gradState, transip, delta, bcFlux_, wallViscF);
+    fluxClass->ComputeBdrViscousFluxes(stateMirror, gradState, transip, delta, distance, bcFlux_, wallViscF);
     wallViscF *= sqrt(normN);  // in case normal is not a unit vector..
   } else {
     DenseMatrix viscFw(num_equation_, dim_);
@@ -433,7 +433,7 @@ void WallBC::computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatr
 
   // evaluate viscous fluxes at the wall
   Vector wallViscF(num_equation_);
-  fluxClass->ComputeBdrViscousFluxes(wallState, gradState, transip, delta, bcFlux_, wallViscF);
+  fluxClass->ComputeBdrViscousFluxes(wallState, gradState, transip, delta, 0.0, bcFlux_, wallViscF);
   wallViscF *= sqrt(normN);  // in case normal is not a unit vector..
 
   // Add visc fluxes (we skip density eq.)
@@ -463,7 +463,7 @@ void WallBC::computeIsothermalWallFlux(Vector &normal, Vector &stateIn, DenseMat
 
   // evaluate viscous fluxes at the wall
   Vector wallViscF(num_equation_);
-  fluxClass->ComputeBdrViscousFluxes(wallState, gradState, transip, delta, bcFlux_, wallViscF);
+  fluxClass->ComputeBdrViscousFluxes(wallState, gradState, transip, delta, 0.0, bcFlux_, wallViscF);
   wallViscF *= sqrt(normN);  // in case normal is not a unit vector..
 
   // evaluate internal viscous fluxes
@@ -496,7 +496,7 @@ void WallBC::computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix
 
   // evaluate viscous fluxes at the wall
   Vector wallViscF(num_equation_);
-  fluxClass->ComputeBdrViscousFluxes(wallState, gradState, transip, delta, bcFlux_, wallViscF);
+  fluxClass->ComputeBdrViscousFluxes(wallState, gradState, transip, delta, 0.0, bcFlux_, wallViscF);
   wallViscF *= sqrt(normN);  // in case normal is not a unit vector..
 
   // evaluate internal viscous fluxes
@@ -719,7 +719,7 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &e
 
         if (type != WallType::SLIP) {
           d_fluxclass->ComputeViscousFluxes(u1, gradUp1, xyz, d_delta[el_bdry], 0.0, vF1);
-          d_fluxclass->ComputeBdrViscousFluxes(u2, gradUp1, xyz, d_delta[el_bdry], bcFlux, vF2);
+          d_fluxclass->ComputeBdrViscousFluxes(u2, gradUp1, xyz, d_delta[el_bdry], 0.0, bcFlux, vF2);
           for (int eq = 0; eq < num_equation; eq++) vF2[eq] *= sqrt(normN);
 
           // add visc flux contribution

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -200,8 +200,8 @@ void WallBC::buildWallElemsArray() {
   wallElems.ReadWrite();
 }
 
-void WallBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector transip,
-                            double delta, Vector &bdrFlux) {
+void WallBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
+                            double delta, double distance, Vector &bdrFlux) {
   switch (wallType_) {
       /*
       case INV:
@@ -219,19 +219,19 @@ void WallBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradSt
       */
 
     case INV:
-      computeINVwallFlux(normal, stateIn, gradState, radius, transip, delta, bdrFlux);
+      computeINVwallFlux(normal, stateIn, gradState, transip, delta, bdrFlux);
       break;
     case SLIP:
-      computeSlipWallFlux(normal, stateIn, gradState, radius, transip, delta, bdrFlux);
+      computeSlipWallFlux(normal, stateIn, gradState, transip, delta, bdrFlux);
       break;
     case VISC_ADIAB:
-      computeAdiabaticWallFlux(normal, stateIn, gradState, radius, transip, delta, bdrFlux);
+      computeAdiabaticWallFlux(normal, stateIn, gradState, transip, delta, bdrFlux);
       break;
     case VISC_ISOTH:
-      computeIsothermalWallFlux(normal, stateIn, gradState, radius, transip, delta, bdrFlux);
+      computeIsothermalWallFlux(normal, stateIn, gradState, transip, delta, bdrFlux);
       break;
     case VISC_GNRL:
-      computeGeneralWallFlux(normal, stateIn, gradState, radius, transip, delta, bdrFlux);
+      computeGeneralWallFlux(normal, stateIn, gradState, transip, delta, bdrFlux);
       break;
   }
 }
@@ -245,7 +245,7 @@ void WallBC::integrationBC(Vector &y, const Vector &x, const elementIndexingData
                      x, elem_index_data, boundary_face_data, maxDofs);
 }
 
-void WallBC::computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector transip,
+void WallBC::computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
                                 double delta, Vector &bdrFlux) {
   Vector vel(nvel_);
   for (int d = 0; d < nvel_; d++) vel[d] = stateIn[1 + d] / stateIn[0];
@@ -312,7 +312,7 @@ void WallBC::computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gr
 Inviscid slip boundary condition.  Finds interior velocity in wall-coordinates, flips normal
 component (mirror state), transforms back to global, send to riemann
 */
-void WallBC::computeSlipWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector transip,
+void WallBC::computeSlipWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
                                  double delta, Vector &bdrFlux) {
   Vector prim(num_equation_);
   mixture->GetPrimitivesFromConservatives(stateIn, prim);
@@ -402,7 +402,7 @@ void WallBC::computeSlipWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &g
   rsolver->Eval(stateIn, state2, normal, bdrFlux);
 }
 
-void WallBC::computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius,
+void WallBC::computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState,
                                       Vector transip, double delta, Vector &bdrFlux) {
   Vector wallState(num_equation_);
   mixture->computeStagnationState(stateIn, wallState);
@@ -443,7 +443,7 @@ void WallBC::computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatr
   }
 }
 
-void WallBC::computeIsothermalWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius,
+void WallBC::computeIsothermalWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState,
                                        Vector transip, double delta, Vector &bdrFlux) {
   Vector wallState(num_equation_);
   mixture->computeStagnantStateWithTemp(stateIn, wallTemp_, wallState);
@@ -477,7 +477,7 @@ void WallBC::computeIsothermalWallFlux(Vector &normal, Vector &stateIn, DenseMat
   }
 }
 
-void WallBC::computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius,
+void WallBC::computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState,
                                     Vector transip, double delta, Vector &bdrFlux) {
   Vector wallState(num_equation_);
   mixture->modifyStateFromPrimitive(stateIn, bcState_, wallState);

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -219,7 +219,7 @@ void WallBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradSt
       */
 
     case INV:
-      computeINVwallFlux(normal, stateIn, gradState, transip, delta, bdrFlux);
+      computeINVwallFlux(normal, stateIn, gradState, transip, delta, distance, bdrFlux);
       break;
     case SLIP:
       computeSlipWallFlux(normal, stateIn, gradState, transip, delta, bdrFlux);
@@ -246,7 +246,7 @@ void WallBC::integrationBC(Vector &y, const Vector &x, const elementIndexingData
 }
 
 void WallBC::computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                                double delta, Vector &bdrFlux) {
+                                double delta, double distance, Vector &bdrFlux) {
   Vector vel(nvel_);
   for (int d = 0; d < nvel_; d++) vel[d] = stateIn[1 + d] / stateIn[0];
 
@@ -279,7 +279,7 @@ void WallBC::computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gr
     // the axis... but... should implement this separately
 
     // incoming visc flux
-    fluxClass->ComputeViscousFluxes(stateIn, gradState, transip, delta, -1, viscF);
+    fluxClass->ComputeViscousFluxes(stateIn, gradState, transip, delta, distance, viscF);
 
     // modify gradients so that wall is adibatic
     Vector unitNorm = normal;
@@ -294,11 +294,11 @@ void WallBC::computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gr
     DenseMatrix viscFw(num_equation_, dim_);
 
     // evaluate viscous fluxes at the wall
-    fluxClass->ComputeViscousFluxes(stateMirror, gradState, transip, delta, -1, viscFw);
+    fluxClass->ComputeViscousFluxes(stateMirror, gradState, transip, delta, distance, viscFw);
     viscFw.Mult(normal, wallViscF);
 
     // evaluate internal viscous fluxes
-    fluxClass->ComputeViscousFluxes(stateIn, gradState, transip, delta, -1, viscF);
+    fluxClass->ComputeViscousFluxes(stateIn, gradState, transip, delta, distance, viscF);
   }
 
   // Add visc fluxes (we skip density eq.)

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -63,17 +63,8 @@ class WallBC : public BoundaryCondition {
   Array<int> wallElems;
   void buildWallElemsArray();
 
-  /*
-  void computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector &bdrFlux);
-  void computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius,
-                                Vector &bdrFlux);
-  void computeIsothermalWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, double delta,
-                                 Vector &bdrFlux);
-  void computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector &bdrFlux);
-  */
-
   void computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                          double delta, Vector &bdrFlux);
+                          double delta, double distance, Vector &bdrFlux);
   void computeSlipWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
                            double delta, Vector &bdrFlux);
   void computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -72,15 +72,15 @@ class WallBC : public BoundaryCondition {
   void computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector &bdrFlux);
   */
 
-  void computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector transip,
+  void computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
                           double delta, Vector &bdrFlux);
-  void computeSlipWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector transip,
+  void computeSlipWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
                            double delta, Vector &bdrFlux);
-  void computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector transip,
+  void computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
                                 double delta, Vector &bdrFlux);
-  void computeIsothermalWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector transip,
+  void computeIsothermalWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
                                  double delta, Vector &bdrFlux);
-  void computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector transip,
+  void computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
                               double delta, Vector &bdrFlux);
 
  public:
@@ -90,8 +90,8 @@ class WallBC : public BoundaryCondition {
          const boundaryFaceIntegrationData &boundary_face_data, const int &maxIntPoints, bool axisym);
   ~WallBC();
 
-  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, double radius, Vector transip,
-                      double delta, Vector &bdrFlux);
+  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
+                      double delta, double distance, Vector &bdrFlux);
 
   virtual void initBCs();
 

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -63,16 +63,16 @@ class WallBC : public BoundaryCondition {
   Array<int> wallElems;
   void buildWallElemsArray();
 
-  void computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                          double delta, double distance, Vector &bdrFlux);
-  void computeSlipWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                           double delta, Vector &bdrFlux);
-  void computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                                double delta, Vector &bdrFlux);
-  void computeIsothermalWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                                 double delta, Vector &bdrFlux);
-  void computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                              double delta, Vector &bdrFlux);
+  void computeINVwallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                          double distance, Vector &bdrFlux);
+  void computeSlipWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                           Vector &bdrFlux);
+  void computeAdiabaticWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                                Vector &bdrFlux);
+  void computeIsothermalWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                                 Vector &bdrFlux);
+  void computeGeneralWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                              Vector &bdrFlux);
 
  public:
   WallBC(RiemannSolver *rsolver_, GasMixture *_mixture, GasMixture *d_mixture, Equations _eqSystem, Fluxes *_fluxClass,
@@ -81,8 +81,8 @@ class WallBC : public BoundaryCondition {
          const boundaryFaceIntegrationData &boundary_face_data, const int &maxIntPoints, bool axisym);
   ~WallBC();
 
-  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                      double delta, double distance, Vector &bdrFlux);
+  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                      double distance, Vector &bdrFlux);
 
   virtual void initBCs();
 

--- a/test/.gitattributes
+++ b/test/.gitattributes
@@ -40,3 +40,5 @@ ref_solns/annulus.restart.sol.h5 filter=lfs diff=lfs merge=lfs -text
 ref_solns/annulus.50100.sol.h5 filter=lfs diff=lfs merge=lfs -text
 ref_solns/pipe.100100.sol.h5 filter=lfs diff=lfs merge=lfs -text
 ref_solns/pipe.restart.sol.h5 filter=lfs diff=lfs merge=lfs -text
+ref_solns/pipe.mix.161100.sol.h5 filter=lfs diff=lfs merge=lfs -text
+ref_solns/pipe.mix.restart.sol.h5 filter=lfs diff=lfs merge=lfs -text

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -36,7 +36,7 @@ EXTRA_DIST      = tap-driver.sh test_tps_splitcomm.py soln_differ inputs meshes 
 	 	  mms.ternary_2d_inout.test cuda-memcheck.test mms.general_wall.test \
 		  independent_coupling.test interp_em.test mms.euler_2d.test mms.cns_2d.test \
 		  gradient.test coupled-3d.test coupled-3d.splitcomm.test tabulated.test lte_mixture.test distance_fcn.test \
-                  sgsSmag.test sgsSigma.test plate.test
+                  sgsSmag.test sgsSigma.test plate.test pipe.mix.test
 
 TESTS = vpath.sh
 XFAIL_TESTS =
@@ -86,7 +86,8 @@ TESTS += cyl3d.test \
 	 lte_mixture.test \
          sgsSmag.test \
          sgsSigma.test \
-         plate.test
+         plate.test \
+         pipe.mix.test
 
 if PYTHON_ENABLED
 TESTS += cyl3d.python.test \

--- a/test/inputs/pipe.axisym.mix.ini
+++ b/test/inputs/pipe.axisym.mix.ini
@@ -1,0 +1,64 @@
+[solver]
+type = flow
+
+[flow]
+mesh = meshes/axi-pipe.msh
+order = 3
+integrationRule = 0
+basisType = 0
+maxIters = 161100
+outputFreq = 100
+useRoe = 0
+enableSummationByParts = 0
+fluid = dry_air
+refLength = 1.
+equation_system = navier-stokes
+viscosityMultiplier = 1.0
+axisymmetric = True
+computeDistance = True
+useMixingLength = True
+mixing-length/max-mixing-length = 0.1
+mixing-length/Pr_ratio = 0.77
+
+[io]
+outdirBase = output-pipe-mix
+enableRestart = True
+restartMode = singleFileReadWrite
+
+[time]
+cfl = 0.12
+integrator = rk3
+enableConstantTimestep = True
+
+[initialConditions]
+rho = 1.16
+rhoU = 0.0
+rhoV = 58.0
+rhoW = 0.
+pressure = 100000.
+
+[boundaryConditions/wall1]
+patch = 2
+type = inviscid
+
+[boundaryConditions/inlet1]
+patch = 3
+type = subsonic
+density = 1.27
+uvw = '0.0 50.0 0.0'
+
+[boundaryConditions/outlet1]
+patch = 4
+type = subsonicPressure
+pressure = 100000.
+
+[boundaryConditions/wall2]
+patch = 5
+type = viscous_isothermal
+temperature = 300.
+
+[boundaryConditions]
+numWalls = 2
+numInlets = 1
+numOutlets = 1
+

--- a/test/inputs/pipe.axisym.viscous.ini
+++ b/test/inputs/pipe.axisym.viscous.ini
@@ -16,6 +16,8 @@ equation_system = navier-stokes
 viscosityMultiplier = 63000.
 axisymmetric = True
 computeDistance = True
+useMixingLength = True
+mixing-length/max-mixing-length = 1.0
 
 [io]
 outdirBase = output-pipe

--- a/test/inputs/pipe.axisym.viscous.ini
+++ b/test/inputs/pipe.axisym.viscous.ini
@@ -16,8 +16,6 @@ equation_system = navier-stokes
 viscosityMultiplier = 63000.
 axisymmetric = True
 computeDistance = True
-useMixingLength = True
-mixing-length/max-mixing-length = 1.0
 
 [io]
 outdirBase = output-pipe

--- a/test/pipe.mix.test
+++ b/test/pipe.mix.test
@@ -1,0 +1,27 @@
+#!./bats
+# -*- mode: sh -*-
+
+TEST="axisymmetric/pipe.mix"
+RUNFILE_MIX="inputs/pipe.axisym.mix.ini"
+
+setup() {
+    SOLN_FILE_MIX=restart_output-pipe-mix.sol.h5
+    RSTRT_FILE_MIX=ref_solns/pipe.mix.restart.sol.h5
+    REF_FILE_MIX=ref_solns/pipe.mix.161100.sol.h5
+}
+
+@test "[$TEST] verify axisymmetric pipe case with mixing length model, input from -> $RUNFILE_MIX" {
+    # paraview+restart will fail if data in output-pipe is from after restart
+    rm -rf output-pipe-mix
+
+    test -s $RUNFILE_MIX
+    test -s $RSTRT_FILE_MIX
+    cp $RSTRT_FILE_MIX $SOLN_FILE_MIX
+
+    mpirun -np 2 ../src/tps --runFile $RUNFILE_MIX
+
+    test -s $SOLN_FILE_MIX
+    test -s $REF_FILE_MIX
+
+    ./soln_differ -r $SOLN_FILE_MIX $REF_FILE_MIX
+}

--- a/test/ref_solns/pipe.mix.161100.sol.h5
+++ b/test/ref_solns/pipe.mix.161100.sol.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08f429c88674783065985d91fb6311f1b950c6534ab7ef3c770e973b6157b2c1
+size 332568

--- a/test/ref_solns/pipe.mix.restart.sol.h5
+++ b/test/ref_solns/pipe.mix.restart.sol.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9606b1a8afb456e13e872e43fe3d8db62bac55d8836e3516cb9e7ec868b5bbc9
+size 332568

--- a/test/test_argon_minimal.cpp
+++ b/test/test_argon_minimal.cpp
@@ -163,10 +163,10 @@ int main (int argc, char *argv[])
     Vector transportBuffer;
     transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
     DenseMatrix diffusionVelocity(numSpecies, dim);
-    transport->ComputeFluxTransportProperties(conservedState, gradUp, Efield, transportBuffer, diffusionVelocity);
+    transport->ComputeFluxTransportProperties(conservedState, gradUp, Efield, -1, transportBuffer, diffusionVelocity);
 
     double visc, bulkVisc, visc_vec[2];
-    transport->GetViscosities(conservedState, primitiveState, visc_vec);
+    transport->GetViscosities(conservedState, primitiveState, -1, visc_vec);
     visc = visc_vec[0];
     bulkVisc = visc_vec[1];
 

--- a/test/test_argon_minimal.cpp
+++ b/test/test_argon_minimal.cpp
@@ -166,7 +166,7 @@ int main (int argc, char *argv[])
     transport->ComputeFluxTransportProperties(conservedState, gradUp, Efield, -1, transportBuffer, diffusionVelocity);
 
     double visc, bulkVisc, visc_vec[2];
-    transport->GetViscosities(conservedState, primitiveState, -1, visc_vec);
+    transport->GetViscosities(conservedState, primitiveState, visc_vec);
     visc = visc_vec[0];
     bulkVisc = visc_vec[1];
 

--- a/test/test_argon_minimal.cpp
+++ b/test/test_argon_minimal.cpp
@@ -163,7 +163,7 @@ int main (int argc, char *argv[])
     Vector transportBuffer;
     transportBuffer.SetSize(FluxTrns::NUM_FLUX_TRANS);
     DenseMatrix diffusionVelocity(numSpecies, dim);
-    transport->ComputeFluxTransportProperties(conservedState, gradUp, Efield, -1, transportBuffer, diffusionVelocity);
+    transport->ComputeFluxTransportProperties(conservedState, gradUp, Efield, -1, -1, transportBuffer, diffusionVelocity);
 
     double visc, bulkVisc, visc_vec[2];
     transport->GetViscosities(conservedState, primitiveState, visc_vec);

--- a/test/test_boundary_flux.cpp
+++ b/test/test_boundary_flux.cpp
@@ -126,7 +126,7 @@ bool testComputeBdrViscousFlux(RunConfiguration &srcConfig, const int dim) {
   grvy_printf(GRVY_INFO, "\n ComputeViscousFluxes * normal. \n");
   DenseMatrix viscF(num_equation, dim);
   Vector viscFdotNorm(num_equation);
-  flux->ComputeViscousFluxes(testConserved, gradUp, xyz, delta, viscF);
+  flux->ComputeViscousFluxes(testConserved, gradUp, xyz, delta, -1.0, viscF);
   viscF.Mult(dir, viscFdotNorm);
   for (int eq = 0; eq < num_equation; eq++) {
     grvy_printf(GRVY_INFO, "%.8E\t", viscFdotNorm(eq));

--- a/test/test_boundary_flux.cpp
+++ b/test/test_boundary_flux.cpp
@@ -142,7 +142,7 @@ bool testComputeBdrViscousFlux(RunConfiguration &srcConfig, const int dim) {
   for (int i = 0; i < primFluxSize; i++) bcFlux.primFluxIdxs[i] = false;
 
   Vector wallViscF(num_equation);
-  flux->ComputeBdrViscousFluxes(testConserved, gradUp, xyz, delta, bcFlux, wallViscF);
+  flux->ComputeBdrViscousFluxes(testConserved, gradUp, xyz, delta, -1.0, bcFlux, wallViscF);
   for (int eq = 0; eq < num_equation; eq++) {
     grvy_printf(GRVY_INFO, "%.8E\t", wallViscF(eq));
   }

--- a/test/test_lte_mixture.cpp
+++ b/test/test_lte_mixture.cpp
@@ -130,7 +130,7 @@ int checkTransport(LteTransport *lte_trans, LteMixture *lte_mix, double rtol) {
     Vector transport;
     DenseMatrix diffusion;
 
-    lte_trans->ComputeFluxTransportProperties(U, gradUp, E, transport, diffusion);
+    lte_trans->ComputeFluxTransportProperties(U, gradUp, E, -1, transport, diffusion);
 
     const double muexact = 2.0656339881365003e-05;
     const double mu = transport[FluxTrns::VISCOSITY];

--- a/test/test_lte_mixture.cpp
+++ b/test/test_lte_mixture.cpp
@@ -130,7 +130,7 @@ int checkTransport(LteTransport *lte_trans, LteMixture *lte_mix, double rtol) {
     Vector transport;
     DenseMatrix diffusion;
 
-    lte_trans->ComputeFluxTransportProperties(U, gradUp, E, -1, transport, diffusion);
+    lte_trans->ComputeFluxTransportProperties(U, gradUp, E, -1, -1, transport, diffusion);
 
     const double muexact = 2.0656339881365003e-05;
     const double mu = transport[FluxTrns::VISCOSITY];


### PR DESCRIPTION
This PR brings our initial RANS modeling capability, which is intended primarily for use in axisymmetric torch simulations, back to the main branch.  The model is very crude, just a simple mixing-length-based eddy viscosity.  Also, the implementation does not support the gpu yet.  Nonetheless, it is a start.

Merging this PR closes #163.