### PR TITLE
Fix compiler warnings

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,7 +121,7 @@ jobs:
       - name: Bootstrap
         run:  module restore tps-gpu; ./bootstrap
       - name: Configure
-        run: module restore tps-gpu; ./configure --enable-pybind11 --enable-gpu-hip HIP_ARCH=gfx803
+        run: module restore tps-gpu; ./configure CXXFLAGS="-Wall -Wno-gpu-maybe-wrong-side -Wno-unused-private-field -Wno-pessimizing-move -Werror" --enable-pybind11 --enable-gpu-hip HIP_ARCH=gfx803
       - name: Make
         run: module restore tps-gpu; make -j 2
       - name: Distclean

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -93,7 +93,7 @@ jobs:
       - name: Bootstrap
         run:  module restore tps-gpu-gnu9; ./bootstrap
       - name: Configure
-        run: module restore tps-gpu-gnu9; ./configure --enable-pybind11 --enable-gpu-cuda CUDA_ARCH=sm_75
+        run: module restore tps-gpu-gnu9; ./configure --enable-pybind11 --enable-gpu-cuda CUDA_ARCH=sm_75 USER_CUDA_CXXFLAGS="-Werror all-warnings -Xcompiler=-Wall -Xcompiler=-Werror"
       - name: Make
         run: module restore tps-gpu-gnu9; make -j 2
       - name: Tests
@@ -247,7 +247,7 @@ jobs:
        - name: Query modules loaded
          run:  module restore tps-gpu-gnu9; module list         
        - name: Configure
-         run:  cd tps-*; module restore tps-gpu-gnu9; ./configure --enable-gpu-cuda CUDA_ARCH=sm_75
+         run: cd tps-*; module restore tps-gpu-gnu9; ./configure --enable-pybind11 --enable-gpu-cuda CUDA_ARCH=sm_75 USER_CUDA_CXXFLAGS="-Werror all-warnings -Xcompiler=-Wall -Xcompiler=-Werror"
        - name: Make
          run:  cd tps-*; module restore tps-gpu-gnu9; make -j 2
        - name: TPS version
