### PR TITLE
Extract restart read/write IO from `M2ulPhyS`

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1988,12 +1988,6 @@ void M2ulPhyS::solveStep() {
 
   const int vis_steps = config.GetNumItersOutput();
   if (iter % vis_steps == 0) {
-    // dump history
-    // NOTE(kevin): this routine is currently obsolete.
-    // It computes `dof`-averaged state and time-derivative, which are useless at this point.
-    // This will not be supported.
-    writeHistoryFile();
-
 #ifdef HAVE_MASA
     if (config.use_mms_) {
       if (config.mmsSaveDetails_) {

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -329,9 +329,9 @@ void M2ulPhyS::initVariables() {
       if (config.isRestartSerialized("read")) {
         assert(serial_mesh->Conforming());
         partitioning_ = Array<int>(serial_mesh->GeneratePartitioning(nprocs_, defaultPartMethod), nelemGlobal_);
-        partitioning_file_hdf5("write");
+        partitioning_file_hdf5("write", config, groupsMPI, nelemGlobal_, partitioning_);
       } else {
-        partitioning_file_hdf5("read");
+        partitioning_file_hdf5("read", config, groupsMPI, nelemGlobal_, partitioning_);
       }
     }
 
@@ -359,7 +359,7 @@ void M2ulPhyS::initVariables() {
     if (nprocs_ > 1) {
       assert(serial_mesh->Conforming());
       partitioning_ = Array<int>(serial_mesh->GeneratePartitioning(nprocs_, defaultPartMethod), nelemGlobal_);
-      if (rank0_) partitioning_file_hdf5("write");
+      if (rank0_) partitioning_file_hdf5("write", config, groupsMPI, nelemGlobal_, partitioning_);
       MPI_Barrier(groupsMPI->getTPSCommWorld());
     }
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -655,7 +655,7 @@ void M2ulPhyS::initVariables() {
     ioData.registerIOVar("/rmsData", "vw", 5);
   }
 
-  ioData.initializeSerial(rank0_, (config.RestartSerial() != "no"), serial_mesh);
+  ioData.initializeSerial(rank0_, (config.RestartSerial() != "no"), serial_mesh, locToGlobElem, &partitioning_);
   projectInitialSolution();
 
   // Boundary attributes in present partition

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -1795,7 +1795,7 @@ void M2ulPhyS::initSolutionAndVisualizationVectors() {
   }
 
   // define solution parameters for i/o
-  ioData.registerIOFamily("Solution state variables", "/solution", U);
+  ioData.registerIOFamily("Solution state variables", "/solution", U, true, true, fec);
   ioData.registerIOVar("/solution", "density", 0);
   ioData.registerIOVar("/solution", "rho-u", 1);
   ioData.registerIOVar("/solution", "rho-v", 2);

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -345,6 +345,8 @@ class M2ulPhyS : public TPS::Solver {
 
   // i/o routines
   void restart_files_hdf5(string mode, string inputFileName = std::string());
+  void write_restart_files_hdf5(hid_t file, bool serialized_write);
+  void read_restart_files_hdf5(hid_t file, bool serialized_read);
 
   void Check_NAN();
   bool Check_JobResubmit();

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -343,11 +343,6 @@ class M2ulPhyS : public TPS::Solver {
   void initGradUp();
   void initilizeSpeciesFromLTE();
 
-  // NOTE(kevin): this routine is currently obsolete.
-  // It computes `dof`-averaged state and time-derivative, which are useless at this point.
-  // This will not be supported.
-  void writeHistoryFile();
-
   // i/o routines
   void read_partitioned_soln_data(hid_t file, string varName, size_t index, double *data);
   void read_serialized_soln_data(hid_t file, string varName, int numDof, int varOffset, double *data, IOFamily &fam);

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -344,12 +344,7 @@ class M2ulPhyS : public TPS::Solver {
   void initilizeSpeciesFromLTE();
 
   // i/o routines
-  void read_partitioned_soln_data(hid_t file, string varName, size_t index, double *data);
-  void read_serialized_soln_data(hid_t file, string varName, int numDof, int varOffset, double *data, IOFamily &fam);
   void restart_files_hdf5(string mode, string inputFileName = std::string());
-  void partitioning_file_hdf5(string mode);
-  void serialize_soln_for_write(IOFamily &fam);
-  void write_soln_data(hid_t group, string varName, hid_t dataspace, double *data);
 
   void Check_NAN();
   bool Check_JobResubmit();

--- a/src/cycle_avg_joule_coupling.cpp
+++ b/src/cycle_avg_joule_coupling.cpp
@@ -313,7 +313,6 @@ void CycleAvgJouleCoupling::interpElectricFieldFromEMToFlow() {
   efieldR_->SetFromTrueDofs(interp_vals);
   efieldR_->HostRead();
 
-
   const ParGridFunction *efield_imag_gf = qmsa_solver_->getElectricFieldimag();
   interp_em_to_flow_->Interpolate(vxyz, *efield_imag_gf, interp_vals);
   efieldI_->SetFromTrueDofs(interp_vals);

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -669,31 +669,6 @@ void M2ulPhyS::write_soln_data(hid_t group, string varName, hid_t dataspace, dou
   return;
 }
 
-void M2ulPhyS::writeHistoryFile() {
-  MPI_Comm TPSCommWorld = this->groupsMPI->getTPSCommWorld();
-  double global_dUdt[5];
-  MPI_Allreduce(rhsOperator->getLocalTimeDerivatives(), &global_dUdt, 5, MPI_DOUBLE, MPI_SUM, TPSCommWorld);
-
-  if (rank0_) {
-    histFile << time << "," << iter;
-    for (int eq = 0; eq < 5; eq++) {
-      histFile << "," << global_dUdt[eq] / static_cast<double>(nprocs_);
-    }
-  }
-
-  if (average->ComputeMean()) {
-    double global_meanData[5 + 6];
-    MPI_Allreduce(average->getLocalSums(), &global_meanData, 5 + 6, MPI_DOUBLE, MPI_SUM, TPSCommWorld);
-
-    if (rank0_) {
-      histFile << "," << average->GetSamplesMean();
-      for (int n = 0; n < 5 + 6; n++) histFile << "," << global_meanData[n] / static_cast<double>(nprocs_);
-    }
-  }
-
-  if (rank0_) histFile << endl;
-}
-
 void M2ulPhyS::readTable(const std::string &inputPath, TableInput &result) {
   MPI_Comm TPSCommWorld = this->groupsMPI->getTPSCommWorld();
   tpsP->getInput((inputPath + "/x_log").c_str(), result.xLogScale, false);

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -98,15 +98,12 @@ class IODataOrganizer {
   void initializeSerial(bool root, bool serial, mfem::Mesh *serial_mesh, int *locToGlob, mfem::Array<int> *part);
 
   void write(hid_t file, bool serial);
-
-  void read(hid_t file, bool rank0);
-  void readSerial(hid_t file, bool rank0, MPI_Groups *groupsMPI, Array<int> partitioning, int global_ne);
-  void readChangeOrder(hid_t file, bool rank0, int read_order);
+  void read(hid_t file, bool serial, int read_order = -1);
 };
 
 void read_partitioned_soln_data(hid_t file, std::string varName, size_t index, double *data);
 void read_serialized_soln_data(hid_t file, std::string varName, int numDof, int varOffset, double *data, IOFamily &fam,
-                               MPI_Groups *groupsMPI, mfem::Array<int> partitioning, int nelemGlobal);
+                               mfem::Array<int> partitioning);
 void write_soln_data(hid_t group, std::string varName, hid_t dataspace, const double *data, bool rank0);
 void partitioning_file_hdf5(std::string mode, const RunConfiguration &config, MPI_Groups *groupsMPI, int nelemGlobal,
                             mfem::Array<int> &partitioning);

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -113,16 +113,16 @@ class IOFamily {
   std::vector<IOVar> vars_;
 
   /** Whether this family allows initialization (read) from other order elements */
-  bool allowsAuxRestart;
+  bool allowsAuxRestart_;
 
   /** true if the family is to be found in restart files */
-  bool inRestartFile;
+  bool inRestartFile_;
 
   /** mfem::FiniteElementSpace for serial mesh (used if serial read and/or write requested) */
-  mfem::FiniteElementSpace *serial_fes = nullptr;
+  mfem::FiniteElementSpace *serial_fes_ = nullptr;
 
   /** mfem::GridFunction on serial mesh (used if serial read and/or write requested) */
-  mfem::GridFunction *serial_sol = nullptr;
+  mfem::GridFunction *serial_sol_ = nullptr;
 
   /** Map from local to global element numbering (used for serial read/write) */
   int *local_to_global_elem_ = nullptr;

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -52,8 +52,14 @@ class IOFamily {
   // true if the family is to be found in restart files
   bool inRestartFile;
 
-  mfem::FiniteElementSpace *serial_fes;
-  mfem::GridFunction *serial_sol;
+  mfem::FiniteElementSpace *serial_fes = nullptr;
+  mfem::GridFunction *serial_sol = nullptr;
+
+  IOFamily(std::string desc, std::string grp, mfem::ParGridFunction *pf)
+      : description_(desc), group_(grp), pfunc_(pf) {}
+
+  void serializeForWrite(MPI_Comm comm, int local_ne, int global_ne, const int *locToGlobElem,
+                         const Array<int> &partitioning);
 };
 
 class IOVar {
@@ -76,6 +82,10 @@ class IODataOrganizer {
   int getIOFamilyIndex(std::string group);
 
   void initializeSerial(bool root, bool serial, mfem::Mesh *serial_mesh);
+
+  void write(hid_t file, bool rank0);
+  void writeSerial(hid_t file, MPI_Comm comm, int local_ne, int global_ne, const int *locToGlobElem,
+                   const Array<int> &partitioning);
 };
 
 void read_partitioned_soln_data(hid_t file, std::string varName, size_t index, double *data);
@@ -84,6 +94,4 @@ void read_serialized_soln_data(hid_t file, std::string varName, int numDof, int 
 void write_soln_data(hid_t group, std::string varName, hid_t dataspace, double *data, bool rank0);
 void partitioning_file_hdf5(std::string mode, const RunConfiguration &config, MPI_Groups *groupsMPI, int nelemGlobal,
                             mfem::Array<int> &partitioning);
-void serialize_soln_for_write(IOFamily &fam, MPI_Groups *groupsMPI, int local_ne, int global_ne,
-                              const int *locToGlobElem, const mfem::Array<int> &partitioning);
 #endif  // IO_HPP_

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -32,8 +32,13 @@
 #ifndef IO_HPP_
 #define IO_HPP_
 
+#include <hdf5.h>
+
+#include <string>
 #include <vector>
 
+#include "mpi_groups.hpp"
+#include "run_configuration.hpp"
 #include "tps_mfem_wrap.hpp"
 
 class IOFamily {
@@ -73,4 +78,12 @@ class IODataOrganizer {
   void initializeSerial(bool root, bool serial, mfem::Mesh *serial_mesh);
 };
 
+void read_partitioned_soln_data(hid_t file, std::string varName, size_t index, double *data);
+void read_serialized_soln_data(hid_t file, std::string varName, int numDof, int varOffset, double *data, IOFamily &fam,
+                               MPI_Groups *groupsMPI, mfem::Array<int> partitioning, int nelemGlobal);
+void write_soln_data(hid_t group, std::string varName, hid_t dataspace, double *data, bool rank0);
+void partitioning_file_hdf5(std::string mode, const RunConfiguration &config, MPI_Groups *groupsMPI, int nelemGlobal,
+                            mfem::Array<int> &partitioning);
+void serialize_soln_for_write(IOFamily &fam, MPI_Groups *groupsMPI, int local_ne, int global_ne,
+                              const int *locToGlobElem, const mfem::Array<int> &partitioning);
 #endif  // IO_HPP_

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -31,6 +31,11 @@
 // -----------------------------------------------------------------------------------el-
 #ifndef IO_HPP_
 #define IO_HPP_
+/** @file
+ * @brief Contains utilities for abstracting field IO tasks
+ *
+ * The primary class is IODataOrganizer.  For example usage, see M2ulPhyS.
+ */
 
 #include <hdf5.h>
 
@@ -43,86 +48,292 @@
 
 class IODataOrganizer;
 
+/**
+ * @brief Stores info about variables to read/write.
+ *
+ * This info is used in IOFamily and IODataOrganizer and is not
+ * intended to be needed separately.
+ */
 class IOVar {
  public:
-  std::string varName_;  // solution variable
-  int index_;            // variable index in the pargrid function
-  bool inRestartFile_;   // Check if we want to read this variable
+  /** Variable name, which combines with family name to set path in hdf5 file */
+  std::string varName_;
+
+  /** Variable index within variables stored in corresponding ParGridFunction */
+  int index_;  // variable index in the pargrid function
+
+  /** Whether variable is to be read
+   *
+   * This allows variables in the state to be skipped, e.g., to enable
+   * restarts from models that do not have all the same state variables.
+   */
+  bool inRestartFile_;
 };
 
+/**
+ * @brief Stores info about a "family" of variables to read/write.
+ *
+ * Here a "family" refers to data stored in a single
+ * mfem::ParGridFunction object.  Thus, the family has a single mesh
+ * and parallel decomposition.  For the moment, the underlying mesh
+ * and decomposition is assumed fixed after initialization.
+ *
+ * This class is intended to be used through IODataOrganizer, which
+ * can track multiple IOFamily objects.
+ */
 class IOFamily {
   friend class IODataOrganizer;
 
  protected:
+  /** Indicates whether current mpi rank is rank 0*/
   bool rank0_ = false;
 
+  /** Local number of elements in this mpi rank */
   int local_ne_ = -1;
+
+  /** Global number of elements in whole mesh */
   int global_ne_ = -1;
 
+  /** Local number of degrees of freedom on this mpi rank, as returned by ParGridFunction::GetNDofs */
   int local_ndofs_ = -1;
+
+  /** Global number of degrees of freedom */
   int global_ndofs_ = -1;
 
-  std::string description_;       // family description
-  std::string group_;             // HDF5 group name
-  mfem::ParGridFunction *pfunc_;  // pargrid function owning the data for this IO family
-  std::vector<IOVar> vars_;       // solution var info for this family
+  /** Description string */
+  std::string description_;
 
+  /** Group name, used to set corresponding group in hdf5 restart files */
+  std::string group_;
+
+  /** mfem::ParGridFunction owning the data to be written or read into */
+  mfem::ParGridFunction *pfunc_ = nullptr;
+
+  /** Variables that make up the family */
+  std::vector<IOVar> vars_;
+
+  /** Whether this family allows initialization (read) from other order elements */
   bool allowsAuxRestart;
 
-  // true if the family is to be found in restart files
+  /** true if the family is to be found in restart files */
   bool inRestartFile;
 
-  // space and grid function used for serial read/write
+  /** mfem::FiniteElementSpace for serial mesh (used if serial read and/or write requested) */
   mfem::FiniteElementSpace *serial_fes = nullptr;
+
+  /** mfem::GridFunction on serial mesh (used if serial read and/or write requested) */
   mfem::GridFunction *serial_sol = nullptr;
 
-  // additional data used for serial read/write (needed to properly
-  // serialize fields in write or properly distribute data in read)
-  int *local_to_global_elem_ = nullptr;       // maps from local elem index to global
-  mfem::Array<int> *partitioning_ = nullptr;  // partitioning[i] mpi rank for element i (in global numbering)
+  /** Map from local to global element numbering (used for serial read/write) */
+  int *local_to_global_elem_ = nullptr;
 
-  // Variables used for "auxilliary" read (i.e., restart from different order soln)
-  mfem::FiniteElementCollection *fec_ = nullptr;  // collection used to instantiate pfunc_
+  /** Partition array; partitioning[i] = mpi rank that owns the ith element (global numbering) */
+  mfem::Array<int> *partitioning_ = nullptr;
+
+  /** mfem::FiniteElementCollection used by pfunc_ (used for variable order read) */
+  mfem::FiniteElementCollection *fec_ = nullptr;
+
+  /** mfem::FiniteElementCollection with read order (used for variable order read) */
   mfem::FiniteElementCollection *aux_fec_ = nullptr;
+
+  /** mfem::FiniteElementCollection with read order elements (used for variable order read) */
   mfem::ParFiniteElementSpace *aux_pfes_ = nullptr;
+
+  /** mfem::ParGridFunction with read order elements (used for variable order read) */
   mfem::ParGridFunction *aux_pfunc_ = nullptr;
 
+  /**
+   * @brief Prepare for serial write by collecting data onto rank 0
+   *
+   * Each rank sends its data in pfunc_ to rank 0 and stores the
+   * results in serial_sol
+   */
   void serializeForWrite();
+
+  /**
+   * @brief Read and distribute a single variable in a serialized restart file
+   *
+   * Rank 0 reads the data and sends to appropriate rank and location in pfunc_
+   * @param file Open HDF5 file handle (e.g., as returned by H5Fcreate or H5Fopen)
+   * @param var IOVar for the variable being read
+   */
   void readDistributeSerializedVariable(hid_t file, const IOVar &var, int numDof, double *data);
 
  public:
+  /**
+   * @brief Constructor, must provide description, group name, and ParGridFunction
+   *
+   * @param desc Description string
+   * @param grp Group name
+   * @param pf Pointer to mfem::ParGridFunction that owns the data
+   */
   IOFamily(std::string desc, std::string grp, mfem::ParGridFunction *pf);
 
+  /** @brief "Partitioned" write (each mpi rank writes its local part of the ParGridFunction to a separate file) */
   void writePartitioned(hid_t file);
+
+  /** @brief "Serial" write (all data communicated to rank 0, which writes everything to a single file) */
   void writeSerial(hid_t file);
+
+  /** @brief "Partitioned" read (inverse of writePartitioned) */
   void readPartitioned(hid_t file);
+
+  /** @brief "Serial" read (inverse of readPartitioned) */
   void readSerial(hid_t file);
+
+  /**
+   * @brief "Partitioned" read of a different order solution
+   *
+   * which is then interpolated onto the desired space, as defined by pfunc_
+   * @param file Open HDF5 file handle (e.g., as returned by H5Fcreate or H5Fopen)
+   * @param read_order Polynomial order of function in HDF5 file
+   */
   void readChangeOrder(hid_t file, int read_order);
 };
 
+/**
+ * @brief Provides IO interface for multiple "families"
+ *
+ * This class is used to read & write the solution data contained in
+ * the mfem::ParGridFunction object in each IOFamily that is
+ * "registered".  Once families and variables are registered, the
+ * underlying data can be read or written with a single call.  Since
+ * it is expected that the calling class will have some class-specific
+ * metadata to read or write in addition to the solution data, this
+ * class does not handle opening or creating the hdf5 file or reading
+ * or writing solution metadata.  These tasks must be handled outside
+ * the IODataOrganizer class.  For example usage, see
+ * M2ulPhyS::initSolutionAndVisualizationVectors and
+ * M2ulPhyS::write_restart_files_hdf5.
+ */
 class IODataOrganizer {
  protected:
+  /** Whether serial read/write is supported.  To enable serial support, must call initializeSerial */
   bool supports_serial_ = false;
 
- public:
-  std::vector<IOFamily> families_;  // registered IO families
+  /** Registered IO families */
+  std::vector<IOFamily> families_;
 
+  /** Get the index of the IOFamily with group name group */
+  int getIOFamilyIndex(std::string group) const;
+
+ public:
+  /**
+   * @brief Register an IOFamily
+   *
+   * Constructs the family using the input arguments.
+   *
+   * @param description Description string for the family
+   * @param group Group name for the family
+   * @param pfunc mfem::ParGridFunction for the family
+   * @param auxRestart Allow initialization from different order read (optional, defaults to true)
+   * @param inRestartFile If false, skip family on read (optional, defaults to true)
+   * @param fec FiniteElementCollection for grid function (optional, only used for different order read)
+   */
   void registerIOFamily(std::string description, std::string group, mfem::ParGridFunction *pfunc,
                         bool auxRestart = true, bool inRestartFile = true, mfem::FiniteElementCollection *fec = NULL);
+  /** Destructor */
   ~IODataOrganizer();
 
+  /**
+   * @brief Register an IOVar as part of the corresponding family
+   *
+   * @param group Group name for the family to add the variable to
+   * @param varName Name of the variable
+   * @param index Variable index within the ParGridFunction of the family
+   * @param inRestartFile If false, skip variable on read (optional, defaults to true)
+   */
   void registerIOVar(std::string group, std::string varName, int index, bool inRestartFile = true);
-  int getIOFamilyIndex(std::string group);
 
+  /**
+   * @brief Initialize data supporting serial read/write.
+   *
+   * @param root True for mpi rank = 0
+   * @param serial True if we want seral read and/or write
+   * @param serial_mesh Pointer to serial mesh object
+   * @param locToGlob Map from local element index to global element index
+   * @param part Map from global element index to mpi rank owning that element
+   */
   void initializeSerial(bool root, bool serial, mfem::Mesh *serial_mesh, int *locToGlob, mfem::Array<int> *part);
 
+  /**
+   * @brief Write data from all families
+   *
+   * All families written to the same HDF5 file, which must be already
+   * open.  If serial write requested, a data is written to a single
+   * HDF5 file by rank 0.  Otherwise, all ranks write to separate
+   * files.
+   *
+   * @param file HDF5 file handle (e.g., as returned by H5Fcreate or H5Fopen)
+   * @param serial True for serial write
+   */
   void write(hid_t file, bool serial);
+
+  /**
+   * @brief Read data for all families
+   *
+   * All families are read from the same HDF5 file, which must be
+   * already open.  If serial read is requested, the data is read from
+   * a single HDF5 file by rank 0.  Otherwise, all ranks read from
+   * separate files.  For variable order (i.e., data in file had
+   * different order than desired), the order of the file being read
+   * must be supplied.
+   *
+   * @param file HDF5 file handle (e.g., as returned by H5Fopen)
+   * @param serial True for serial read
+   * @param read_order Polynomial order for data in file (optional, only required for variable order read)
+   */
   void read(hid_t file, bool serial, int read_order = -1);
 };
 
+/**
+ * @brief Get number of points to be read
+ *
+ * This convenience function returns the number of points to be read
+ * for a given name.  This is used frequently to check for consistency
+ * between the size of the read and the size of the container being
+ * read into.
+ *
+ * @param file Open HDF5 file
+ * @param name Name to query (corresponds to "family group/variable name")
+ * @returns Size of corresponding data in file
+ */
 hsize_t get_variable_size_hdf5(hid_t file, std::string name);
-void read_partitioned_soln_data(hid_t file, std::string varName, size_t index, double *data);
-void write_soln_data(hid_t group, std::string varName, hid_t dataspace, const double *data);
+
+/**
+ * @brief Read data from hdf5 file
+ *
+ * Reads data from the hdf5 file into the data buffer, starting at
+ * location index (i.e., fill starting at data[index])
+ *
+ * @param file Open HDF5 file
+ * @param varName Name of object to read  (corresponds to "family group/variable name")
+ * @param index Starting location within data buffer
+ * @param data Data buffer
+ */
+void read_variable_data_hdf5(hid_t file, std::string varName, size_t index, double *data);
+
+/**
+ * @brief Write data to an hdf5 file
+ *
+ * @param group Group within the hdf5 file to write to (e.g., as returned by H5Gcreate)
+ * @param varName Name of variable to write
+ * @param dataspace HDF5 dataspace (e.g., as returned by H5Screate_simple)
+ * @param data Buffer with data to write
+ */
+void write_variable_data_hdf5(hid_t group, std::string varName, hid_t dataspace, const double *data);
+
+/**
+ * @brief Read/write partitioning information
+ *
+ * For normal restarts, this is used to write/read the partitioning
+ * information to ensure that it remains consistent across the
+ * restart.  For serial restarts, it is also used to properly
+ * distribute the incoming fields.
+ *
+ * @todo Refactor this function to make it more generic and fit better
+ * into the IODataOrganizer paradigm.
+ */
 void partitioning_file_hdf5(std::string mode, const RunConfiguration &config, MPI_Groups *groupsMPI, int nelemGlobal,
                             mfem::Array<int> &partitioning);
 #endif  // IO_HPP_

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -52,6 +52,8 @@ class IOFamily {
  protected:
   bool rank0_;
 
+  void serializeForWrite();
+
  public:
   std::string description_;       // family description
   std::string group_;             // HDF5 group name
@@ -80,7 +82,8 @@ class IOFamily {
 
   IOFamily(std::string desc, std::string grp, mfem::ParGridFunction *pf);
 
-  void serializeForWrite();
+  void writePartitioned(hid_t file);
+  void writeSerial(hid_t file);
   void readPartitioned(hid_t file);
   void readSerial(hid_t file);
   void readChangeOrder(hid_t file, int read_order);

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -53,6 +53,7 @@ class IOFamily {
   bool rank0_;
 
   void serializeForWrite();
+  void readDistributeSerializedVariable(hid_t file, string varName, int numDof, int varOffset, double *data);
 
  public:
   std::string description_;       // family description
@@ -110,9 +111,7 @@ class IODataOrganizer {
 };
 
 void read_partitioned_soln_data(hid_t file, std::string varName, size_t index, double *data);
-void read_serialized_soln_data(hid_t file, std::string varName, int numDof, int varOffset, double *data, IOFamily &fam,
-                               mfem::Array<int> partitioning);
-void write_soln_data(hid_t group, std::string varName, hid_t dataspace, const double *data, bool rank0);
+void write_soln_data(hid_t group, std::string varName, hid_t dataspace, const double *data);
 void partitioning_file_hdf5(std::string mode, const RunConfiguration &config, MPI_Groups *groupsMPI, int nelemGlobal,
                             mfem::Array<int> &partitioning);
 #endif  // IO_HPP_

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -298,7 +298,7 @@ class RunConfiguration {
 
   string GetMeshFileName() { return meshFile; }
   string GetOutputName() { return outputFile; }
-  string GetPartitionBaseName() { return partFile; }
+  string GetPartitionBaseName() const { return partFile; }
   int GetUniformRefLevels() { return ref_levels; }
 
   int GetTimeIntegratorType() { return timeIntegratorType; }

--- a/src/tps2Boltzmann.cpp
+++ b/src/tps2Boltzmann.cpp
@@ -41,9 +41,10 @@
 #include <pybind11/stl.h>
 #endif
 
+#include <math.h>
+
 #include <cstddef>
 #include <cstdlib>
-#include <math.h>
 
 namespace TPS {
 
@@ -85,7 +86,7 @@ Tps2Boltzmann::Tps2Boltzmann(Tps *tps) : NIndexes(7), tps_(tps), all_fes_(nullpt
   assert(basis_type_ == 0 || basis_type_ == 1);
 
   tps->getRequiredInput("em/current_frequency", EfieldAngularFreq_);
-  EfieldAngularFreq_ *= 2.*M_PI;
+  EfieldAngularFreq_ *= 2. * M_PI;
 
   offsets.SetSize(NIndexes + 1);
   ncomps.SetSize(NIndexes + 1);


### PR DESCRIPTION
The goal of this PR is to refactor the restart file IO capabilities currently housed within `M2ulPhyS` so that they may be better used by other classes in the future.   Specifically, we have moved the bulk of the data read/write functions into the `IODataOrganizer` and `IOFamily` classes.  The parts that remain within `M2ulPhyS` are metadata read/write capabilities that, at least in principle, could change in other classes and therefore should remain class-specific.

Merging this PR closes #244.