### PR TITLE
Refactor plane dump

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -739,40 +739,17 @@ void M2ulPhyS::initVariables() {
   }
 
   // Determine domain bounding box size
-  ParGridFunction coordsVert(dfes);
-  mesh->GetVertices(coordsVert);
-  int nVert = coordsVert.Size() / dim;
-  {
-    double local_xmin = 1.0e18;
-    double local_ymin = 1.0e18;
-    double local_zmin = 1.0e18;
-    double local_xmax = -1.0e18;
-    double local_ymax = -1.0e18;
-    double local_zmax = -1.0e18;
-    for (int n = 0; n < nVert; n++) {
-      auto hcoords = coordsVert.HostRead();
-      double coords[3];
-      for (int d = 0; d < dim; d++) {
-        coords[d] = hcoords[n + d * nVert];
-      }
-      local_xmin = min(coords[0], local_xmin);
-      local_ymin = min(coords[1], local_ymin);
-      if (dim == 3) {
-        local_zmin = min(coords[2], local_zmin);
-      }
-      local_xmax = max(coords[0], local_xmax);
-      local_ymax = max(coords[1], local_ymax);
-      if (dim == 3) {
-        local_zmax = max(coords[2], local_zmax);
-      }
-    }
-    MPI_Allreduce(&local_xmin, &xmin, 1, MPI_DOUBLE, MPI_MIN, mesh->GetComm());
-    MPI_Allreduce(&local_ymin, &ymin, 1, MPI_DOUBLE, MPI_MIN, mesh->GetComm());
-    MPI_Allreduce(&local_zmin, &zmin, 1, MPI_DOUBLE, MPI_MIN, mesh->GetComm());
-    MPI_Allreduce(&local_xmax, &xmax, 1, MPI_DOUBLE, MPI_MAX, mesh->GetComm());
-    MPI_Allreduce(&local_ymax, &ymax, 1, MPI_DOUBLE, MPI_MAX, mesh->GetComm());
-    MPI_Allreduce(&local_zmax, &zmax, 1, MPI_DOUBLE, MPI_MAX, mesh->GetComm());
-  }
+  Vector bb_min;
+  Vector bb_max;
+  mesh->GetBoundingBox(bb_min, bb_max);
+
+  xmin = bb_min[0];
+  ymin = bb_min[1];
+  (dim == 3) ? zmin = bb_min[2] : zmin = 0.0;
+
+  xmax = bb_max[0];
+  ymax = bb_max[1];
+  (dim == 3) ? zmax = bb_max[2] : zmin = 0.0;
 
   // estimate initial dt
   Up->ExchangeFaceNbrData();

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,7 +37,7 @@ cxx_sources          = averaging_and_rms.cpp faceGradientIntegration.cpp M2ulPhy
                        reaction.cpp collision_integrals.cpp argon_transport.cpp source_term.cpp gpu_constructor.cpp \
                        independent_coupling.cpp cycle_avg_joule_coupling.cpp table.cpp radiation.cpp lte_mixture.cpp \
                        lte_transport_properties.cpp mixing_length_transport.cpp tps2Boltzmann.cpp  M2ulPhyS2Boltzmann.cpp \
-					   pybindings.cpp
+                       pybindings.cpp gslib_interpolator.cpp
 
 mfem_extra_sources   = ../utils/mfem_extras/pfem_extras.cpp
 
@@ -49,7 +49,7 @@ headers              = averaging_and_rms.hpp equation_of_state.hpp transport_pro
 		       quasimagnetostatic.hpp gradients.hpp logger.hpp solver.hpp tps.hpp chemistry.hpp reaction.hpp \
 	               collision_integrals.hpp argon_transport.hpp source_term.hpp tps_mfem_wrap.hpp gpu_constructor.hpp \
                        independent_coupling.hpp cycle_avg_joule_coupling.hpp table.hpp radiation.hpp lte_mixture.hpp \
-                       lte_transport_properties.hpp mixing_length_transport.hpp tps2Boltzmann.hpp
+                       lte_transport_properties.hpp mixing_length_transport.hpp tps2Boltzmann.hpp gslib_interpolator.hpp
 
 mfem_extra_headers   = ../utils/mfem_extras/pfem_extras.hpp
 

