### PR TITLE
Some "usability" fixes

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1765,12 +1765,18 @@ void M2ulPhyS::solveStep() {
 #endif
 
     if (iter != MaxIters) {
-      // Up->HostRead();
-      Up->ReadWrite();  // sets memory to GPU
+      // auto hUp = Up->HostRead();
+      Up->HostRead();
       mixture->UpdatePressureGridFunction(press, Up);
+
+      restart_files_hdf5("write");
+
       paraviewColl->SetCycle(iter);
       paraviewColl->SetTime(time);
       paraviewColl->Save();
+      // auto dUp = Up->ReadWrite();  // sets memory to GPU
+      Up->ReadWrite();  // sets memory to GPU
+
       average->write_meanANDrms_restart_files(iter, time);
     }
 

--- a/src/cycle_avg_joule_coupling.cpp
+++ b/src/cycle_avg_joule_coupling.cpp
@@ -46,7 +46,7 @@ CycleAvgJouleCoupling::CycleAvgJouleCoupling(string &inputFileName, TPS::Tps *tp
   tps->getRequiredInput("cycle-avg-joule-coupled/solve-em-every-n", solve_em_every_n_);
   tps->getRequiredInput("cycle-avg-joule-coupled/max-iters", max_iters_);
   bool axisym = false;
-  tps->getInput("cycle-avg-joule-coupled/asymmetric", axisym, false);
+  tps->getInput("cycle-avg-joule-coupled/axisymmetric", axisym, false);
   tps->getInput("cycle-avg-joule-coupled/input-power", input_power_, -1.);
   tps->getInput("cycle-avg-joule-coupled/initial-input-power", initial_input_power_, -1.);
 

--- a/src/cycle_avg_joule_coupling.hpp
+++ b/src/cycle_avg_joule_coupling.hpp
@@ -59,6 +59,8 @@ class CycleAvgJouleCoupling : public TPS::Solver {
   int current_iter_;
   //! We call the em solver only every solve_em_every_n steps
   int solve_em_every_n_;
+  //! Report timings every timing_freq_ steps
+  int timing_freq_;
 
 #ifdef HAVE_GSLIB
   FindPointsGSLIB *interp_flow_to_em_;


### PR DESCRIPTION
This PR collects 3 fixes for issues that were noticed while working on the cycle-averaged solver:

1. There was a typo in the `axisymmetric` option (the code was reading `asymmetric` instead).
2. As part of 1499f9a, the restart file write was erroneously eliminated from `M2ulPhyS::solveStep`
3. After PR #217, the cycle averaged solver no longer printed timing info.