@@ -262,4 +262,4 @@ jobs:
          run:  cd tps-*; cd build; module restore tps-gpu-gnu9; make -j 2
        - name: VPATH Tests
          run:  cd tps-*; cd build; module restore tps-gpu-gnu9; make AM_COLOR_TESTS=yes check || (cat test/*.log; exit 1)
- 
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
        - name: Cancel previous runs
          uses: styfle/cancel-workflow-action@0.11.0
          with:
-           access_token: ${{ github.token }}     
+           access_token: ${{ github.token }}
        - name: Checkout code
          uses: actions/checkout@v3
          with:
@@ -58,7 +58,7 @@ jobs:
        - name: Bootstrap
          run:  ./bootstrap
        - name: Configure
-         run:  ./configure CXXFLAGS="-fdiagnostics-color=always" --enable-pybind11
+         run:  ./configure CXXFLAGS="-g -O2 -Wall -Werror -fdiagnostics-color=always" --enable-pybind11
        - name: Make
          run:  make -j 2
        - name: Tests
@@ -66,7 +66,7 @@ jobs:
        - name: Distclean
          run:  make distclean
        - name: VPATH configure
-         run:  mkdir build; cd build; ../configure
+         run:  mkdir build; cd build; ../configure CXXFLAGS="-g -O2 -Wall -Werror -fdiagnostics-color=always"
        - name: VPATH make
          run:  cd build; make -j 2
        - name: VPATH tests
@@ -183,7 +183,7 @@ jobs:
        - name: Bootstrap
          run:  ./bootstrap
        - name: Configure
-         run:  ./configure
+         run:  ./configure CXXFLAGS="-g -O2 -Wall -Werror -fdiagnostics-color=always"
        - name: Dist
          run:  make dist
        - name: Archive tarball
@@ -220,7 +220,7 @@ jobs:
        - name: Distclean
          run:  cd tps-*; make distclean
        - name: VPATH configure
-         run:  cd tps-*; mkdir build; cd build; ../configure
+         run:  cd tps-*; mkdir build; cd build; ../configure CXXFLAGS="-g -O2 -Wall -Werror -fdiagnostics-color=always"
        - name: VPATH make
          run:  cd tps-*; cd build; make -j 2
        - name: VPATH tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -151,7 +151,7 @@ jobs:
       - name: Bootstrap
         run:  module restore tps-gpu-cpu; ./bootstrap
       - name: Configure
-        run: module restore tps-gpu-cpu; ./configure --enable-pybind11 --enable-gpu-cpu
+        run: module restore tps-gpu-cpu; ./configure CXXFLAGS="-g -O2 -Wall -Wno-nonnull -Werror" --enable-pybind11 --enable-gpu-cpu
       - name: Make
         run: module restore tps-gpu-cpu; make -j 2
       - name: Tests
@@ -159,7 +159,7 @@ jobs:
       - name: Distclean
         run:  make distclean
       - name: VPATH configure
-        run:  mkdir build; cd build; module restore tps-gpu-cpu; ../configure --enable-pybind11 --enable-gpu-cpu
+        run:  mkdir build; cd build; module restore tps-gpu-cpu; ../configure CXXFLAGS="-g -O2 -Wall -Wno-nonnull -Werror" --enable-pybind11 --enable-gpu-cpu
       - name: VPATH make
         run:  cd build; module restore tps-gpu-cpu; make -j 2
       - name: VPATH tests

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 SUBDIRS          = src test utils
 AUTOMAKE_OPTIONS = foreign
 ACLOCAL_AMFLAGS  = -I m4
-EXTRA_DIST       = CHANGES LICENSE dist_version m4/snarf_mfem.py m4/wrap_lines.py src/tps.py
+EXTRA_DIST       = CHANGES LICENSE dist_version m4/snarf_mfem.py m4/snarf_mpi4py.py m4/wrap_lines.py src/tps.py
 
 # --------------------------------------------------
 # Revision control support for external distribution

--- a/configure.ac
+++ b/configure.ac
@@ -141,8 +141,10 @@ AC_LANG_PUSH([C])
 AX_CHECK_CUDA
 AC_LANG_POP([C])
 
+AC_ARG_VAR(USER_CUDA_CXXFLAGS,"Additional C++ compiler flags")
+
 CXX=$NVCC_PATH/nvcc
-CUDA_CXXFLAGS="-Xcompiler=-fPIC -x=cu --expt-extended-lambda -arch=$CUDA_ARCH -ccbin mpicxx $CUDA_CXXFLAGS"
+CUDA_CXXFLAGS="-Xcompiler=-fPIC -x=cu --expt-extended-lambda -arch=$CUDA_ARCH $USER_CUDA_CXXFLAGS -ccbin mpicxx $CUDA_CXXFLAGS"
 CUDA_LDFLAGS="--expt-extended-lambda -arch=$CUDA_ARCH -ccbin mpicxx $CUDA_LDFLAGS -lcuda -lcudart"
 
 dnl CUDA does not support -fPIC, disable in libtool in favor of -Xcompiler option above

--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -55,12 +55,12 @@ BCintegrator::BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElem
       vfes(_vfes),
       Up(_Up),
       gradUp(_gradUp),
+      distance_(distance),
       boundary_face_data_(boundary_face_data),
       dim(_dim),
       num_equation(_num_equation),
       maxIntPoints(_maxIntPoints),
-      maxDofs(_maxDofs),
-      distance_(distance) {
+      maxDofs(_maxDofs) {
   inletBCmap.clear();
   outletBCmap.clear();
   wallBCmap.clear();

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -2394,6 +2394,7 @@ void M2ulPhyS::initilizeSpeciesFromLTE() {
 #else
   energy_table = NULL;
   R_table = NULL;
+  c_table = NULL;
   T_table = NULL;
   mfem_error("Restart from LTE mixture requires GSL support.");
 #endif

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -457,9 +457,9 @@ class M2ulPhyS : public TPS::Solver {
 
   // tps2Boltzmann interface (implemented in M2ulPhyS2Boltzmann.cpp)
   /// Push solver variables to interface
-  void push(TPS::Tps2Boltzmann &interface);
+  void push(TPS::Tps2Boltzmann &interface) override;
   /// Fetch solver variables from interface
-  void fetch(TPS::Tps2Boltzmann &interface);
+  void fetch(TPS::Tps2Boltzmann &interface) override;
 
   // Exit code access
   void SetStatus(int code) {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -88,7 +88,8 @@ libtps_la_LIBADD    += $(CUDA_LDFLAGS) -lcuda -lcusparse
 #
 libtool_cxx_objects = $(cxx_sources:.cpp=.lo)
 libtool_objects = $(libtool_cxx_objects) $(mfem_extra_sources:.cpp=.lo)
-raw_objects = $(addprefix .libs/, $(libtool_cxx_objects:.lo=.o))
+obj_list = $(libtool_cxx_objects:.lo=.o)
+raw_objects = `for f in $(obj_list); do echo .libs/$$f; done`
 raw_objects += ../utils/mfem_extras/.libs/pfem_extras.o
 
 tmp_cuda_object.lo: $(libtool_objects)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -100,7 +100,7 @@ endif
 if HIP_ENABLED
 libtps_la_LIBADD    += $(HIP_LDFLAGS)
 # Need link to have -fgpu-rdc.  Protect with -Xcompiler to libtool does not strip.
-libtps_la_LDFLAGS += -Xcompiler -fgpu-rdc
+libtps_la_LDFLAGS += -Xcompiler -fgpu-rdc -Xcompiler -Wno-unused-command-line-argument
 endif
 
 if MASA_ENABLED

--- a/src/argon_transport.cpp
+++ b/src/argon_transport.cpp
@@ -520,8 +520,8 @@ MFEM_HOST_DEVICE void ArgonMinimalTransport::GetViscosities(const double *conser
                                                             double *visc) {
   double n_sp[3], X_sp[3], Y_sp[3];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
-  double nTotal = 0.0;
-  for (int sp = 0; sp < numSpecies; sp++) nTotal += n_sp[sp];
+  // double nTotal = 0.0;
+  // for (int sp = 0; sp < numSpecies; sp++) nTotal += n_sp[sp];
 
   double Te = (twoTemperature_) ? primitive[num_equation - 1] : primitive[nvel_ + 1];
   double Th = primitive[nvel_ + 1];
@@ -991,8 +991,8 @@ MFEM_HOST_DEVICE void ArgonMixtureTransport::GetViscosities(const double *conser
                                                             double *visc) {
   double n_sp[gpudata::MAXSPECIES], X_sp[gpudata::MAXSPECIES], Y_sp[gpudata::MAXSPECIES];
   mixture->computeSpeciesPrimitives(conserved, X_sp, Y_sp, n_sp);
-  double nTotal = 0.0;
-  for (int sp = 0; sp < numSpecies; sp++) nTotal += n_sp[sp];
+  // double nTotal = 0.0;
+  // for (int sp = 0; sp < numSpecies; sp++) nTotal += n_sp[sp];
 
   collisionInputs collInputs = computeCollisionInputs(primitive, n_sp);
 

--- a/src/argon_transport.hpp
+++ b/src/argon_transport.hpp
@@ -121,9 +121,8 @@ class ArgonMinimalTransport : public MolecularTransport {
 
   // virtual double computeThirdOrderElectronThermalConductivity(const Vector &X_sp, const double debyeLength,
   //                                                             const double Te, const double nondimTe);
-  MFEM_HOST_DEVICE virtual double computeThirdOrderElectronThermalConductivity(const double *X_sp,
-                                                                               const double debyeLength,
-                                                                               const double Te, const double nondimTe);
+  MFEM_HOST_DEVICE double computeThirdOrderElectronThermalConductivity(const double *X_sp, const double debyeLength,
+                                                                       const double Te, const double nondimTe);
 
   virtual void computeMixtureAverageDiffusivity(const Vector &state, Vector &diffusivity);
   MFEM_HOST_DEVICE void computeMixtureAverageDiffusivity(const double *state, double *diffusivity);
@@ -187,8 +186,8 @@ class ArgonMixtureTransport : public ArgonMinimalTransport {
   using ArgonMinimalTransport::GetViscosities;
   MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) final;
 
-  MFEM_HOST_DEVICE virtual double computeThirdOrderElectronThermalConductivity(const double *X_sp,
-                                                                               const collisionInputs &collInputs);
+  MFEM_HOST_DEVICE double computeThirdOrderElectronThermalConductivity(const double *X_sp,
+                                                                       const collisionInputs &collInputs);
   //
   // virtual void computeMixtureAverageDiffusivity(const Vector &state, Vector &diffusivity);
 };

--- a/src/chemistry.cpp
+++ b/src/chemistry.cpp
@@ -231,8 +231,8 @@ MFEM_HOST_DEVICE void Chemistry::computeCreationRate(const double *progressRate,
   }
 
   // check total created mass is 0
-  double totMass = 0.;
-  for (int sp = 0; sp < numSpecies_; sp++) totMass += creationRate[sp];
+  // double totMass = 0.;
+  // for (int sp = 0; sp < numSpecies_; sp++) totMass += creationRate[sp];
   // NOTE: this assertion below should be made non-dimensional with dt and density
   //   assert(fabs(totMass) < 1e-7);
 }

--- a/src/cycle_avg_joule_coupling.cpp
+++ b/src/cycle_avg_joule_coupling.cpp
@@ -169,13 +169,14 @@ void CycleAvgJouleCoupling::initializeInterpolationData() {
 void CycleAvgJouleCoupling::interpConductivityFromFlowToEM() {
   const bool verbose = rank0_;
   if (verbose) grvy_printf(ginfo, "Interpolating conductivity to EM mesh.\n");
+
+#ifdef HAVE_GSLIB
   const ParMesh *em_mesh = qmsa_solver_->getMesh();
   const ParFiniteElementSpace *em_fespace = qmsa_solver_->getFESpace();
 
   const int NE = em_mesh->GetNE();
   const int dim = em_mesh->Dimension();
 
-#ifdef HAVE_GSLIB
   // Generate list of points where the grid function will be evaluated.
   Vector vxyz;
 
@@ -273,9 +274,10 @@ void CycleAvgJouleCoupling::interpolationPoints(Vector &vxyz, int n_interp_nodes
 void CycleAvgJouleCoupling::interpJouleHeatingFromEMToFlow() {
   const bool verbose = rank0_;
   if (verbose) grvy_printf(ginfo, "Interpolating Joule heating to flow mesh.\n");
-  const ParFiniteElementSpace *flow_fespace = flow_solver_->GetFESpace();
 
 #ifdef HAVE_GSLIB
+  const ParFiniteElementSpace *flow_fespace = flow_solver_->GetFESpace();
+
   // Generate list of points where the grid function will be evaluated.
   Vector vxyz;
   interpolationPoints(vxyz, n_flow_interp_nodes_, flow_fespace);

--- a/src/dgNonlinearForm.cpp
+++ b/src/dgNonlinearForm.cpp
@@ -86,56 +86,6 @@ void DGNonLinearForm::setParallelData(dataTransferArrays *_transferU, dataTransf
   shared_flux.SetSize(maxNumElems * 5 * maxIntPoints_ * num_equation_);
 }
 
-void DGNonLinearForm::Mult(const Vector &x, Vector &y) {
-  ParNonlinearForm::Mult(x, y);
-  // the following is equivalent to the line above
-  //   NonlinearForm::Mult(x,y);
-  //
-  //   if (fnfi.Size())
-  //   {
-  //     // Terms over shared interior faces in parallel.
-  //     ParFiniteElementSpace *pfes = ParFESpace();
-  //     ParMesh *pmesh = pfes->GetParMesh();
-  //     FaceElementTransformations *tr;
-  //     const FiniteElement *fe1, *fe2;
-  //     Array<int> vdofs1, vdofs2;
-  //     Vector el_x, el_y;
-  //     aux1.HostReadWrite();
-  //     X.MakeRef(aux1, 0); // aux1 contains P.x
-  //     X.ExchangeFaceNbrData();
-  //     const int n_shared_faces = pmesh->GetNSharedFaces();
-  //     for (int i = 0; i < n_shared_faces; i++)
-  //     {
-  //         tr = pmesh->GetSharedFaceTransformations(i, true);
-  //         int Elem2NbrNo = tr->Elem2No - pmesh->GetNE();
-  //
-  //         fe1 = pfes->GetFE(tr->Elem1No);
-  //         fe2 = pfes->GetFaceNbrFE(Elem2NbrNo);
-  //
-  //         pfes->GetElementVDofs(tr->Elem1No, vdofs1);
-  //         pfes->GetFaceNbrElementVDofs(Elem2NbrNo, vdofs2);
-  //
-  //         el_x.SetSize(vdofs1.Size() + vdofs2.Size());
-  //         X.GetSubVector(vdofs1, el_x.GetData());
-  //         X.FaceNbrData().GetSubVector(vdofs2, el_x.GetData() + vdofs1.Size());
-  //
-  //         for (int k = 0; k < fnfi.Size(); k++)
-  //         {
-  //           fnfi[k]->AssembleFaceVector(*fe1, *fe2, *tr, el_x, el_y);
-  //           aux2.AddElementVector(vdofs1, el_y.GetData());
-  //         }
-  //     }
-  //   }
-  //
-  //   P->MultTranspose(aux2, y);
-  //
-  //   y.HostReadWrite();
-  //   for (int i = 0; i < ess_tdof_list.Size(); i++)
-  //   {
-  //     y(ess_tdof_list[i]) = 0.0;
-  //   }
-}
-
 #ifdef _GPU_
 void DGNonLinearForm::Mult_domain(const Vector &x, Vector &y) {
   const elementIndexingData &elem_data = gpu_precomputed_data_.element_indexing_data;

--- a/src/dgNonlinearForm.hpp
+++ b/src/dgNonlinearForm.hpp
@@ -82,8 +82,6 @@ class DGNonLinearForm : public ParNonlinearForm {
                   const int num_equation, GasMixture *mixture, const precomputedIntegrationData &gpu_precomputed_data,
                   const int &maxIntPoints, const int &maxDofs);
 
-  void Mult(const Vector &x, Vector &y);
-
   void setParallelData(dataTransferArrays *_transferU, dataTransferArrays *_transferGradUp);
 
   void faceIntegration_gpu(Vector &y, int elType, int elemOffset, int elDof);

--- a/src/equation_of_state.cpp
+++ b/src/equation_of_state.cpp
@@ -51,13 +51,15 @@ void GasMixture::SetConstantPlasmaConductivity(ParGridFunction *pc, const ParGri
 
   // otherwise, set plasma conductivity
   double *plasma_conductivity_gf = pc->HostWrite();
-  const double *UpData = Up->HostRead();
 
   // To a constant
   const int nnode = pc->FESpace()->GetNDofs();
   for (int n = 0; n < nnode; n++) {
     plasma_conductivity_gf[n] = const_plasma_conductivity_;
   }
+
+  // You may use the primitive state if you wish
+  // const double *UpData = Up->HostRead();
 
   // To use a spatially varying conductivity, uncomment the code
   // below, and put in the function of space you wish to use.  Note

--- a/src/faceGradientIntegration.cpp
+++ b/src/faceGradientIntegration.cpp
@@ -56,7 +56,7 @@ void GradFaceIntegrator::AssembleFaceVector(const FiniteElement &el1, const Fini
 
   // NB: Incoming Vector &elfun is in gradient space.  The first
   // component is the state, and the rest is zero.  See
-  // GradNonLinearForm::Mult in gradNonLinearForm.cpp for details.
+  // GradNonLinearForm::Apply in gradNonLinearForm.cpp for details.
   DenseMatrix elfun1_mat(elfun.GetData(), dof1, num_equation);
   DenseMatrix elfun2_mat(elfun.GetData() + dof1 * num_equation * dim, dof2, num_equation);
 

--- a/src/face_integrator.cpp
+++ b/src/face_integrator.cpp
@@ -45,10 +45,10 @@ FaceIntegrator::FaceIntegrator(IntegrationRules *_intRules, RiemannSolver *rsolv
       max_char_speed(_max_char_speed),
       gradUp(_gradUp),
       gradUpfes(_gradUpfes),
+      distance_(distance),
       intRules(_intRules),
       useLinear(_useLinear),
-      axisymmetric_(axisym),
-      distance_(distance) {
+      axisymmetric_(axisym) {
   assert(!useLinear);
   totDofs = vfes->GetNDofs();
 }

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -35,15 +35,15 @@ Fluxes::Fluxes(GasMixture *_mixture, Equations _eqSystem, TransportProperties *_
                const int _dim, bool axisym)
     : mixture(_mixture),
       eqSystem(_eqSystem),
-      transport(_transport),
-      num_equation(_num_equation),
-      dim(_dim),
-      nvel(axisym ? 3 : _dim),
-      axisymmetric_(axisym),
       config_(NULL),
+      transport(_transport),
+      dim(_dim),
+      axisymmetric_(axisym),
+      num_equation(_num_equation),
       sgs_model_type_(0),
       sgs_model_floor_(0.0),
       sgs_model_const_(0.0) {
+  nvel = axisym ? 3 : dim;
   vsd_.enabled = false;
   vsd_.n[0] = vsd_.n[1] = vsd_.n[2] = 0.;
   vsd_.p[0] = vsd_.p[1] = vsd_.p[2] = 0.;
@@ -55,15 +55,15 @@ Fluxes::Fluxes(GasMixture *_mixture, Equations _eqSystem, TransportProperties *_
                const int _dim, bool axisym, RunConfiguration *config)
     : mixture(_mixture),
       eqSystem(_eqSystem),
-      transport(_transport),
-      num_equation(_num_equation),
-      dim(_dim),
-      nvel(axisym ? 3 : _dim),
-      axisymmetric_(axisym),
       config_(config),
+      transport(_transport),
+      dim(_dim),
+      axisymmetric_(axisym),
+      num_equation(_num_equation),
       sgs_model_type_(config->GetSgsModelType()),
       sgs_model_floor_(config->GetSgsFloor()),
       sgs_model_const_(config->GetSgsConstant()) {
+  nvel = axisym ? 3 : dim;
   vsd_.enabled = config_->linViscData.isEnabled;
   vsd_.n[0] = vsd_.n[1] = vsd_.n[2] = 0.;
   vsd_.p[0] = vsd_.p[1] = vsd_.p[2] = 0.;
@@ -93,15 +93,15 @@ MFEM_HOST_DEVICE Fluxes::Fluxes(GasMixture *_mixture, Equations _eqSystem, Trans
                                 double sgs_const, viscositySpongeData vsd)
     : mixture(_mixture),
       eqSystem(_eqSystem),
-      transport(_transport),
-      num_equation(_num_equation),
-      dim(_dim),
-      nvel(axisym ? 3 : _dim),
-      axisymmetric_(axisym),
       config_(NULL),
+      transport(_transport),
+      dim(_dim),
+      axisymmetric_(axisym),
+      num_equation(_num_equation),
       sgs_model_type_(sgs_type),
       sgs_model_floor_(sgs_floor),
       sgs_model_const_(sgs_const) {
+  nvel = axisym ? 3 : dim;
   vsd_.enabled = vsd.enabled;
   vsd_.n[0] = vsd_.n[1] = vsd_.n[2] = 0.;
   vsd_.p[0] = vsd_.p[1] = vsd_.p[2] = 0.;
@@ -646,8 +646,6 @@ Simple planar viscous sponge layer with smooth tanh-transtion using user-specifi
 total amplification.  Note: duplicate in M2
 */
 MFEM_HOST_DEVICE void Fluxes::viscSpongePlanar(double *x, double &wgt) {
-  double normal[3];
-  double point[3];
   double s[3];
   double factor, width, dist;
 

--- a/src/gradNonLinearForm.cpp
+++ b/src/gradNonLinearForm.cpp
@@ -37,7 +37,7 @@ GradNonLinearForm::GradNonLinearForm(ParFiniteElementSpace *_vfes, IntegrationRu
                                      const int _num_equation)
     : ParNonlinearForm(_vfes), vfes(_vfes), intRules(_intRules), dim(_dim), num_equation(_num_equation) {}
 
-void GradNonLinearForm::Mult(const ParGridFunction *Up, Vector &y) {
+void GradNonLinearForm::Apply(const ParGridFunction *Up, Vector &y) {
   Vector x;
   const double *data = Up->GetData();
 

--- a/src/gradNonLinearForm.hpp
+++ b/src/gradNonLinearForm.hpp
@@ -50,7 +50,7 @@ class GradNonLinearForm : public ParNonlinearForm {
  public:
   GradNonLinearForm(ParFiniteElementSpace *f, IntegrationRules *intRules, const int dim, const int num_equation);
 
-  void Mult(const ParGridFunction *Up, Vector &y);
+  void Apply(const ParGridFunction *Up, Vector &y);
 };
 
 #endif  // GRADNONLINEARFORM_HPP_

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -44,6 +44,7 @@ Gradients::Gradients(ParFiniteElementSpace *_vfes, ParFiniteElementSpace *_gradU
       gradUpfes(_gradUpfes),
       dim_(_dim),
       num_equation_(_num_equation),
+      nvel_(nvel),
       Up(_Up),
       gradUp(_gradUp),
       mixture(_mixture),
@@ -55,8 +56,7 @@ Gradients::Gradients(ParFiniteElementSpace *_vfes, ParFiniteElementSpace *_gradU
       invMArray(_invMArray),
       posDofInvM(_posDofInvM),
       maxIntPoints_(_maxIntPoints),
-      maxDofs_(_maxDofs),
-      nvel_(nvel) {
+      maxDofs_(_maxDofs) {
   const elementIndexingData &elem_data = gpu_precomputed_data_.element_indexing_data;
   h_num_elems_of_type = elem_data.num_elems_of_type.HostRead();
 

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -732,7 +732,7 @@ void Gradients::interpGradBdryFace_gpu() {
 
   const int *d_rbf_to_abf = bdry_face_data.rbf_to_abf.Read();
 
-  const double *d_xyz = bdry_face_data.xyz.Read();
+  // const double *d_xyz = bdry_face_data.xyz.Read();
 
   double *d_dun = dun_bdry_face.Write();
 
@@ -826,7 +826,6 @@ void Gradients::integrationGradBdryFace_gpu() {
   const double *d_shape = bdry_face_data.shape.Read();
   const int *d_face_num_quad = bdry_face_data.num_quad.Read();
   const int *d_elem_to_face = bdry_face_data.elements_to_faces.Read();
-  const double *d_xyz = bdry_face_data.xyz.Read();
 
   const double *d_dun = dun_bdry_face.Read();
 
@@ -838,8 +837,9 @@ void Gradients::integrationGradBdryFace_gpu() {
 
   const int nbelem = bdry_face_data.elements_to_faces.Size() / 7;
 
-  const boundaryCategory *d_bc_cat = bdry_face_data.bc_category.Read();
-  const bool *d_bc_use = bdry_face_data.use_bc_in_grad.Read();
+  // const double *d_xyz = bdry_face_data.xyz.Read();
+  // const boundaryCategory *d_bc_cat = bdry_face_data.bc_category.Read();
+  // const bool *d_bc_use = bdry_face_data.use_bc_in_grad.Read();
 
   MFEM_FORALL(el, nbelem, {
     const int elind = d_elem_to_face[0 + el * 7];

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -193,7 +193,7 @@ void Gradients::computeGradients() {
   }
 
   // Calc boundary contribution
-  gradUp_A->Mult(Up, faceContrib);
+  gradUp_A->Apply(Up, faceContrib);
 
   // Add contributions and multiply by invers mass matrix
   for (int el = 0; el < vfes->GetNE(); el++) {

--- a/src/lte_mixture.cpp
+++ b/src/lte_mixture.cpp
@@ -397,7 +397,10 @@ MFEM_HOST_DEVICE double LteMixture::ComputeMaxCharSpeed(const double *state) {
 }
 
 // only used in non-reflecting BCs... don't implement for now
-double LteMixture::ComputePressureDerivative(const Vector &dUp_dx, const Vector &Uin, bool primitive) { assert(false); }
+double LteMixture::ComputePressureDerivative(const Vector &dUp_dx, const Vector &Uin, bool primitive) {
+  assert(false);
+  return 0.0;
+}
 
 /// Check if the density, temperature, and pressure are positive
 bool LteMixture::StateIsPhysical(const Vector &state) {

--- a/src/lte_mixture.hpp
+++ b/src/lte_mixture.hpp
@@ -163,6 +163,11 @@ class LteMixture : public GasMixture {
     mfem_error("computeSheathBdrFlux not implemented");
   }
 
+  MFEM_HOST_DEVICE virtual void computeSheathBdrFlux(const double *state, BoundaryViscousFluxData &bcFlux) {
+    printf("ERROR: computeSheathBdrFlux is not supposed to be executed for LteMixture!");
+    return;
+  }
+
   virtual double computeElectronEnergy(const double n_e, const double T_e) {
     mfem_error("computeElectronEnergy not implemented");
     return 0;

--- a/src/lte_transport_properties.hpp
+++ b/src/lte_transport_properties.hpp
@@ -81,6 +81,7 @@ class LteTransport : public MolecularTransport {
                                                         double *speciesTransport, double *diffusionVelocity,
                                                         double *n_sp) final;
 
+  using MolecularTransport::GetViscosities;
   MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) final;
 };
 

--- a/src/mixing_length_transport.cpp
+++ b/src/mixing_length_transport.cpp
@@ -65,11 +65,9 @@ MFEM_HOST_DEVICE void MixingLengthTransport::ComputeFluxTransportProperties(cons
                                                                             double *diffusionVelocity) {
   molecular_transport_->ComputeFluxMolecularTransport(state, gradUp, Efield, transportBuffer, diffusionVelocity);
 
-  const double cp_over_Pr =
-      transportBuffer[FluxTrns::HEAVY_THERMAL_CONDUCTIVITY] / transportBuffer[FluxTrns::VISCOSITY];
-
   const double kappa = transportBuffer[FluxTrns::HEAVY_THERMAL_CONDUCTIVITY];
   const double mu = transportBuffer[FluxTrns::VISCOSITY];
+  const double cp_over_Pr = kappa / mu;
 
   // Add mixing length model results to computed molecular transport
   double primitiveState[gpudata::MAXEQUATIONS];

--- a/src/mixing_length_transport.cpp
+++ b/src/mixing_length_transport.cpp
@@ -76,17 +76,17 @@ MFEM_HOST_DEVICE void MixingLengthTransport::ComputeFluxTransportProperties(cons
   const double rho = state[0];
   // const double Th = primitiveState[nvel_ + 1];
 
-  // Compute divergence
-  double divV = 0.;
-  for (int i = 0; i < dim; i++) {
-    divV += gradUp[(1 + i) + i * num_equation];
-  }
+  // // Compute divergence
+  // double divV = 0.;
+  // for (int i = 0; i < dim; i++) {
+  //   divV += gradUp[(1 + i) + i * num_equation];
+  // }
 
   // If axisymmetric
   double ur = 0;
   if (nvel_ != dim) {
     ur = primitiveState[1];
-    if (radius > 0) divV += ur / radius;
+    // if (radius > 0) divV += ur / radius;
   }
 
   // eddy viscosity

--- a/src/mixing_length_transport.hpp
+++ b/src/mixing_length_transport.hpp
@@ -62,16 +62,15 @@ class MixingLengthTransport : public TransportProperties {
   void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
                                       double radius, double distance, Vector &transportBuffer,
                                       DenseMatrix &diffusionVelocity) final;
-  MFEM_HOST_DEVICE void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                       const double *Efield, double radius, double distance,
-                                                       double *transportBuffer, double *diffusionVelocity) final;
+  MFEM_HOST_DEVICE void ComputeFluxTransportProperties(const double *state, const double *gradUp, const double *Efield,
+                                                       double radius, double distance, double *transportBuffer,
+                                                       double *diffusionVelocity) final;
   void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
                                         const Vector &Efield, double distance, Vector &globalTransport,
                                         DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
                                         Vector &n_sp) final;
-  MFEM_HOST_DEVICE void ComputeSourceTransportProperties(const double *state, const double *Up,
-                                                         const double *gradUp, const double *Efield,
-                                                         double distance, double *globalTransport,
+  MFEM_HOST_DEVICE void ComputeSourceTransportProperties(const double *state, const double *Up, const double *gradUp,
+                                                         const double *Efield, double distance, double *globalTransport,
                                                          double *speciesTransport, double *diffusionVelocity,
                                                          double *n_sp) final;
 
@@ -102,7 +101,7 @@ MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double 
   double ur = 0;
   if (nvel_ != dim) {
     ur = primitive[1];
-  //   if (radius > 0) divV += ur / radius;
+    //   if (radius > 0) divV += ur / radius;
   }
 
   // eddy viscosity

--- a/src/mixing_length_transport.hpp
+++ b/src/mixing_length_transport.hpp
@@ -59,25 +59,25 @@ class MixingLengthTransport : public TransportProperties {
 
   MFEM_HOST_DEVICE virtual ~MixingLengthTransport() { delete molecular_transport_; }
 
-  virtual void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
-                                              double radius, double distance, Vector &transportBuffer,
-                                              DenseMatrix &diffusionVelocity);
-  MFEM_HOST_DEVICE virtual void ComputeFluxTransportProperties(const double *state, const double *gradUp,
-                                                               const double *Efield, double radius, double distance,
-                                                               double *transportBuffer, double *diffusionVelocity);
-  virtual void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
-                                                const Vector &Efield, double distance, Vector &globalTransport,
-                                                DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
-                                                Vector &n_sp);
-  MFEM_HOST_DEVICE virtual void ComputeSourceTransportProperties(const double *state, const double *Up,
-                                                                 const double *gradUp, const double *Efield,
-                                                                 double distance, double *globalTransport,
-                                                                 double *speciesTransport, double *diffusionVelocity,
-                                                                 double *n_sp);
+  void ComputeFluxTransportProperties(const Vector &state, const DenseMatrix &gradUp, const Vector &Efield,
+                                      double radius, double distance, Vector &transportBuffer,
+                                      DenseMatrix &diffusionVelocity) final;
+  MFEM_HOST_DEVICE void ComputeFluxTransportProperties(const double *state, const double *gradUp,
+                                                       const double *Efield, double radius, double distance,
+                                                       double *transportBuffer, double *diffusionVelocity) final;
+  void ComputeSourceTransportProperties(const Vector &state, const Vector &Up, const DenseMatrix &gradUp,
+                                        const Vector &Efield, double distance, Vector &globalTransport,
+                                        DenseMatrix &speciesTransport, DenseMatrix &diffusionVelocity,
+                                        Vector &n_sp) final;
+  MFEM_HOST_DEVICE void ComputeSourceTransportProperties(const double *state, const double *Up,
+                                                         const double *gradUp, const double *Efield,
+                                                         double distance, double *globalTransport,
+                                                         double *speciesTransport, double *diffusionVelocity,
+                                                         double *n_sp) final;
 
-  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) final;
   MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, const double *gradUp,
-                                       double radius, double distance, double *visc) override;
+                                       double radius, double distance, double *visc) final;
 };
 
 MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double *conserved, const double *primitive,
@@ -92,17 +92,17 @@ MFEM_HOST_DEVICE inline void MixingLengthTransport::GetViscosities(const double 
 
   const double rho = conserved[0];
 
-  // Compute divergence
-  double divV = 0.;
-  for (int i = 0; i < dim; i++) {
-    divV += gradUp[(1 + i) + i * num_equation];
-  }
+  // // Compute divergence
+  // double divV = 0.;
+  // for (int i = 0; i < dim; i++) {
+  //   divV += gradUp[(1 + i) + i * num_equation];
+  // }
 
   // If axisymmetric
   double ur = 0;
   if (nvel_ != dim) {
     ur = primitive[1];
-    if (radius > 0) divV += ur / radius;
+  //   if (radius > 0) divV += ur / radius;
   }
 
   // eddy viscosity

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -41,8 +41,8 @@ OutletBC::OutletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_
                    const Array<double> &_inputData, const int &_maxIntPoints, const int &_maxDofs, bool axisym)
     : BoundaryCondition(_rsolver, _mixture, _eqSystem, _vfes, _intRules, _dt, _dim, _num_equation, _patchNumber,
                         _refLength, axisym),
-      d_mixture_(d_mixture),
       groupsMPI(_groupsMPI),
+      d_mixture_(d_mixture),
       outletType_(_bcType),
       inputState(_inputData),
       maxIntPoints_(_maxIntPoints),

--- a/src/pybindings.cpp
+++ b/src/pybindings.cpp
@@ -38,10 +38,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#ifdef HAVE_MPI4PY
-#include <mpi4py/mpi4py.h>
-#endif
-
 namespace py = pybind11;
 
 namespace tps_wrappers {

--- a/src/quasimagnetostatic.cpp
+++ b/src/quasimagnetostatic.cpp
@@ -622,8 +622,8 @@ void QuasiMagnetostaticSolver3D::InterpolateToYAxis() const {
     H5Fclose(file);
   }
 
-  delete Byloc;
-  delete By;
+  delete[] Byloc;
+  delete[] By;
 }
 
 void QuasiMagnetostaticSolver3D::setStoreE(bool storeE) {

--- a/src/quasimagnetostatic.hpp
+++ b/src/quasimagnetostatic.hpp
@@ -180,7 +180,7 @@ class QuasiMagnetostaticSolver3D : public QuasiMagnetostaticSolverBase {
    *  Build the source current function and do a divergence free
    *  projection to form the RHS
    */
-  void InitializeCurrent();
+  void InitializeCurrent() override;
 
   void parseSolverOptions() override;
 
@@ -196,7 +196,7 @@ class QuasiMagnetostaticSolver3D : public QuasiMagnetostaticSolverBase {
   /** Does nothing */
   void solveEnd() override;
 
-  mfem::ParFiniteElementSpace *getFESpace() { return pspace_; }
+  mfem::ParFiniteElementSpace *getFESpace() override { return pspace_; }
   void setStoreE(bool storeE) override;
 
   double elementJouleHeating(const FiniteElement &el, ElementTransformation &Tr, const Vector &elfun) override;
@@ -244,7 +244,7 @@ class QuasiMagnetostaticSolverAxiSym : public QuasiMagnetostaticSolverBase {  //
    *
    *  Build the source current function
    */
-  void InitializeCurrent();
+  void InitializeCurrent() override;
 
   void parseSolverOptions() override;
 
@@ -260,7 +260,7 @@ class QuasiMagnetostaticSolverAxiSym : public QuasiMagnetostaticSolverBase {  //
   /** Does nothing */
   void solveEnd() override;
 
-  mfem::ParFiniteElementSpace *getFESpace() { return Atheta_space_; }
+  mfem::ParFiniteElementSpace *getFESpace() override { return Atheta_space_; }
   void setStoreE(bool storeE) override;
 
   double elementJouleHeating(const FiniteElement &el, ElementTransformation &Tr, const Vector &elfun) override;

--- a/src/rhs_operator.cpp
+++ b/src/rhs_operator.cpp
@@ -558,7 +558,6 @@ void RHSoperator::GetFlux_gpu(const Vector &x, DenseTensor &flux) const {
   const int dim = dim_;
   const int num_equation = num_equation_;
 
-  const bool axisymmetric = config_.isAxisymmetric();
   const double *d_coord = coordsDof->Read();
   const double *d_gradUp = gradUp->Read();
 

--- a/src/rhs_operator.hpp
+++ b/src/rhs_operator.hpp
@@ -115,7 +115,6 @@ class RHSoperator : public TimeDependentOperator {
   ParGridFunction *Up;
   ParGridFunction *plasma_conductivity_;
   ParGridFunction *joule_heating_;
-  ParGridFunction *distance_;
 
   // gradients of primitives and associated forms&FE space
   ParGridFunction *gradUp;
@@ -124,6 +123,7 @@ class RHSoperator : public TimeDependentOperator {
   GradNonLinearForm *gradUp_A;
 
   BCintegrator *bcIntegrator;
+  ParGridFunction *distance_;
 
   Array<ForcingTerms *> forcing;
   int masaForcingIndex_ = -1;

--- a/src/riemann_solver.cpp
+++ b/src/riemann_solver.cpp
@@ -90,7 +90,6 @@ MFEM_HOST_DEVICE void RiemannSolver::Eval_LF(const double *state1, const double 
                                              double *flux) const {
   const int dim = mixture->GetDimension();
 
-  double Pe = 0.0;
   const double maxE1 = mixture->ComputeMaxCharSpeed(state1);
   const double maxE2 = mixture->ComputeMaxCharSpeed(state2);
 

--- a/src/transport_properties.hpp
+++ b/src/transport_properties.hpp
@@ -210,7 +210,10 @@ class MolecularTransport : public TransportProperties {
                                     n_sp);
   }
 
-  using TransportProperties::GetViscosities;
+  MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, double *visc) override {
+    printf("MolecularTransport::GetViscosities is not implemented!\n");
+  }
+
   MFEM_HOST_DEVICE void GetViscosities(const double *conserved, const double *primitive, const double *gradUp,
                                        double radius, double distance, double *visc) final {
     GetViscosities(conserved, primitive, visc);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -465,9 +465,9 @@ void evaluateDistanceSerial(mfem::Mesh &mesh, const mfem::Array<int> &wall_patch
 
           // Update reference coordinates
           Vector xi(ref, rdim);
-          ip.Get(xi.GetData(), rdim);
+          ip.Get(xi.HostWrite(), rdim);
           xi += dxi;
-          ip.Set(xi.GetData(), rdim);
+          ip.Set(xi.HostRead(), rdim);
 
           // Update dx and residual
           Tr->SetIntPoint(&ip);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -304,7 +304,7 @@ bool h5ReadTable(const std::string &fileName, const std::string &datasetName, mf
   datasetID = H5Dopen2(file, datasetName.c_str(), H5P_DEFAULT);
   if (datasetID < 0) return success;
   dataspace = H5Dget_space(datasetID);
-  const int ndims = H5Sget_simple_extent_ndims(dataspace);
+  // const int ndims = H5Sget_simple_extent_ndims(dataspace);
   hsize_t dims[gpudata::MAXTABLEDIM];
   // int dummy = H5Sget_simple_extent_dims(dataspace,dims,NULL);
   H5Sget_simple_extent_dims(dataspace, dims, NULL);
@@ -353,13 +353,13 @@ bool h5ReadBcastMultiColumnTable(const std::string &fileName, const std::string 
   MPI_Bcast(&nrow, 1, MPI_INT, 0, TPSCommWorld);
   MPI_Bcast(&ncol, 1, MPI_INT, 0, TPSCommWorld);
   assert(nrow > 0);
-  assert(ncol == tables.size() + 1);
+  assert(ncol == (int)tables.size() + 1);
 
   if (!rank0) output.SetSize(nrow, ncol);
   double *h_table = output.HostReadWrite();
   MPI_Bcast(h_table, nrow * ncol, MPI_DOUBLE, 0, TPSCommWorld);
 
-  for (int icol = 0; icol < tables.size(); icol++) {
+  for (size_t icol = 0; icol < tables.size(); icol++) {
     tables[icol].Ndata = nrow;
     tables[icol].xdata = output.HostRead();
     tables[icol].fdata = output.HostRead() + (icol + 1) * nrow;
@@ -465,9 +465,9 @@ void evaluateDistanceSerial(mfem::Mesh &mesh, const mfem::Array<int> &wall_patch
 
           // Update reference coordinates
           Vector xi(ref, rdim);
-          ip.Get(xi, rdim);
+          ip.Get(xi.GetData(), rdim);
           xi += dxi;
-          ip.Set(xi, rdim);
+          ip.Set(xi.GetData(), rdim);
 
           // Update dx and residual
           Tr->SetIntPoint(&ip);

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -43,11 +43,11 @@ WallBC::WallBC(RiemannSolver *_rsolver, GasMixture *_mixture, GasMixture *d_mixt
                         axisym),  // so far walls do not require ref. length. Left at 1
       wallType_(_bcType),
       wallData_(_inputData),
+      useBCinGrad_(useBCinGrad),
       d_mixture_(d_mixture),
       fluxClass(_fluxClass),
       boundary_face_data_(boundary_face_data),
-      maxIntPoints_(_maxIntPoints),
-      useBCinGrad_(useBCinGrad) {
+      maxIntPoints_(_maxIntPoints) {
   // Initialize bc state.
   // bcState_.prim.SetSize(num_equation_);
   // bcState_.primIdxs.SetSize(num_equation_);
@@ -259,6 +259,9 @@ void WallBC::computeBdrPrimitiveStateForGradient(const Vector &primIn, Vector &p
     case VISC_GNRL:
       // TODO(trevilo): fix
       break;
+    default:
+      // If BC is unknown to this function, don't do anything
+      break;
   }
 }
 
@@ -324,7 +327,6 @@ void WallBC::computeSlipWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &g
                                  Vector &bdrFlux) {
   Vector prim(num_equation_);
   mixture->GetPrimitivesFromConservatives(stateIn, prim);
-  double wallT = prim[dim_ + 1];
 
   // stateIn is conserved
   Vector vel(nvel_);

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -87,18 +87,18 @@ class WallBC : public BoundaryCondition {
   WallType getType() { return wallType_; }
 
   void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
-                      double distance, Vector &bdrFlux);
+                      double distance, Vector &bdrFlux) override;
   void computeBdrPrimitiveStateForGradient(const Vector &primIn, Vector &primBC) const override;
 
-  virtual void initBCs();
+  void initBCs() override;
 
-  virtual void updateMean(IntegrationRules *intRules, ParGridFunction *Up) {}
+  void updateMean(IntegrationRules *intRules, ParGridFunction *Up) override {}
 
   // functions for BC integration on GPU
-  virtual void integrationBC(Vector &y,  // output
-                             const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
-                             ParGridFunction *gradUp, const boundaryFaceIntegrationData &boundary_face_data,
-                             const int &maxIntPoints, const int &maxDofs);
+  void integrationBC(Vector &y,  // output
+                     const Vector &x, const elementIndexingData &elem_index_data, ParGridFunction *Up,
+                     ParGridFunction *gradUp, const boundaryFaceIntegrationData &boundary_face_data,
+                     const int &maxIntPoints, const int &maxDofs) override;
 
   void integrateWalls_gpu(Vector &y,  // output
                           const Vector &x, const elementIndexingData &elem_index_data,

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -143,14 +143,12 @@ tps_splitcomm_test_SOURCES  = test_tps_splitcomm.cpp
 tps_splitcomm_test_LDADD    = ../src/libtps.la
 tps_splitcomm_test_LDADD   += $(HDF5_LIBS)
 tps_splitcomm_test_LDADD   += $(GRVY_LIBS)
-test_splitcomm_test_LDFLAGS = $(CUDA_LDFLAGS)
 
 check_PROGRAMS += tps_interface_test
 tps_interface_test_SOURCES  = test_tps_interface.cpp
 tps_interface_test_LDADD    = ../src/libtps.la
 tps_interface_test_LDADD   += $(HDF5_LIBS)
 tps_interface_test_LDADD   += $(GRVY_LIBS)
-test_interface_test_LDFLAGS = $(CUDA_LDFLAGS)
 
 if !GPU_ENABLED
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -28,7 +28,7 @@ EXTRA_DIST      = tap-driver.sh test_tps_splitcomm.py soln_differ inputs meshes 
 		  ref_solns/noSGM1K/*.h5 ref_solns/smag1K_1/*.h5 ref_solns/sigma1K_1/*.h5 \
 	          ref_solns/plate150K/*.h5 ref_solns/plate150K_1step/*.h5 \
 		  vpath.sh die.sh cyl3d.gpu.test cyl3d.mflow.gpu.test wedge.gpu.test \
-	          averages.gpu.test cyl3d.test cyl3d.mflow.test cyl3d.dtconst.test \
+	          averages.gpu.test cyl3d.test cyl3d.gpu.python.test cyl3d.mflow.test cyl3d.dtconst.test \
 		  die.test averages.test wedge.test cyl3d.interp.test qms.rings.test qms.axisym.test \
 		  sponge_zone.test annulus.test pipe.test valgrind.test valgrind.suppressions \
 		  mms.euler.test reaction.test perfect_gas.test collision_integrals.test \

--- a/test/inputs/interp-em-test.ini
+++ b/test/inputs/interp-em-test.ini
@@ -9,7 +9,7 @@ type = cycle-avg-joule-coupled  # options are (flow, em, em-axi, toy-coupled or 
 [cycle-avg-joule-coupled]
 max-iters = 900000
 solve-em-every-n = 900000
-axisymmetric = False
+axisymmetric = True
 input-power = -1.
 initial-input-power = -1.
 

--- a/test/test_argon_minimal.cpp
+++ b/test/test_argon_minimal.cpp
@@ -77,6 +77,10 @@ int main (int argc, char *argv[])
     case ARGON_MIXTURE:
       transport = new ArgonMixtureTransport(mixture, srcConfig);
       break;
+    default:
+      printf("test_argon_minimal only supports argon transport models.\n"); fflush(stdout);
+      exit(ERROR);
+      break;
   }
   //ArgonMinimalTransport *transport = new ArgonMinimalTransport(mixture, srcConfig);
   int numSpecies = mixture->GetNumSpecies();
@@ -166,7 +170,7 @@ int main (int argc, char *argv[])
     transport->ComputeFluxTransportProperties(conservedState, gradUp, Efield, -1, -1, transportBuffer, diffusionVelocity);
 
     double visc, bulkVisc, visc_vec[2];
-    transport->GetViscosities(conservedState, primitiveState, visc_vec);
+    transport->GetViscosities(conservedState.GetData(), primitiveState.GetData(), visc_vec);
     visc = visc_vec[0];
     bulkVisc = visc_vec[1];
 

--- a/test/test_argon_minimal.cpp
+++ b/test/test_argon_minimal.cpp
@@ -170,7 +170,7 @@ int main (int argc, char *argv[])
     transport->ComputeFluxTransportProperties(conservedState, gradUp, Efield, -1, -1, transportBuffer, diffusionVelocity);
 
     double visc, bulkVisc, visc_vec[2];
-    transport->GetViscosities(conservedState.GetData(), primitiveState.GetData(), visc_vec);
+    transport->GetViscosities(conservedState.HostRead(), primitiveState.HostRead(), visc_vec);
     visc = visc_vec[0];
     bulkVisc = visc_vec[1];
 

--- a/test/test_interp_em.cpp
+++ b/test/test_interp_em.cpp
@@ -123,9 +123,7 @@ int main (int argc, char *argv[])
   std::cout << "tps.getSolverType() = " << tps.getSolverType() << std::endl;
   assert(tps.getSolverType() == "cycle-avg-joule-coupled");
 
-  int max_out = 1;
-  CycleAvgJouleCoupling *solver = new CycleAvgJouleCoupling(tps.getInputFilename(), &tps,
-                                                            max_out, true);
+  CycleAvgJouleCoupling *solver = new CycleAvgJouleCoupling(tps.getInputFilename(), &tps);
 
   solver->parseSolverOptions();
   solver->initialize();

--- a/test/test_perfect_mixture.cpp
+++ b/test/test_perfect_mixture.cpp
@@ -997,7 +997,7 @@ int main (int argc, char *argv[])
     }
 
     double T_h, T_e;
-    mixture->computeTemperaturesBase(conservedState, &n_sp[0], n_sp[numSpecies-2], n_sp[numSpecies-1], T_h, T_e);
+    mixture->computeTemperaturesBase(conservedState.GetData(), &n_sp[0], n_sp[numSpecies-2], n_sp[numSpecies-1], T_h, T_e);
     if (abs( (T_h - testPrimitives[dim + 1]) / testPrimitives[dim + 1] ) > scalarErrorThreshold) {
       std::cout << T_h << " != " << testPrimitives[dim + 1] << std::endl;
       grvy_printf(GRVY_ERROR, "\n computeTemperaturesBase does not compute heavy-species temperature properly.");
@@ -1373,7 +1373,7 @@ int main (int argc, char *argv[])
     }
 
     double T_h, T_e;
-    mixture->computeTemperaturesBase(conservedState, &n_sp[0], n_sp[numSpecies-2], n_sp[numSpecies-1], T_h, T_e);
+    mixture->computeTemperaturesBase(conservedState.GetData(), &n_sp[0], n_sp[numSpecies-2], n_sp[numSpecies-1], T_h, T_e);
     if (abs( (T_h - testPrimitives[dim + 1]) / testPrimitives[dim + 1] ) > scalarErrorThreshold) {
       std::cout << T_h << " != " << testPrimitives[dim + 1] << std::endl;
       grvy_printf(GRVY_ERROR, "\n computeTemperaturesBase does not compute heavy-species temperature properly.");

--- a/test/test_perfect_mixture.cpp
+++ b/test/test_perfect_mixture.cpp
@@ -997,7 +997,7 @@ int main (int argc, char *argv[])
     }
 
     double T_h, T_e;
-    mixture->computeTemperaturesBase(conservedState.GetData(), &n_sp[0], n_sp[numSpecies-2], n_sp[numSpecies-1], T_h, T_e);
+    mixture->computeTemperaturesBase(conservedState.HostRead(), &n_sp[0], n_sp[numSpecies-2], n_sp[numSpecies-1], T_h, T_e);
     if (abs( (T_h - testPrimitives[dim + 1]) / testPrimitives[dim + 1] ) > scalarErrorThreshold) {
       std::cout << T_h << " != " << testPrimitives[dim + 1] << std::endl;
       grvy_printf(GRVY_ERROR, "\n computeTemperaturesBase does not compute heavy-species temperature properly.");
@@ -1373,7 +1373,7 @@ int main (int argc, char *argv[])
     }
 
     double T_h, T_e;
-    mixture->computeTemperaturesBase(conservedState.GetData(), &n_sp[0], n_sp[numSpecies-2], n_sp[numSpecies-1], T_h, T_e);
+    mixture->computeTemperaturesBase(conservedState.HostRead(), &n_sp[0], n_sp[numSpecies-2], n_sp[numSpecies-1], T_h, T_e);
     if (abs( (T_h - testPrimitives[dim + 1]) / testPrimitives[dim + 1] ) > scalarErrorThreshold) {
       std::cout << T_h << " != " << testPrimitives[dim + 1] << std::endl;
       grvy_printf(GRVY_ERROR, "\n computeTemperaturesBase does not compute heavy-species temperature properly.");

--- a/utils/pfield_interpolate.cpp
+++ b/utils/pfield_interpolate.cpp
@@ -78,8 +78,7 @@ int main (int argc, char *argv[])
 
   if (mesh_1->GetNodes() == NULL) { mesh_1->SetCurvature(1); }
   if (mesh_2->GetNodes() == NULL) { mesh_2->SetCurvature(1); }
-  const int mesh_poly_deg =
-    mesh_2->GetNodes()->FESpace()->GetElementOrder(0);
+
   cout << "Source mesh curvature: "
        << mesh_1->GetNodes()->OwnFEC()->Name() << endl
        << "Target mesh curvature: "
@@ -87,11 +86,9 @@ int main (int argc, char *argv[])
 
   // 2) Set up source field
   FiniteElementCollection *src_fec = NULL;
-  ParFiniteElementSpace *src_fes = NULL;
   ParGridFunction *func_source = NULL;
 
   src_fec = srcField.GetFEC();
-  src_fes = srcField.GetFESpace();
   func_source = srcField.GetSolutionGF();
 
   // 3) Some checks


### PR DESCRIPTION
We have accumulated many compiler warnings.  This PR fixes these, at least those generated in our automated CI environments.  This PR also fixes some warnings occuring at `./bootstrap` time.

In all the CI environments, we have added appropriate flags (e.g., `-Werror` for `gcc`) to force compiler warnings to be treated as errors.  This should keep the code, at least changes merged to `main`, clear of warnings going forward.