--- a/src/gslib_interpolator.cpp
+++ b/src/gslib_interpolator.cpp
@@ -149,9 +149,12 @@ void PlaneInterpolator::setInterpolationPoints() {
     const double dz = Lz / ncell;
     for (int j = 0; j < n_; j++) {
       for (int i = 0; i < n_; i++) {
-        xyz_[iCnt + 0 * totalPts] = ndotp / normal_[0];
-        xyz_[iCnt + 1 * totalPts] = dy * (double)i + bb0_[1];
-        xyz_[iCnt + 2 * totalPts] = dz * (double)j + bb0_[2];
+        const double yp = dy * (double)i + bb0_[1];
+        const double zp = dz * (double)j + bb0_[2];
+        const double xp = (ndotp - (normal_[1] * yp) - (normal_[2] * zp)) / normal_[0];
+        xyz_[iCnt + 0 * totalPts] = xp;
+        xyz_[iCnt + 1 * totalPts] = yp;
+        xyz_[iCnt + 2 * totalPts] = zp;
         iCnt++;
       }
     }
@@ -160,9 +163,12 @@ void PlaneInterpolator::setInterpolationPoints() {
     const double dz = Lz / ncell;
     for (int j = 0; j < n_; j++) {
       for (int i = 0; i < n_; i++) {
-        xyz_[iCnt + 0 * totalPts] = dx * (double)i + bb0_[0];
-        xyz_[iCnt + 1 * totalPts] = ndotp / normal_[1];
-        xyz_[iCnt + 2 * totalPts] = dz * (double)j + bb0_[2];
+        const double xp = dx * (double)i + bb0_[0];
+        const double zp = dz * (double)j + bb0_[2];
+        const double yp = (ndotp - (normal_[0] * xp) - (normal_[2] * zp)) / normal_[1];
+        xyz_[iCnt + 0 * totalPts] = xp;
+        xyz_[iCnt + 1 * totalPts] = yp;
+        xyz_[iCnt + 2 * totalPts] = zp;
         iCnt++;
       }
     }
@@ -171,9 +177,12 @@ void PlaneInterpolator::setInterpolationPoints() {
     const double dy = Ly / ncell;
     for (int j = 0; j < n_; j++) {
       for (int i = 0; i < n_; i++) {
-        xyz_[iCnt + (0 * totalPts)] = dx * (double)i + bb0_[0];
-        xyz_[iCnt + (1 * totalPts)] = dy * (double)j + bb0_[1];
-        xyz_[iCnt + (2 * totalPts)] = ndotp / normal_[2];
+        const double xp = dx * (double)i + bb0_[0];
+        const double yp = dy * (double)j + bb0_[1];
+        const double zp = (ndotp - (normal_[0] * xp) - (normal_[1] * yp)) / normal_[2];
+        xyz_[iCnt + (0 * totalPts)] = xp;
+        xyz_[iCnt + (1 * totalPts)] = yp;
+        xyz_[iCnt + (2 * totalPts)] = zp;
         iCnt++;
       }
     }

--- a/src/gslib_interpolator.cpp
+++ b/src/gslib_interpolator.cpp
@@ -1,0 +1,197 @@
+// -----------------------------------------------------------------------------------bl-
+// BSD 3-Clause License
+//
+// Copyright (c) 2020-2022, The PECOS Development Team, University of Texas at Austin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// -----------------------------------------------------------------------------------el-
+
+#include "gslib_interpolator.hpp"
+
+using namespace std;
+using namespace mfem;
+
+InterpolatorBase::InterpolatorBase() {
+  dim_ = 0;
+  xyz_.SetSize(0);
+  soln_.SetSize(0);
+#ifdef HAVE_GSLIB
+  finder_ = NULL;
+#endif
+}
+
+InterpolatorBase::~InterpolatorBase() {
+#ifdef HAVE_GSLIB
+  delete finder_;
+#endif
+}
+
+void InterpolatorBase::initializeFinder(ParMesh *mesh) {
+  dim_ = mesh->Dimension();
+#ifdef HAVE_GSLIB
+  finder_ = new FindPointsGSLIB(mesh->GetComm());
+  finder_->Setup(*mesh);
+#else
+  mfem_error("InterpolatorBase requires gslib support!");
+#endif
+}
+
+void InterpolatorBase::setInterpolationPoints(mfem::Vector xyz) { xyz_ = xyz; }
+
+void InterpolatorBase::setInterpolationPoints() {
+  mfem_error("InterpolatorBase::setInterpolationPoints() is not implemented");
+}
+
+void InterpolatorBase::interpolate(ParGridFunction *u) {
+  assert(dim_ == 2 || dim_ == 3);
+
+  const int totalPts = xyz_.Size();
+  assert(totalPts > 0);
+
+  assert(u != NULL);
+  const int interpNum = u->VectorDim();
+
+  soln_.SetSize(totalPts * interpNum);
+#ifdef HAVE_GSLIB
+  finder_->Interpolate(xyz_, *u, soln_);
+#else
+  mfem_error("InterpolatorBase requires gslib support!");
+#endif
+}
+
+void InterpolatorBase::writeAscii(std::string oname, bool rank0) const {
+  if (rank0) {
+    assert(dim_ == 2 || dim_ == 3);
+    assert(xyz_.Size() > 0);
+    assert(soln_.Size() > 0);
+
+    const int totalPts = xyz_.Size() / dim_;
+    const int interpNum = soln_.Size() / totalPts;
+
+    std::ofstream outfile;
+    outfile.open(oname, std::ios_base::app);
+    for (int n = 0; n < totalPts; n++) {
+      outfile << n << " ";
+      for (int d = 0; d < dim_; d++) {
+        outfile << xyz_[n + d * totalPts] << " ";
+      }
+      for (int eq = 0; eq < interpNum; eq++) {
+        outfile << soln_[n + eq * totalPts] << " ";
+      }
+      outfile << endl;
+    }
+    outfile.close();
+  }
+}
+
+PlaneInterpolator::PlaneInterpolator() : InterpolatorBase() {
+  point_.SetSize(0);
+  normal_.SetSize(0);
+}
+
+PlaneInterpolator::PlaneInterpolator(mfem::Vector point, mfem::Vector normal, mfem::Vector bb0, mfem::Vector bb1, int n)
+    : InterpolatorBase(), point_(point), normal_(normal), bb0_(bb0), bb1_(bb1), n_(n) {}
+
+PlaneInterpolator::~PlaneInterpolator() {}
+
+void PlaneInterpolator::setInterpolationPoints() {
+  assert(dim_ == 3);
+  const int totalPts = n_ * n_;
+
+  double ndotp = 0.0;
+  double majorD;
+  for (int i = 0; i < dim_; i++) {
+    ndotp += normal_[i] * point_[i];
+  }
+  majorD = std::max(std::abs(normal_[0]), std::abs(normal_[1]));
+  if (dim_ == 3) {
+    majorD = std::max(majorD, std::abs(normal_[2]));
+  }
+
+  // plane points
+  xyz_.SetSize(totalPts * 3);
+
+  int iCnt = 0;
+  const double Lx = bb1_[0] - bb0_[0];
+  const double Ly = bb1_[1] - bb0_[1];
+  const double Lz = bb1_[2] - bb0_[2];
+
+  const double ncell = (double)(n_ - 1);
+
+  // TODO(trevilo): This only works when the plane we want is aligned
+  // with a coordinate direction.  Extend to generic plane.
+  if (majorD == std::abs(normal_[0])) {
+    const double dy = Ly / ncell;
+    const double dz = Lz / ncell;
+    for (int j = 0; j < n_; j++) {
+      for (int i = 0; i < n_; i++) {
+        xyz_[iCnt + 0 * totalPts] = ndotp / normal_[0];
+        xyz_[iCnt + 1 * totalPts] = dy * (double)i + bb0_[1];
+        xyz_[iCnt + 2 * totalPts] = dz * (double)j + bb0_[2];
+        iCnt++;
+      }
+    }
+  } else if (majorD == std::abs(normal_[1])) {
+    const double dx = Lx / ncell;
+    const double dz = Lz / ncell;
+    for (int j = 0; j < n_; j++) {
+      for (int i = 0; i < n_; i++) {
+        xyz_[iCnt + 0 * totalPts] = dx * (double)i + bb0_[0];
+        xyz_[iCnt + 1 * totalPts] = ndotp / normal_[1];
+        xyz_[iCnt + 2 * totalPts] = dz * (double)j + bb0_[2];
+        iCnt++;
+      }
+    }
+  } else {
+    const double dx = Lx / ncell;
+    const double dy = Ly / ncell;
+    for (int j = 0; j < n_; j++) {
+      for (int i = 0; i < n_; i++) {
+        xyz_[iCnt + (0 * totalPts)] = dx * (double)i + bb0_[0];
+        xyz_[iCnt + (1 * totalPts)] = dy * (double)j + bb0_[1];
+        xyz_[iCnt + (2 * totalPts)] = ndotp / normal_[2];
+        iCnt++;
+      }
+    }
+  }
+}
+
+void PlaneInterpolator::writeAscii(std::string oname, bool rank0) const {
+  if (rank0) {
+    std::cout << " Writing plane data to " << oname << endl;
+
+    // First write a little info about the plane
+    assert(dim_ == 3);
+    std::ofstream outfile;
+    outfile.open(oname, std::ios_base::app);
+    outfile << "#plane point " << point_[0] << " " << point_[1] << " " << point_[2] << endl;
+    outfile << "#plane normal " << normal_[0] << " " << normal_[1] << " " << normal_[2] << endl;
+    outfile.close();
+  }
+  // Rest of the write is handled by the base class
+  InterpolatorBase::writeAscii(oname, rank0);
+}

--- a/src/gslib_interpolator.hpp
+++ b/src/gslib_interpolator.hpp
@@ -1,0 +1,113 @@
+// -----------------------------------------------------------------------------------bl-
+// BSD 3-Clause License
+//
+// Copyright (c) 2020-2022, The PECOS Development Team, University of Texas at Austin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// -----------------------------------------------------------------------------------el-
+#ifndef GSLIB_INTERPOLATOR_HPP_
+#define GSLIB_INTERPOLATOR_HPP_
+
+#include <tps_config.h>
+
+#include "tps_mfem_wrap.hpp"
+
+/** @file
+ *
+ * Provides utilities for interpolating fields to arbitrary * sets of
+ * points.  These utilities make use of the * mfem::FindPointsGSLIB
+ * class to do the actual work.
+ */
+
+class InterpolatorBase {
+ protected:
+  // Spatial dimensions
+  int dim_;
+
+  // Coordinates of points to interpolate to
+  mfem::Vector xyz_;
+
+  // Interpolated values
+  mfem::Vector soln_;
+
+#ifdef HAVE_GSLIB
+  // mfem interpolator
+  mfem::FindPointsGSLIB *finder_;
+#endif
+
+ public:
+  /** Construct interpolation object.
+   *
+   * Nothing is allocated or initialized.  You must call
+   * initializeFinder and setInterpolationPoints prior to interpolate.
+   */
+  InterpolatorBase();
+
+  /** Destructor.  Frees the FindPointsGSLIB object */
+  virtual ~InterpolatorBase();
+
+  /** Initialize the internal FindPointsGSLIB object */
+  void initializeFinder(mfem::ParMesh *mesh);
+
+  /** Sets the interpolation points from user input */
+  void setInterpolationPoints(mfem::Vector xyz);
+
+  virtual void setInterpolationPoints();
+
+  /** Interpolation the input ParGridFunction to the desired points.
+   *
+   * Must call initializeFinder and setInterpolationPoints prior.
+   */
+  void interpolate(mfem::ParGridFunction *u);
+
+  /** Write the data to an ascii file */
+  virtual void writeAscii(std::string oname, bool rank0 = true) const;
+};
+
+class PlaneInterpolator : public InterpolatorBase {
+ private:
+  // point and normal that define the plane
+  mfem::Vector point_;
+  mfem::Vector normal_;
+
+  // corners of bounding box to intersect with plane
+  mfem::Vector bb0_;
+  mfem::Vector bb1_;
+
+  // number of points per side
+  int n_;
+
+ public:
+  PlaneInterpolator();
+  PlaneInterpolator(mfem::Vector point, mfem::Vector normal, mfem::Vector bb0, mfem::Vector bb1, int n);
+  virtual ~PlaneInterpolator();
+
+  void setInterpolationPoints() final;
+  void writeAscii(std::string oname, bool rank0 = true) const final;
+};
+
+#endif  // GSLIB_INTERPOLATOR_HPP_

--- a/test/cyl3d.test
+++ b/test/cyl3d.test
@@ -9,6 +9,8 @@ EXE="../src/tps"
 setup() {
     SOLN_FILE=restart_output.sol.h5
     REF_FILE=ref_solns/cyl3d_coarse.4iters.h5
+    rm -rf planeData
+    mkdir planeData
 }
 
 @test "[$TEST] check for input file $RUNFILE" {

--- a/test/inputs/input.4iters.cyl.ini
+++ b/test/inputs/input.4iters.cyl.ini
@@ -7,7 +7,7 @@ order = 1
 integrationRule = 0
 basisType = 0
 maxIters = 4
-outputFreq = 5
+outputFreq = 2
 useRoe = 0
 enableSummationByParts = 0
 fluid = dry_air
@@ -49,3 +49,9 @@ numWalls = 1
 numInlets = 1
 numOutlets = 1
 
+[planeDump]
+isEnabled = True
+norm = '1 0 0'
+point = '0.1 0 0'
+samples = 10
+conserved = True


### PR DESCRIPTION
This PR refactors the plane dump functionality (see PR #230) to remove much of the code from the `M2ulPhyS` class.  For now, the options parsing is left as it was, but the code to set up the plane, perform the interpolation call, and write the output are factored out into a new class `PlaneInterpolator`.