### PR TITLE
Fixes for 1499f9a

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1878,18 +1878,6 @@ void M2ulPhyS::solveStep() {
       
   }  // step check
     
-#ifdef HAVE_SLURM
-    // check if near end of a run and ready to submit restart
-    if ((iter % config.rm_checkFreq() == 0) && (iter != MaxIters)) {
-      readyForRestart = Check_JobResubmit();
-      if (readyForRestart) {
-        MaxIters = iter;
-        SetStatus(JOB_RESTART);
-        break;
-      }
-    }
-
-
   average->addSampleMean(iter);
 }
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1774,8 +1774,9 @@ void M2ulPhyS::solveStep() {
       average->write_meanANDrms_restart_files(iter, time);
     }
 
-    // make a separate routine! plane interp and dump here, add gslib check (ifdef?)
+    // make a separate routine! plane interp and dump here
     if ( config.planeDump.isEnabled == true ) {
+#ifdef HAVE_GSLIB
       // source
       ParGridFunction *u_gf = GetSolutionGF();
 
@@ -1872,6 +1873,10 @@ void M2ulPhyS::solveStep() {
         }
         outfile.close();
       }
+#else
+      grvy_printf(GRVY_ERROR, "\nPlane dump capability requires gslib support.\n");
+      exit(ERROR);
+#endif
     }  // plane dump
   }  // step check
 

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -275,8 +275,8 @@ class M2ulPhyS : public TPS::Solver {
 
   // domain extent
   double xmin, ymin, zmin;
-  double xmax, ymax, zmax;  
-  
+  double xmax, ymax, zmax;
+
   // exit status code;
   int exit_status_;
 

--- a/src/run_configuration.cpp
+++ b/src/run_configuration.cpp
@@ -98,7 +98,6 @@ RunConfiguration::RunConfiguration() {
   planeDump.point = 0.;
   planeDump.samples = 0;
 
-  
   //   initSpongeData();
   numSpongeRegions_ = 0;
   spongeData_ = NULL;

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -144,7 +144,7 @@ class RunConfiguration {
   // the plane defined by point0.
   linearlyVaryingVisc linViscData;
 
-  planeDumpData planeDump;  
+  planeDumpData planeDump;
 
   SutherlandData sutherland_;
 


### PR DESCRIPTION
1499f9a was inadvertently pushed directly to `main` with build errors.  This PR fixes them, specifically three issues:
* An unterminated `#ifdef` in `src/M2ulPhyS.cpp`
* White space causing the style check to fail
* Protection for added gslib dependence, so `tps` still builds without gslib