### PR TITLE
Circuit parameter calculations and EM scaling fixes

### DIFF
--- a/src/cycle_avg_joule_coupling.cpp
+++ b/src/cycle_avg_joule_coupling.cpp
@@ -397,6 +397,13 @@ void CycleAvgJouleCoupling::solveStep() {
         grvy_printf(GRVY_INFO, "The input current amplitude = %.6e\n", 2 * tot_I);
         grvy_printf(GRVY_INFO, "The effective plasma resistance = %.6e\n", Rplasma);
       }
+
+      const double magnetic_energy = qmsa_solver_->magneticEnergy();
+      const double Lplasma = 2 * magnetic_energy / (2 * tot_I * tot_I);
+      if (rank0_) {
+        grvy_printf(GRVY_INFO, "The magnetic field energy = %.6e\n", magnetic_energy);
+        grvy_printf(GRVY_INFO, "The effective plasma inductance = %.6e\n", Lplasma);
+      }
     }
 
     // scale the Joule heating (if we are controlling the power input)

--- a/src/cycle_avg_joule_coupling.cpp
+++ b/src/cycle_avg_joule_coupling.cpp
@@ -385,6 +385,20 @@ void CycleAvgJouleCoupling::solveStep() {
       grvy_printf(GRVY_INFO, "The total input Joule heating = %.6e\n", tot_jh);
     }
 
+    if (qmsa_solver_->evalRplasma()) {
+      const double tot_I = qmsa_solver_->coilCurrent();
+
+      // the effective plasma resistance = < Sjoule > / < I^2 >, where < * > is the cycle average
+      //
+      // the cycle-average of the current squared = 2 * Re(\hat{I})^2,
+      // where \hat{I} is the Fourier coefficient of the driving current
+      const double Rplasma = tot_jh / (2 * tot_I * tot_I);
+      if (rank0_) {
+        grvy_printf(GRVY_INFO, "The input current amplitude = %.6e\n", 2 * tot_I);
+        grvy_printf(GRVY_INFO, "The effective plasma resistance = %.6e\n", Rplasma);
+      }
+    }
+
     // scale the Joule heating (if we are controlling the power input)
     if (input_power_ > 0) {
       const double target_power = initial_input_power_ + (current_iter_ / solve_em_every_n_ + 1) * delta_power;

--- a/src/em_options.hpp
+++ b/src/em_options.hpp
@@ -67,6 +67,8 @@ class ElectromagneticOptions {
 
   mfem::Vector current_axis;
 
+  bool eval_Rplasma;
+
   ElectromagneticOptions() {
     order = 1;
     ref_levels = 0;
@@ -83,6 +85,7 @@ class ElectromagneticOptions {
     current_amplitude = 1.0;
     current_frequency = 1.0;
     mu0 = 1.0;
+    eval_Rplasma = false;
   }
 
   void print(std::ostream &out) {
@@ -104,6 +107,7 @@ class ElectromagneticOptions {
     out << "  current_amplitude = " << current_amplitude << std::endl;
     out << "  current_frequency = " << current_frequency << std::endl;
     out << "  mu0 = " << mu0 << std::endl;
+    out << "  eval_Rplasma = " << eval_Rplasma << std::endl;
     out << std::endl;
   }
 };

--- a/src/quasimagnetostatic.cpp
+++ b/src/quasimagnetostatic.cpp
@@ -876,7 +876,7 @@ void QuasiMagnetostaticSolverAxiSym::InitializeCurrent() {
   Vector J0(pmesh_->attributes.Max());
   J0 = 0.0;
 
-  const double mu0J = em_opts_.mu0 * em_opts_.current_amplitude;
+  const double mu0J = em_opts_.mu0 * em_opts_.current_amplitude * 0.5;
 
   if (em_opts_.bot_only) {
     // only bottom rings
@@ -1035,7 +1035,7 @@ void QuasiMagnetostaticSolverAxiSym::solveStep() {
 
   tmp2 += tmp1;
   tmp2 *= (*plasma_conductivity_);
-  tmp2 *= omega2;
+  tmp2 *= 2.0 * omega2;
 
   *joule_heating_ = tmp2;
 

--- a/src/quasimagnetostatic.hpp
+++ b/src/quasimagnetostatic.hpp
@@ -102,6 +102,13 @@ class QuasiMagnetostaticSolverBase : public TPS::Solver {
   virtual double totalJouleHeating() = 0;
 
   void scaleJouleHeating(const double val) { (*joule_heating_) *= val; }
+
+  virtual double coilCurrent() const {
+    mfem::mfem_error("QuasiMagnetostaticSolverBase::coilCurrent is not implemented.");
+    return 0.0;
+  }
+
+  bool evalRplasma() const { return em_opts_.eval_Rplasma; }
 };
 
 /** Helper class for Joule heating evaluation
@@ -265,6 +272,9 @@ class QuasiMagnetostaticSolverAxiSym : public QuasiMagnetostaticSolverBase {  //
 
   double elementJouleHeating(const FiniteElement &el, ElementTransformation &Tr, const Vector &elfun) override;
   double totalJouleHeating() override;
+
+  /** Evaluate the total current in the coil */
+  double coilCurrent() const final;
 };
 
 #endif  // QUASIMAGNETOSTATIC_HPP_

--- a/src/quasimagnetostatic.hpp
+++ b/src/quasimagnetostatic.hpp
@@ -103,8 +103,20 @@ class QuasiMagnetostaticSolverBase : public TPS::Solver {
 
   void scaleJouleHeating(const double val) { (*joule_heating_) *= val; }
 
+  /** @brief Evaluate the total current in the coil
+   *
+   *  This function returns the current in the coil.  Primarily this
+   *  is useful in computing integrated quantities, such as the plamsa
+   *  resistance, for using in a circuit model.
+   */
   virtual double coilCurrent() const {
     mfem::mfem_error("QuasiMagnetostaticSolverBase::coilCurrent is not implemented.");
+    return 0.0;
+  }
+
+  /** Evaluate the energy in the magnetic field */
+  virtual double magneticEnergy() const {
+    mfem::mfem_error("QuasiMagnetostaticSolverBase::magneticEnergy is not implemented.");
     return 0.0;
   }
 
@@ -273,8 +285,9 @@ class QuasiMagnetostaticSolverAxiSym : public QuasiMagnetostaticSolverBase {  //
   double elementJouleHeating(const FiniteElement &el, ElementTransformation &Tr, const Vector &elfun) override;
   double totalJouleHeating() override;
 
-  /** Evaluate the total current in the coil */
   double coilCurrent() const final;
+
+  double magneticEnergy() const final;
 };
 
 #endif  // QUASIMAGNETOSTATIC_HPP_

--- a/test/inputs/plasma.lte2d.ini
+++ b/test/inputs/plasma.lte2d.ini
@@ -146,3 +146,4 @@ By_file     =  ref_solns/By.h5   # file for By interpolant output
 current_amplitude = 4e6        # run 1 of heating # A/m^2 (with reactions
 current_frequency = 6e6          # 1/s
 permeability = 1.25663706e-6     # m * kg / s^2 / A^2
+eval_Rplasma = true


### PR DESCRIPTION
This PR includes capabilities to evaluate some bulk plamsa properties that will interface with a circuit model (e.g., the plasma resistance).  While implementing these, some multiplicative factor bugs were fixed in the frequency domain solver.  These fixes do not impact any previous plasma simulations where the power is controlled but will affect simulations where the current is controlled.