### PR TITLE
Parla container

### DIFF
--- a/docker/parla/Dockerfile
+++ b/docker/parla/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Umberto Villa <uvilla@oden.utexas.edu>
 
 USER root
 
-ARG parla_token=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
+ARG parla_token
 
 RUN . /etc/profile.d/lmod.sh &&\
     pip3 install --upgrade pip &&\
@@ -13,8 +13,14 @@ RUN . /etc/profile.d/lmod.sh &&\
     pip3 install scikit-build &&\
     pip3 install nvtx
 
+
+COPY parla-experimental parla-experimental
+
+RUN chown -R test parla-experimental
+
+USER test
+
 RUN . /etc/profile.d/lmod.sh && ml gnu9 && \ 
-    cd /tmp && git clone https://${parla_token}@github.com/ut-parla/parla-experimental.git &&\
     cd parla-experimental && \
     git checkout tps-interface && \
     sed -i 's\git@github.com:\https://github.com/\g' .gitmodules && \
@@ -23,5 +29,9 @@ RUN . /etc/profile.d/lmod.sh && ml gnu9 && \
     export CXX=/opt/ohpc/pub/compiler/gcc/9.4.0/bin/g++ && \
     python3 setup.py clean --all && pip3 install . --verbose
 
-USER test
+ENV PYTHONPATH=/home/test/.local/lib/python3.8/site-packages/:$PYTHONPATH
+RUN chmod -R a+rX /home/test/.local
+RUN chmod a+x /home/test/
+
+RUN python3 -c "import parla"
 

--- a/docker/parla/Dockerfile
+++ b/docker/parla/Dockerfile
@@ -1,0 +1,27 @@
+ARG base_image=pecosut/tps_gpu_env:sm_80
+FROM ${base_image}
+MAINTAINER Umberto Villa <uvilla@oden.utexas.edu>
+
+USER root
+
+ARG parla_token=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
+
+RUN . /etc/profile.d/lmod.sh &&\
+    pip3 install --upgrade pip &&\
+    pip3 install cython &&\
+    pip3 install psutil &&\
+    pip3 install scikit-build &&\
+    pip3 install nvtx
+
+RUN . /etc/profile.d/lmod.sh && ml gnu9 && \ 
+    cd /tmp && git clone https://${parla_token}@github.com/ut-parla/parla-experimental.git &&\
+    cd parla-experimental && \
+    git checkout tps-interface && \
+    sed -i 's\git@github.com:\https://github.com/\g' .gitmodules && \
+    git submodule update --init --recursive &&\
+    export CC=/opt/ohpc/pub/compiler/gcc/9.4.0/bin/gcc && \
+    export CXX=/opt/ohpc/pub/compiler/gcc/9.4.0/bin/g++ && \
+    python3 setup.py clean --all && pip3 install . --verbose
+
+USER test
+

--- a/docker/parla/README.md
+++ b/docker/parla/README.md
@@ -1,0 +1,12 @@
+# Install PARLA on top of a TPS GPU ENV
+
+Example for building this image
+
+```
+export BASE_IMAGE=pecosut/tps_gpu_env:sm_80
+export TAG=pecosut/tps_gpu_env_parla:sm_80
+export PARLA_TOKEN=<personal token to clone the parla experimental repo>
+sudo docker build -t $TAB \
+                  --build-arg base_image=$BASE_IMAGE \
+                  --build-arg parla_token=$PARLA_TOKEN .
+```

--- a/docker/parla/README.md
+++ b/docker/parla/README.md
@@ -5,8 +5,6 @@ Example for building this image
 ```
 export BASE_IMAGE=pecosut/tps_gpu_env:sm_80
 export TAG=pecosut/tps_gpu_env_parla:sm_80
-export PARLA_TOKEN=<personal token to clone the parla experimental repo>
 sudo docker build -t $TAB \
-                  --build-arg base_image=$BASE_IMAGE \
-                  --build-arg parla_token=$PARLA_TOKEN .
+                  --build-arg base_image=$BASE_IMAGE .
 ```


### PR DESCRIPTION
Install Parla on top of one `tps_gpu_env` image.

Note one needs to create a personal authorization token on GitHub for Parla.
@trevilo : Let me know if we can add that token as a secret, so that we can use the CI to build all containers.