### PR TITLE
Add a reusable class to manage IO options

### DIFF
--- a/src/io.hpp
+++ b/src/io.hpp
@@ -42,11 +42,39 @@
 #include <string>
 #include <vector>
 
+#include "logger.hpp"
 #include "mpi_groups.hpp"
-#include "run_configuration.hpp"
 #include "tps_mfem_wrap.hpp"
 
+class RunConfiguration;
 class IODataOrganizer;
+
+namespace TPS {
+class Tps;
+}
+
+/**
+ * @brief A place to hold options from the "io" section of a tps input deck
+ */
+class IOOptions {
+ public:
+  IOOptions();
+
+  std::string output_dir_;
+  bool enable_restart_ = false;
+  bool enable_restart_from_lte_ = false;
+
+  int exit_check_frequency_ = 500;
+
+  std::string restart_mode_;
+
+  bool restart_variable_order_ = false;
+  bool restart_serial_read_ = false;
+  bool restart_serial_write_ = false;
+
+  void read(TPS::Tps *tps, std::string prefix = std::string(""));
+  void setRestartFlags();
+};
 
 /**
  * @brief Stores info about variables to read/write.

--- a/src/run_configuration.cpp
+++ b/src/run_configuration.cpp
@@ -53,12 +53,8 @@ RunConfiguration::RunConfiguration() {
   dt_fixed = -1.0;
   numIters = 10;
   useRoe = false;
-  restart = false;
-  restartFromLTE = false;
   restart_hdf5_conversion = false;
-  restart_serial = "no";
   restart_cycle = 0;
-  restartFromAux = false;
   singleRestartFile = false;
 
   sampleInterval = 0;
@@ -111,9 +107,8 @@ RunConfiguration::RunConfiguration() {
 
   // Resource manager monitoring
   rm_enableMonitor_ = false;
-  rm_threshold_ = 15 * 60;     // 15 minutes
-  rm_checkFrequency_ = 25;     // 25 iterations
-  exit_checkFrequency_ = 500;  // 500 iterations
+  rm_threshold_ = 15 * 60;  // 15 minutes
+  rm_checkFrequency_ = 25;  // 25 iterations
 
   initialElectronTemperature = 0.;
 
@@ -134,14 +129,21 @@ RunConfiguration::~RunConfiguration() {
 // convenience function to determine whether a restart is serialized (using a
 // single HDF5 file)
 bool RunConfiguration::isRestartSerialized(string mode) {
-  if (restart_serial == "readwrite") {
+  if (io_opts_.restart_serial_read_ && io_opts_.restart_serial_write_) {
     return true;
   } else if (mode == "read") {
-    if (restart_serial == "read") return true;
+    return io_opts_.restart_serial_read_;
   } else if (mode == "write") {
-    if (restart_serial == "write") return true;
+    return io_opts_.restart_serial_write_;
+  } else if (mode == "either") {
+    return (io_opts_.restart_serial_read_ || io_opts_.restart_serial_write_);
+  } else if (mode == "both") {
+    return (io_opts_.restart_serial_read_ && io_opts_.restart_serial_write_);
+  } else {
+    // should never get here
+    assert(false);
   }
-
+  // should never get here, but have to return to avoid "missing return statement" error
   return false;
 }
 

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -41,6 +41,7 @@
 #include <vector>
 
 #include "dataStructures.hpp"
+#include "io.hpp"
 #include "tps_mfem_wrap.hpp"
 
 using namespace mfem;
@@ -51,15 +52,15 @@ using namespace std;
 // Lines begining with # are ignored
 class RunConfiguration {
  public:
+  // IO options
+  IOOptions io_opts_;
+
   // mesh file file
   string meshFile;
   int ref_levels;
 
   // partition file
   string partFile;
-
-  // output file name
-  string outputFile;
 
   // time integrator. Possible values
   //  1: ForwardEulerSolver
@@ -107,15 +108,11 @@ class RunConfiguration {
   bool useRoe;
 
   // restart controls
-  bool restart;
-  bool restartFromLTE;
   bool restart_hdf5_conversion;  // read in older ascii format
-  std::string restart_serial;    // mode for serial restarts
   int restart_cycle;
 
   // Restart from different order solution on same mesh.  New order
   // set by POL_ORDER, old order determined from restart file.
-  bool restartFromAux;
   bool singleRestartFile;
 
   // mean and RMS
@@ -297,7 +294,7 @@ class RunConfiguration {
   double GetWallTemp() { return wallTemperature; }
 
   string GetMeshFileName() { return meshFile; }
-  string GetOutputName() { return outputFile; }
+  string GetOutputName() { return io_opts_.output_dir_; }
   string GetPartitionBaseName() const { return partFile; }
   int GetUniformRefLevels() { return ref_levels; }
 
@@ -338,19 +335,18 @@ class RunConfiguration {
   int rm_threshold() { return rm_threshold_; }
   int rm_checkFreq() { return rm_checkFrequency_; }
 
-  int exit_checkFreq() { return exit_checkFrequency_; }
+  int exit_checkFreq() { return io_opts_.exit_check_frequency_; }
 
   bool thereIsForcing() { return isForcing; }
   double* GetImposedPressureGradient() { return &gradPress[0]; }
 
-  int GetRestartCycle() { return restart; }
+  int GetRestartCycle() { return io_opts_.enable_restart_; }
   void SetRestartCycle(int iter) {
     restart_cycle = iter;
     return;
   }
-  bool RestartFromAux() { return restartFromAux; }
+  bool RestartFromAux() { return io_opts_.restart_variable_order_; }
   bool RestartHDFConversion() { return restart_hdf5_conversion; }
-  std::string RestartSerial() { return restart_serial; }
   bool isRestartSerialized(string mode);
   bool isRestartPartitioned(string mode);
 


### PR DESCRIPTION
TPS options are current mostly stored in the `RunConfiguration` class and mostly "parsed" within `M2ulPhyS`.  See `M2ulPhyS::parseSolverOptions2` and the functions it calls.  This design means that both very generic
(e.g., io-related options) and very specific (e.g., the `third_order_thermal_conductivity` flag for argon transport modeling) are mixed together.  This fact makes it hard to reuse the generic parts of `RunConfiguration` in new situations (e.g., in implementing the low Mach capabilities) without carrying around a bunch of stuff that is irrelevant.

To improve this situation, we could create options classes to manage specific types of options.  These can then be combined as appropriate in different cases.  

This PR takes a small step toward this design.  Specifically, we implement the above approach for the currently existing "io" options (i.e., everything within the `io` block of an input file).  These options are now read and stored by the new `IOOptions` class.  To preserve the existing capabilities and behavior, `RunConfiguration` now has a new data member `IOOptions io_opts_`, which replaces a number of variables (e.g., `bool restart`) that were previously directly housed in `RunConfiguration`.

There are minor changes to `RunConfiguration` behavior, mostly surrounding the serial restart flags.  All capabilities are the same, but rather than checking strings (e.g., `config.RestartSerial() == "no"`), we rely on `isRestartSerialized`, which uses booleans stored within `IOOptions`.  Otherwise, the functionality of `RunConfiguration` should be the same.  The only difference is that the IO options capabilities can now be easily reused elsewhere.