### PR TITLE
Reacting bugfixes

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -370,11 +370,12 @@ void M2ulPhyS::initVariables() {
   // If requested, evaluate the distance function (i.e., the distance to the nearest no-slip wall)
   distance_ = NULL;
   GridFunction *serial_distance = NULL;
+  FiniteElementSpace *serial_fes = NULL;
+  DG_FECollection *tmp_fec = NULL;
   if (config.compute_distance) {
     order = config.GetSolutionOrder();
     dim = serial_mesh->Dimension();
     basisType = config.GetBasisType();
-    DG_FECollection *tmp_fec = NULL;
     if (basisType == 0) {
       tmp_fec = new DG_FECollection(order, dim, BasisType::GaussLegendre);
     } else if (basisType == 1) {
@@ -382,7 +383,7 @@ void M2ulPhyS::initVariables() {
     }
 
     // Serial FE space for scalar variable
-    FiniteElementSpace *serial_fes = new FiniteElementSpace(serial_mesh, tmp_fec);
+    serial_fes = new FiniteElementSpace(serial_mesh, tmp_fec);
 
     // Serial grid function for scalar variable
     serial_distance = new GridFunction(serial_fes);
@@ -405,6 +406,7 @@ void M2ulPhyS::initVariables() {
 
     // Evaluate the distance function
     evaluateDistanceSerial(*serial_mesh, wall_patch_list, coordinates, *serial_distance);
+    delete tmp_dfes;
   }
 
   // Instantiate parallel mesh
@@ -419,6 +421,8 @@ void M2ulPhyS::initVariables() {
     }
     // Done with serial_distance
     delete serial_distance;
+    delete serial_fes;
+    delete tmp_fec;
 
     distance_->ParFESpace()->ExchangeFaceNbrData();
     distance_->ExchangeFaceNbrData();

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -750,7 +750,7 @@ void M2ulPhyS::initVariables() {
 
   xmax = bb_max[0];
   ymax = bb_max[1];
-  (dim == 3) ? zmax = bb_max[2] : zmin = 0.0;
+  (dim == 3) ? zmax = bb_max[2] : zmax = 0.0;
 
   // estimate initial dt
   Up->ExchangeFaceNbrData();

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -3395,11 +3395,15 @@ void M2ulPhyS::parseReactionInputs() {
         reactEnergy += react(sp) * config.gasParams(sp, FORMATION_ENERGY);
         prodEnergy += product(sp) * config.gasParams(sp, FORMATION_ENERGY);
       }
-      // This may be too strict..
-      if (reactEnergy + config.reactionEnergies[r] != prodEnergy) {
+
+      double max_e = max(reactEnergy, prodEnergy);
+      const double delta = abs(reactEnergy + config.reactionEnergies[r] - prodEnergy);
+      const double rel_delta = delta / max_e;
+      if (rel_delta > 5e-16) {
         grvy_printf(GRVY_ERROR, "Reaction %d does not conserve energy.\n", r);
         grvy_printf(GRVY_ERROR, "%.8E + %.8E = %.8E =/= %.8E\n", reactEnergy, config.reactionEnergies[r],
                     reactEnergy + config.reactionEnergies[r], prodEnergy);
+        grvy_printf(GRVY_ERROR, "Difference = %.8E\n", delta);
         exit(-1);
       }
     }

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -3267,6 +3267,7 @@ void M2ulPhyS::parseTransportInputs() {
 
 void M2ulPhyS::parseReactionInputs() {
   tpsP->getInput("reactions/number_of_reactions", config.numReactions, 0);
+  tpsP->getInput("reactions/minimum_chemistry_temperature", config.chemistryInput.minimumTemperature, 0.0);
   if (config.numReactions > 0) {
     assert((config.workFluid != DRY_AIR) && (config.numSpecies > 1));
     config.reactionEnergies.SetSize(config.numReactions);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1918,7 +1918,10 @@ void M2ulPhyS::projectInitialSolution() {
 
     restart_files_hdf5("read");
 
-    if (config.restartFromLTE) initilizeSpeciesFromLTE();
+    if (config.restartFromLTE) {
+      initilizeSpeciesFromLTE();
+      Check_Undershoot();
+    }
 
     paraviewColl->SetCycle(iter);
     paraviewColl->SetTime(time);

--- a/src/chemistry.cpp
+++ b/src/chemistry.cpp
@@ -46,6 +46,7 @@ MFEM_HOST_DEVICE Chemistry::Chemistry(GasMixture *mixture, const ChemistryInput 
   dim_ = mixture->GetDimension();
 
   model_ = inputs.model;
+  min_temperature_ = inputs.minimumTemperature;
 
   electronIndex_ = inputs.electronIndex;
 
@@ -107,7 +108,11 @@ MFEM_HOST_DEVICE Chemistry::~Chemistry() {
 
 void Chemistry::computeForwardRateCoeffs(const double &T_h, const double &T_e, Vector &kfwd) {
   kfwd.SetSize(numReactions_);
-  computeForwardRateCoeffs(T_h, T_e, &kfwd[0]);
+
+  const double Thlim = max(T_h, min_temperature_);
+  const double Telim = max(T_e, min_temperature_);
+
+  computeForwardRateCoeffs(Thlim, Telim, &kfwd[0]);
   // kfwd = 0.0;
   //
   // for (int r = 0; r < numReactions_; r++) {
@@ -122,9 +127,12 @@ MFEM_HOST_DEVICE void Chemistry::computeForwardRateCoeffs(const double &T_h, con
   // kfwd.SetSize(numReactions_);
   for (int r = 0; r < numReactions_; r++) kfwd[r] = 0.0;
 
+  const double Thlim = max(T_h, min_temperature_);
+  const double Telim = max(T_e, min_temperature_);
+
   for (int r = 0; r < numReactions_; r++) {
     bool isElectronInvolved = isElectronInvolvedAt(r);
-    kfwd[r] = reactions_[r]->computeRateCoefficient(T_h, T_e, isElectronInvolved);
+    kfwd[r] = reactions_[r]->computeRateCoefficient(Thlim, Telim, isElectronInvolved);
   }
 
   return;
@@ -133,7 +141,11 @@ MFEM_HOST_DEVICE void Chemistry::computeForwardRateCoeffs(const double &T_h, con
 // NOTE: if not detailedBalance, equilibrium constant is returned as zero, though it cannot be used.
 void Chemistry::computeEquilibriumConstants(const double &T_h, const double &T_e, Vector &kC) {
   kC.SetSize(numReactions_);
-  computeEquilibriumConstants(T_h, T_e, &kC[0]);
+
+  const double Thlim = max(T_h, min_temperature_);
+  const double Telim = max(T_e, min_temperature_);
+
+  computeEquilibriumConstants(Thlim, Telim, &kC[0]);
   // kC = 0.0;
   //
   // for (int r = 0; r < numReactions_; r++) {
@@ -151,8 +163,11 @@ void Chemistry::computeEquilibriumConstants(const double &T_h, const double &T_e
 MFEM_HOST_DEVICE void Chemistry::computeEquilibriumConstants(const double &T_h, const double &T_e, double *kC) {
   for (int r = 0; r < numReactions_; r++) kC[r] = 0.0;
 
+  const double Thlim = max(T_h, min_temperature_);
+  const double Telim = max(T_e, min_temperature_);
+
   for (int r = 0; r < numReactions_; r++) {
-    double temp = (isElectronInvolvedAt(r)) ? T_e : T_h;
+    double temp = (isElectronInvolvedAt(r)) ? Telim : Thlim;
     if (detailedBalance_[r]) {
       kC[r] = equilibriumConstantParams_[0 + r * gpudata::MAXCHEMPARAMS] *
               pow(temp, equilibriumConstantParams_[1 + r * gpudata::MAXCHEMPARAMS]) *

--- a/src/chemistry.hpp
+++ b/src/chemistry.hpp
@@ -87,6 +87,8 @@ class Chemistry {
   // Kevin: currently, I doubt we need mixture class here. but left it just in case.
   GasMixture *mixture_ = NULL;
 
+  double min_temperature_;
+
  public:
   Chemistry(GasMixture *mixture, RunConfiguration &config);
   MFEM_HOST_DEVICE Chemistry(GasMixture *mixture, const ChemistryInput &inputs);

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -632,8 +632,14 @@ struct ChemistryInput {
   int numReactions;
   double reactionEnergies[gpudata::MAXREACTIONS];
   bool detailedBalance[gpudata::MAXREACTIONS];
-  double reactantStoich[gpudata::MAXSPECIES * gpudata::MAXREACTIONS];
-  double productStoich[gpudata::MAXSPECIES * gpudata::MAXREACTIONS];
+  // NOTE(trevilo): reactantStoich and productStoich used to be
+  // double.  Changed to short int to conserve space to satisfy cuda
+  // parameter space limit, which was breached after increasing
+  // MAXREACTIONS.  Causes no issue now, since our stoichiometric
+  // coefficients are alwas small integers, but if ever need more
+  // generality for some reason, then it will have to be implemented.
+  short int reactantStoich[gpudata::MAXSPECIES * gpudata::MAXREACTIONS];
+  short int productStoich[gpudata::MAXSPECIES * gpudata::MAXREACTIONS];
   ReactionModel reactionModels[gpudata::MAXREACTIONS];
   double equilibriumConstantParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
   ReactionInput reactionInputs[gpudata::MAXREACTIONS];

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -638,8 +638,8 @@ struct ChemistryInput {
   // MAXREACTIONS.  Causes no issue now, since our stoichiometric
   // coefficients are alwas small integers, but if ever need more
   // generality for some reason, then it will have to be implemented.
-  short int reactantStoich[gpudata::MAXSPECIES * gpudata::MAXREACTIONS];
-  short int productStoich[gpudata::MAXSPECIES * gpudata::MAXREACTIONS];
+  int16_t reactantStoich[gpudata::MAXSPECIES * gpudata::MAXREACTIONS];
+  int16_t productStoich[gpudata::MAXSPECIES * gpudata::MAXREACTIONS];
   ReactionModel reactionModels[gpudata::MAXREACTIONS];
   double equilibriumConstantParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
   ReactionInput reactionInputs[gpudata::MAXREACTIONS];

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -637,6 +637,8 @@ struct ChemistryInput {
   ReactionModel reactionModels[gpudata::MAXREACTIONS];
   double equilibriumConstantParams[gpudata::MAXCHEMPARAMS * gpudata::MAXREACTIONS];
   ReactionInput reactionInputs[gpudata::MAXREACTIONS];
+
+  double minimumTemperature;
 };
 
 struct PostProcessInput {

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -49,7 +49,7 @@ const int MAXEQUATIONS = MAXDIM + 2 + MAXSPECIES;  // momentum + two energies + 
 // NOTE: (presumably from marc) lets make sure we don't have more than 20 eq.
 // NOTE(kevin): with MAXEQUATIONS=20, marvin fails with out-of-memery with 3 MPI process.
 
-const int MAXREACTIONS = 20;
+const int MAXREACTIONS = 34;
 const int MAXCHEMPARAMS = 3;
 
 const int MAXTABLE = 512;

--- a/src/fluxes.cpp
+++ b/src/fluxes.cpp
@@ -237,6 +237,12 @@ MFEM_HOST_DEVICE void Fluxes::ComputeViscousFluxes(const double *state, const do
     visc *= wgt;
     bulkViscosity *= wgt;
     k *= wgt;
+
+    for (int sp = 0; sp < numActiveSpecies; sp++) {
+      for (int d = 0; d < dim; d++) {
+        diffusionVelocity[sp + d * numSpecies] *= wgt;
+      }
+    }
   }
 
   if (twoTemperature) {
@@ -393,6 +399,12 @@ MFEM_HOST_DEVICE void Fluxes::ComputeBdrViscousFluxes(const double *state, const
     visc *= wgt;
     bulkViscosity *= wgt;
     k *= wgt;
+
+    for (int sp = 0; sp < numActiveSpecies; sp++) {
+      for (int d = 0; d < dim; d++) {
+        diffusionVelocity[sp + d * numSpecies] *= wgt;
+      }
+    }
   }
 
   // Primitive viscous fluxes.

--- a/src/forcing_terms.cpp
+++ b/src/forcing_terms.cpp
@@ -499,7 +499,7 @@ SpongeZone::SpongeZone(const int &_dim, const int &_num_equation, const int &_or
       for (int sp = 0; sp < numActiveSpecies_; sp++) {
         // int inputIndex = (*mixtureToInputMap)[sp];
         // store species density into inputState in the order of mixture-sorted index.
-        conserved[dim + 2 + sp] = szData.targetUp[0] * szData.targetUp[5 + sp];
+        conserved[nvel + 2 + sp] = szData.targetUp[0] * szData.targetUp[5 + sp];
       }
     }
 

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -349,9 +349,16 @@ void WallBC::computeSlipWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &g
 
   // dominant direction
   int dir, next_dir, previous_dir;
-  if (abs(unitNorm[0]) >= abs(unitNorm[1]) && abs(unitNorm[0]) >= abs(unitNorm[2])) dir = 0;
-  if (abs(unitNorm[1]) >= abs(unitNorm[0]) && abs(unitNorm[1]) >= abs(unitNorm[2])) dir = 1;
-  if (abs(unitNorm[2]) >= abs(unitNorm[0]) && abs(unitNorm[2]) >= abs(unitNorm[1])) dir = 2;
+  if (dim_ == 3) {
+    if (abs(unitNorm[0]) >= abs(unitNorm[1]) && abs(unitNorm[0]) >= abs(unitNorm[2])) dir = 0;
+    if (abs(unitNorm[1]) >= abs(unitNorm[0]) && abs(unitNorm[1]) >= abs(unitNorm[2])) dir = 1;
+    if (abs(unitNorm[2]) >= abs(unitNorm[0]) && abs(unitNorm[2]) >= abs(unitNorm[1])) dir = 2;
+  } else if (dim_ == 2) {
+    if (abs(unitNorm[0]) >= abs(unitNorm[1])) dir = 0;
+    if (abs(unitNorm[1]) >= abs(unitNorm[0])) dir = 1;
+  } else {
+    assert(false);
+  }
   next_dir = (dir + 1) % (dim_);
   previous_dir = (dir + 2) % (dim_);
 
@@ -365,12 +372,20 @@ void WallBC::computeSlipWallFlux(Vector &normal, Vector &stateIn, DenseMatrix &g
   tangent1 *= 1. / max(sqrt(mod), sml);
 
   // tangent 2
-  tangent2[0] = +(unitNorm[1] * tangent1[2] - unitNorm[2] * tangent1[1]);
-  tangent2[1] = -(unitNorm[0] * tangent1[2] - unitNorm[2] * tangent1[0]);
-  tangent2[2] = +(unitNorm[0] * tangent1[1] - unitNorm[1] * tangent1[0]);
-  mod = 0.;
-  for (int d = 0; d < dim_; d++) mod += tangent2[d] * tangent2[d];
-  tangent2 *= 1. / max(sqrt(mod), sml);
+  if (dim_ == 3) {
+    tangent2[0] = +(unitNorm[1] * tangent1[2] - unitNorm[2] * tangent1[1]);
+    tangent2[1] = -(unitNorm[0] * tangent1[2] - unitNorm[2] * tangent1[0]);
+    tangent2[2] = +(unitNorm[0] * tangent1[1] - unitNorm[1] * tangent1[0]);
+    mod = 0.;
+    for (int d = 0; d < dim_; d++) mod += tangent2[d] * tangent2[d];
+    tangent2 *= 1. / max(sqrt(mod), sml);
+  } else if (dim_ == 2) {
+    // tangent2 is not used in 2d
+    tangent2[0] = 0.0;
+    tangent2[1] = 0.0;
+  } else {
+    assert(false);
+  }
 
   // velocity in wall coordinate system
   Vector nVel(dim_);


### PR DESCRIPTION
This PR includes a few fixes/upgrades for reacting cases.  The major mods are as follows:

1. Fixing errors detected by valgrind, including an error initializing the sponge target soln for the species for axisymmetric cases;
2. Extending the viscosity multiplier sponge to the diffusion velocities;
3. Increasing the maximum number of reactions to support the 6 species, 34 reaction argon mechanism;
4. Adding an input to help avoid pathologically large reaction rates at low temperatures by specifying a minimum T to use in rate calculations.