### PR TITLE
Refactor `Averaging`

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -618,7 +618,7 @@ void M2ulPhyS::initVariables() {
   initSolutionAndVisualizationVectors();
 
   average = new Averaging(config);
-  average->registerField(Up);
+  average->registerField(Up, true, 1, dim);
   average->initializeViz(fes, dfes);
 
   // NOTE: this should also be completed by the GasMixture class
@@ -648,12 +648,21 @@ void M2ulPhyS::initVariables() {
 
     // rms
     ioData.registerIOFamily("RMS velocity fluctuation", "/rmsData", average->GetRMS(), false, config.GetRestartMean());
-    ioData.registerIOVar("/rmsData", "uu", 0);
-    ioData.registerIOVar("/rmsData", "vv", 1);
-    ioData.registerIOVar("/rmsData", "ww", 2);
-    ioData.registerIOVar("/rmsData", "uv", 3);
-    ioData.registerIOVar("/rmsData", "uw", 4);
-    ioData.registerIOVar("/rmsData", "vw", 5);
+    if (nvel == 3) {
+      ioData.registerIOVar("/rmsData", "uu", 0);
+      ioData.registerIOVar("/rmsData", "vv", 1);
+      ioData.registerIOVar("/rmsData", "ww", 2);
+      ioData.registerIOVar("/rmsData", "uv", 3);
+      ioData.registerIOVar("/rmsData", "uw", 4);
+      ioData.registerIOVar("/rmsData", "vw", 5);
+    } else if (nvel == 2) {
+      ioData.registerIOVar("/rmsData", "uu", 0);
+      ioData.registerIOVar("/rmsData", "vv", 1);
+      ioData.registerIOVar("/rmsData", "uv", 2);
+    } else {
+      // only nvel = 2 or 3 supported
+      assert(false);
+    }
   }
 
   ioData.initializeSerial(rank0_, config.isRestartSerialized("either"), serial_mesh, locToGlobElem, &partitioning_);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -617,7 +617,8 @@ void M2ulPhyS::initVariables() {
 #endif
   initSolutionAndVisualizationVectors();
 
-  average = new Averaging(Up, mesh, config);
+  average = new Averaging(config);
+  average->registerField(Up);
   average->initializeViz(fes, dfes);
 
   // NOTE: this should also be completed by the GasMixture class

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -619,7 +619,7 @@ void M2ulPhyS::initVariables() {
 
   average = new Averaging(config);
   average->registerField(Up, true, 1, nvel);
-  average->initializeViz(fes, dfes, nvel);
+  average->initializeVizForM2ulPhyS(fes, dfes, nvel);
 
   // NOTE: this should also be completed by the GasMixture class
   // Kevin: Do we need GasMixture class for this?
@@ -2025,7 +2025,7 @@ void M2ulPhyS::solveStep() {
       // auto dUp = Up->ReadWrite();  // sets memory to GPU
       Up->ReadWrite();  // sets memory to GPU
 
-      average->write_meanANDrms_restart_files(iter, time, config.isMeanHistEnabled());
+      average->writeViz(iter, time, config.isMeanHistEnabled());
     }
 
     // make a separate routine! plane interp and dump here
@@ -2075,7 +2075,7 @@ void M2ulPhyS::solveStep() {
     }  // plane dump
   }    // step check
 
-  average->addSampleMean(iter, d_mixture);
+  average->addSample(iter, d_mixture);
 }
 
 void M2ulPhyS::solveEnd() {
@@ -2091,7 +2091,7 @@ void M2ulPhyS::solveEnd() {
     paraviewColl->SetTime(time);
     paraviewColl->Save();
 
-    average->write_meanANDrms_restart_files(iter, time, config.isMeanHistEnabled());
+    average->writeViz(iter, time, config.isMeanHistEnabled());
 
 #ifndef HAVE_MASA
     // // If HAVE_MASA is defined, this is handled above
@@ -4063,9 +4063,9 @@ void M2ulPhyS::visualization() {
     paraviewColl->SetTime(time);
     paraviewColl->Save();
 
-    average->write_meanANDrms_restart_files(iter, time, config.isMeanHistEnabled());
+    average->writeViz(iter, time, config.isMeanHistEnabled());
 
-    average->addSampleMean(iter, d_mixture);
+    average->addSample(iter, d_mixture);
 
     // periodically check for DIE file which requests to terminate early
     if (Check_ExitEarly(fileIter)) {

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -617,7 +617,7 @@ void M2ulPhyS::initVariables() {
 #endif
   initSolutionAndVisualizationVectors();
 
-  average = new Averaging(Up, mesh, fec, fes, dfes, vfes, eqSystem, d_mixture, num_equation, dim, config, groupsMPI);
+  average = new Averaging(Up, mesh, fec, fes, dfes, vfes, eqSystem, num_equation, dim, config, groupsMPI);
 
   // NOTE: this should also be completed by the GasMixture class
   // Kevin: Do we need GasMixture class for this?
@@ -2064,7 +2064,7 @@ void M2ulPhyS::solveStep() {
     }  // plane dump
   }    // step check
 
-  average->addSampleMean(iter);
+  average->addSampleMean(iter, d_mixture);
 }
 
 void M2ulPhyS::solveEnd() {
@@ -4054,7 +4054,7 @@ void M2ulPhyS::visualization() {
 
     average->write_meanANDrms_restart_files(iter, time);
 
-    average->addSampleMean(iter);
+    average->addSampleMean(iter, d_mixture);
 
     // periodically check for DIE file which requests to terminate early
     if (Check_ExitEarly(fileIter)) {

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -617,7 +617,7 @@ void M2ulPhyS::initVariables() {
 #endif
   initSolutionAndVisualizationVectors();
 
-  average = new Averaging(Up, mesh, fec, fes, dfes, vfes, eqSystem, num_equation, dim, config, groupsMPI);
+  average = new Averaging(Up, mesh, fes, dfes, config);
 
   // NOTE: this should also be completed by the GasMixture class
   // Kevin: Do we need GasMixture class for this?

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -618,7 +618,6 @@ void M2ulPhyS::initVariables() {
   initSolutionAndVisualizationVectors();
 
   average = new Averaging(Up, mesh, fec, fes, dfes, vfes, eqSystem, d_mixture, num_equation, dim, config, groupsMPI);
-  average->read_meanANDrms_restart_files();
 
   // NOTE: this should also be completed by the GasMixture class
   // Kevin: Do we need GasMixture class for this?

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -618,7 +618,7 @@ void M2ulPhyS::initVariables() {
   initSolutionAndVisualizationVectors();
 
   average = new Averaging(config);
-  average->registerField(Up, true, 1, nvel);
+  average->registerField(std::string("primitive_state"), Up, true, 1, nvel);
   average->initializeVizForM2ulPhyS(fes, dfes, nvel);
 
   // NOTE: this should also be completed by the GasMixture class
@@ -626,8 +626,8 @@ void M2ulPhyS::initVariables() {
   // register rms and mean sol into ioData
   if (average->ComputeMean()) {
     // meanUp
-    ioData.registerIOFamily("Time-averaged primitive vars", "/meanSolution", average->GetMeanUp(), false,
-                            config.GetRestartMean());
+    ioData.registerIOFamily("Time-averaged primitive vars", "/meanSolution",
+                            average->GetMeanUp(std::string("primitive_state")), false, config.GetRestartMean());
     ioData.registerIOVar("/meanSolution", "meanDens", 0);
     ioData.registerIOVar("/meanSolution", "mean-u", 1);
     ioData.registerIOVar("/meanSolution", "mean-v", 2);
@@ -647,7 +647,8 @@ void M2ulPhyS::initVariables() {
     }
 
     // rms
-    ioData.registerIOFamily("RMS velocity fluctuation", "/rmsData", average->GetRMS(), false, config.GetRestartMean());
+    ioData.registerIOFamily("RMS velocity fluctuation", "/rmsData", average->GetRMS(std::string("primitive_state")),
+                            false, config.GetRestartMean());
     if (nvel == 3) {
       ioData.registerIOVar("/rmsData", "uu", 0);
       ioData.registerIOVar("/rmsData", "vv", 1);
@@ -2039,9 +2040,9 @@ void M2ulPhyS::solveStep() {
       } else if (config.planeDump.primitive == true) {
         u_gf = getPrimitiveGF();
       } else if (config.planeDump.mean == true) {
-        u_gf = average->GetMeanUp();
+        u_gf = average->GetMeanUp(std::string("primitive_state"));
       } else if (config.planeDump.reynolds == true) {
-        u_gf = average->GetRMS();
+        u_gf = average->GetRMS(std::string("primitive_state"));
       } else {
         grvy_printf(GRVY_ERROR, "\nSpecified interpolation type not supported.\n");
         exit(ERROR);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -617,7 +617,7 @@ void M2ulPhyS::initVariables() {
 #endif
   initSolutionAndVisualizationVectors();
 
-  average = new Averaging(config);
+  average = new Averaging(config.avg_opts_, config.GetOutputName());
   average->registerField(std::string("primitive_state"), Up, true, 1, nvel);
   average->initializeVizForM2ulPhyS(fes, dfes, nvel);
 
@@ -2715,13 +2715,7 @@ void M2ulPhyS::parseTimeIntegrationOptions() {
   }
 }
 
-void M2ulPhyS::parseStatOptions() {
-  tpsP->getInput("averaging/saveMeanHist", config.meanHistEnable, false);
-  tpsP->getInput("averaging/startIter", config.startIter, 0);
-  tpsP->getInput("averaging/sampleFreq", config.sampleInterval, 0);
-  tpsP->getInput("averaging/enableContinuation", config.restartMean, false);
-  tpsP->getInput("averaging/restartRMS", config.restartRMS, false);
-}
+void M2ulPhyS::parseStatOptions() { config.avg_opts_.read(tpsP); }
 
 void M2ulPhyS::parseIOSettings() { config.io_opts_.read(tpsP); }
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -627,7 +627,7 @@ void M2ulPhyS::initVariables() {
   if (average->ComputeMean()) {
     // meanUp
     ioData.registerIOFamily("Time-averaged primitive vars", "/meanSolution",
-                            average->GetMeanUp(std::string("primitive_state")), false, config.GetRestartMean());
+                            average->GetMeanField(std::string("primitive_state")), false, config.GetRestartMean());
     ioData.registerIOVar("/meanSolution", "meanDens", 0);
     ioData.registerIOVar("/meanSolution", "mean-u", 1);
     ioData.registerIOVar("/meanSolution", "mean-v", 2);
@@ -647,8 +647,8 @@ void M2ulPhyS::initVariables() {
     }
 
     // rms
-    ioData.registerIOFamily("RMS velocity fluctuation", "/rmsData", average->GetRMS(std::string("primitive_state")),
-                            false, config.GetRestartMean());
+    ioData.registerIOFamily("RMS velocity fluctuation", "/rmsData",
+                            average->GetVariField(std::string("primitive_state")), false, config.GetRestartMean());
     if (nvel == 3) {
       ioData.registerIOVar("/rmsData", "uu", 0);
       ioData.registerIOVar("/rmsData", "vv", 1);
@@ -2040,9 +2040,9 @@ void M2ulPhyS::solveStep() {
       } else if (config.planeDump.primitive == true) {
         u_gf = getPrimitiveGF();
       } else if (config.planeDump.mean == true) {
-        u_gf = average->GetMeanUp(std::string("primitive_state"));
+        u_gf = average->GetMeanField(std::string("primitive_state"));
       } else if (config.planeDump.reynolds == true) {
-        u_gf = average->GetRMS(std::string("primitive_state"));
+        u_gf = average->GetVariField(std::string("primitive_state"));
       } else {
         grvy_printf(GRVY_ERROR, "\nSpecified interpolation type not supported.\n");
         exit(ERROR);

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -618,8 +618,8 @@ void M2ulPhyS::initVariables() {
   initSolutionAndVisualizationVectors();
 
   average = new Averaging(config);
-  average->registerField(Up, true, 1, dim);
-  average->initializeViz(fes, dfes);
+  average->registerField(Up, true, 1, nvel);
+  average->initializeViz(fes, dfes, nvel);
 
   // NOTE: this should also be completed by the GasMixture class
   // Kevin: Do we need GasMixture class for this?
@@ -2025,7 +2025,7 @@ void M2ulPhyS::solveStep() {
       // auto dUp = Up->ReadWrite();  // sets memory to GPU
       Up->ReadWrite();  // sets memory to GPU
 
-      average->write_meanANDrms_restart_files(iter, time);
+      average->write_meanANDrms_restart_files(iter, time, config.isMeanHistEnabled());
     }
 
     // make a separate routine! plane interp and dump here
@@ -2091,7 +2091,7 @@ void M2ulPhyS::solveEnd() {
     paraviewColl->SetTime(time);
     paraviewColl->Save();
 
-    average->write_meanANDrms_restart_files(iter, time);
+    average->write_meanANDrms_restart_files(iter, time, config.isMeanHistEnabled());
 
 #ifndef HAVE_MASA
     // // If HAVE_MASA is defined, this is handled above
@@ -4063,7 +4063,7 @@ void M2ulPhyS::visualization() {
     paraviewColl->SetTime(time);
     paraviewColl->Save();
 
-    average->write_meanANDrms_restart_files(iter, time);
+    average->write_meanANDrms_restart_files(iter, time, config.isMeanHistEnabled());
 
     average->addSampleMean(iter, d_mixture);
 

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -617,7 +617,8 @@ void M2ulPhyS::initVariables() {
 #endif
   initSolutionAndVisualizationVectors();
 
-  average = new Averaging(Up, mesh, fes, dfes, config);
+  average = new Averaging(Up, mesh, config);
+  average->initializeViz(fes, dfes);
 
   // NOTE: this should also be completed by the GasMixture class
   // Kevin: Do we need GasMixture class for this?

--- a/src/M2ulPhyS.hpp
+++ b/src/M2ulPhyS.hpp
@@ -52,7 +52,7 @@ class Tps;
 
 #include "BCintegrator.hpp"
 #include "argon_transport.hpp"
-#include "averaging_and_rms.hpp"
+#include "averaging.hpp"
 #include "chemistry.hpp"
 #include "dataStructures.hpp"
 #include "dgNonlinearForm.hpp"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,7 +29,7 @@ tps_LDFLAGS += -fgpu-rdc
 endif
 
 # C++ solver library sources
-cxx_sources          = averaging_and_rms.cpp faceGradientIntegration.cpp M2ulPhyS.cpp rhs_operator.cpp wallBC.cpp \
+cxx_sources          = averaging.cpp faceGradientIntegration.cpp M2ulPhyS.cpp rhs_operator.cpp wallBC.cpp \
 		       BCintegrator.cpp face_integrator.cpp riemann_solver.cpp BoundaryCondition.cpp fluxes.cpp \
                        masa_handler.cpp run_configuration.cpp domain_integrator.cpp forcing_terms.cpp mpi_groups.cpp \
 	               equation_of_state.cpp transport_properties.cpp inletBC.cpp outletBC.cpp utils.cpp io.cpp \
@@ -42,7 +42,7 @@ cxx_sources          = averaging_and_rms.cpp faceGradientIntegration.cpp M2ulPhy
 
 mfem_extra_sources   = ../utils/mfem_extras/pfem_extras.cpp
 
-headers              = averaging_and_rms.hpp equation_of_state.hpp transport_properties.hpp forcing_terms.hpp mpi_groups.hpp \
+headers              = averaging.hpp equation_of_state.hpp transport_properties.hpp forcing_terms.hpp mpi_groups.hpp \
 		       run_configuration.hpp BCintegrator.hpp faceGradientIntegration.hpp inletBC.hpp outletBC.hpp \
 	               BoundaryCondition.hpp face_integrator.hpp M2ulPhyS.hpp rhs_operator.hpp \
 	               wallBC.hpp domain_integrator.hpp fluxes.hpp masa_handler.hpp riemann_solver.hpp \

--- a/src/averaging.cpp
+++ b/src/averaging.cpp
@@ -29,7 +29,7 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // -----------------------------------------------------------------------------------el-
-#include "averaging_and_rms.hpp"
+#include "averaging.hpp"
 
 #include <mfem/general/forall.hpp>
 

--- a/src/averaging.hpp
+++ b/src/averaging.hpp
@@ -29,8 +29,8 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // -----------------------------------------------------------------------------------el-
-#ifndef AVERAGING_AND_RMS_HPP_
-#define AVERAGING_AND_RMS_HPP_
+#ifndef AVERAGING_HPP_
+#define AVERAGING_HPP_
 
 #include <tps_config.h>
 
@@ -289,4 +289,4 @@ class Averaging {
   void SetSamplesInterval(int &interval) { sample_interval_ = interval; }
 };
 
-#endif  // AVERAGING_AND_RMS_HPP_
+#endif  // AVERAGING_HPP_

--- a/src/averaging_and_rms.cpp
+++ b/src/averaging_and_rms.cpp
@@ -52,7 +52,7 @@ Averaging::~Averaging() {
   }
 }
 
-void Averaging::registerField(ParGridFunction *field_to_average, bool compute_rms, int rms_start_index,
+void Averaging::registerField(const ParGridFunction *field_to_average, bool compute_rms, int rms_start_index,
                               int rms_components) {
   // quick return if not computing stats...
   if (!computeMean) return;
@@ -156,127 +156,95 @@ void Averaging::addSample(GasMixture *mixture) {
 
   // Loop through families that have been registered and compute means and variances
   for (size_t ifam = 0; ifam < avg_families_.size(); ifam++) {
-    double dSamplesMean = (double)samplesMean;
-    double dSamplesRMS = (double)samplesRMS;
-
-    GasMixture *d_mixture = mixture;
-
+    // Extract fields for use on device (when available)
     AveragingFamily &fam = avg_families_[ifam];
 
-    ParGridFunction *meanUp = fam.mean_fcn_;
-    ParGridFunction *rms = fam.rms_fcn_;
+    const ParGridFunction *inst = fam.instantaneous_fcn_;
+    ParGridFunction *mean = fam.mean_fcn_;
+    ParGridFunction *vari = fam.rms_fcn_;
 
-    const double *d_Up = fam.instantaneous_fcn_->Read();
+    const double *d_inst = inst->Read();
+    double *d_mean = mean->ReadWrite();
+    double *d_vari = vari->ReadWrite();
 
-    double *d_meanUp = meanUp->ReadWrite();
-    double *d_rms = rms->ReadWrite();
+    // Get mixture class pointer for use on device
+    //
+    // This is here to support original M2ulPhyS usage, where the
+    // instantaneous field contains temperature, but the averaged
+    // quantity is pressure.  But, in general, it may be null, in
+    // which case, whatever data are in the state are averaged
+    // directly.
+    GasMixture *d_mixture = mixture;
 
-    ParMesh *mesh = meanUp->ParFESpace()->GetParMesh();
-
-    const int d_neqn = meanUp->ParFESpace()->GetVDim();
-    const int d_dim = mesh->Dimension();
+    // Extract size information for use on device
+    const int dof = mean->ParFESpace()->GetNDofs();                 // dofs per scalar field
+    const int neq = mean->ParFESpace()->GetVDim();                  // number of scalar variables in mean field
+    const int dim = mean->ParFESpace()->GetParMesh()->Dimension();  // spatial dimension
 
     const int d_rms_start = fam.rms_start_index_;
     const int d_rms_components = fam.rms_components_;
 
-    const int Ndof = meanUp->ParFESpace()->GetNDofs();
+    // Extract sample size information for use on device
+    double dSamplesMean = (double)samplesMean;
+    double dSamplesRMS = (double)samplesRMS;
 
-    MFEM_FORALL(n, Ndof, {
-      // double meanVel[gpudata::MAXDIM], vel[gpudata::MAXDIM];  // double meanVel[3], vel[3];
-      // double nUp[20];  // NOTE: lets make sure we don't have more than 20 eq.
-      // NOTE(kevin): (presumably) marc left this hidden note here..
+    // "Loop" over all dofs and update statistics
+    MFEM_FORALL(n, dof, {
+      // NB: This is only necessary when mixture is not nulltpr
       double nUp[gpudata::MAXEQUATIONS];
-
-      for (int eq = 0; eq < d_neqn; eq++) {
-        nUp[eq] = d_Up[n + eq * Ndof];
+      for (int eq = 0; eq < neq; eq++) {
+        nUp[eq] = d_inst[n + eq * dof];
       }
 
-      // mean
-      for (int eq = 0; eq < d_neqn; eq++) {
-        double mUpi = d_meanUp[n + eq * Ndof];
-        double mVal = dSamplesMean * mUpi;
+      // Update mean
+      for (int eq = 0; eq < neq; eq++) {
+        const double uinst = d_inst[n + eq * dof];
+        const double umean = d_mean[n + eq * dof];
+        const double N_umean = dSamplesMean * umean;
 
-        double newMeanUp;
-        if (eq != 1 + d_dim) {
-          newMeanUp = (mVal + nUp[eq]) / (dSamplesMean + 1);
-        } else {  // eq == 1+d_dim
+        if (eq != 1 + dim) {
+          d_mean[n + eq * dof] = (N_umean + uinst) / (dSamplesMean + 1);
+        } else {  // eq == 1+dim
           double p = nUp[eq];
           if (mixture != nullptr) {
             p = d_mixture->ComputePressureFromPrimitives(nUp);
           }
-          newMeanUp = (mVal + p) / (dSamplesMean + 1);
+          d_mean[n + eq * dof] = (N_umean + p) / (dSamplesMean + 1);
         }
-
-        d_meanUp[n + eq * Ndof] = newMeanUp;
       }
 
-      if (d_rms != nullptr) {
+      // Update variances (only computed if we have a place to put them)
+      if (d_vari != nullptr) {
         double mean_state[gpudata::MAXEQUATIONS];
 
-        for (int eq = 0; eq < d_neqn; eq++) {
-          mean_state[eq] = d_meanUp[n + eq * Ndof];
+        for (int eq = 0; eq < neq; eq++) {
+          mean_state[eq] = d_mean[n + eq * dof];
         }
 
-        // // fill out mean velocity array
-        // for (int d = 0; d < d_dim; d++) {
-        //   meanVel[d] = d_meanUp[n + (d + 1) * Ndof];
-        //   vel[d] = nUp[d + 1];
-        // }
-        // if (d_dim != 3) {
-        //   meanVel[2] = 0.;
-        //   vel[2] = 0.;
-        // }
-
-        // ----- RMS -----
         double val = 0.;
         double delta_i = 0.;
         double delta_j = 0.;
         int rms_index = 0;
 
-        // Variances first
+        // Variances first (i.e., diagonal of the covariance matrix)
         for (int i = d_rms_start; i < d_rms_start + d_rms_components; i++) {
-          val = d_rms[n + rms_index * Ndof];
+          val = d_vari[n + rms_index * dof];
           delta_i = (nUp[i] - mean_state[i]);
-          d_rms[n + rms_index * Ndof] = (val * dSamplesRMS + delta_i * delta_i) / (dSamplesRMS + 1);
+          d_vari[n + rms_index * dof] = (val * dSamplesRMS + delta_i * delta_i) / (dSamplesRMS + 1);
           rms_index++;
         }
 
-        // // NB: Leaving this here temporarily b/c even in 2-D, TPS
-        // // keeps the "zz" component of the velocity rms
-
-        // // TODO(trevilo): Eliminate this and update reference fields
-        // // in regression tests once we have checked all the non-zero
-        // // fields when computed with the refactored approach zz
-        // val = d_rms[n + 2 * Ndof];
-        // d_rms[n + 2 * Ndof] = (val * dSamplesRMS + (vel[2] - meanVel[2]) * (vel[2] - meanVel[2])) / (dSamplesRMS +
-        // 1); rms_index++;
-
-        // Covariances second
+        // Covariances second (i.e., off-diagonal components, if any)
         for (int i = d_rms_start; i < d_rms_start + d_rms_components - 1; i++) {
           for (int j = d_rms_start + 1; j < d_rms_start + d_rms_components; j++) {
-            val = d_rms[n + rms_index * Ndof];
+            val = d_vari[n + rms_index * dof];
             delta_i = (nUp[i] - mean_state[i]);
             delta_j = (nUp[j] - mean_state[j]);
-            d_rms[n + rms_index * Ndof] = (val * dSamplesRMS + delta_i * delta_j) / (dSamplesRMS + 1);
+            d_vari[n + rms_index * dof] = (val * dSamplesRMS + delta_i * delta_j) / (dSamplesRMS + 1);
             rms_index++;
           }
         }
-
-        // // xy
-        // val = d_rms[n + 3 * Ndof];
-        // d_rms[n + 3 * Ndof] = (val * dSamplesRMS + (vel[0] - meanVel[0]) * (vel[1] - meanVel[1])) / (dSamplesRMS +
-        // 1);
-
-        // // xz
-        // val = d_rms[n + 4 * Ndof];
-        // d_rms[n + 4 * Ndof] = (val * dSamplesRMS + (vel[0] - meanVel[0]) * (vel[2] - meanVel[2])) / (dSamplesRMS +
-        // 1);
-
-        // // yz
-        // val = d_rms[n + 5 * Ndof];
-        // d_rms[n + 5 * Ndof] = (val * dSamplesRMS + (vel[1] - meanVel[1]) * (vel[2] - meanVel[2])) / (dSamplesRMS +
-        // 1);
-      }
+      }  // end variance
     });
   }
 }

--- a/src/averaging_and_rms.cpp
+++ b/src/averaging_and_rms.cpp
@@ -62,8 +62,8 @@ Averaging::~Averaging() {
   }
 }
 
-void Averaging::registerField(const ParGridFunction *field_to_average, bool compute_rms, int rms_start_index,
-                              int rms_components) {
+void Averaging::registerField(std::string name, const ParGridFunction *field_to_average, bool compute_rms,
+                              int rms_start_index, int rms_components) {
   // quick return if not computing stats...
   if (!compute_mean_) return;
 
@@ -94,7 +94,7 @@ void Averaging::registerField(const ParGridFunction *field_to_average, bool comp
   }
 
   // and store those fields in an AveragingFamily object that gets appended to the avg_families_ vector
-  avg_families_.emplace_back(AveragingFamily(field_to_average, mean, vari, rms_start_index, rms_components));
+  avg_families_.emplace_back(AveragingFamily(name, field_to_average, mean, vari, rms_start_index, rms_components));
 }
 
 void Averaging::initializeViz() {
@@ -128,12 +128,12 @@ void Averaging::initializeViz() {
 
     // TODO(trevilo): Add a name to AveragingFamily so we can use it here
     std::string mean_name("mean_");
-    mean_name += std::to_string(i);
+    mean_name += avg_families_[i].name_;
     pvdc_->RegisterField(mean_name.c_str(), mean);
 
     if (vari != nullptr) {
       std::string vari_name("vari_");
-      vari_name += std::to_string(i);
+      vari_name += avg_families_[i].name_;
       pvdc_->RegisterField(vari_name.c_str(), vari);
     }
   }

--- a/src/averaging_and_rms.cpp
+++ b/src/averaging_and_rms.cpp
@@ -97,66 +97,199 @@ void Averaging::registerField(const ParGridFunction *field_to_average, bool comp
   avg_families_.emplace_back(AveragingFamily(field_to_average, mean, vari, rms_start_index, rms_components));
 }
 
-void Averaging::initializeViz(ParFiniteElementSpace *fes, ParFiniteElementSpace *dfes, int nvel) {
-  if (compute_mean_) {
-    assert(avg_families_.size() == 1);
+void Averaging::initializeViz() {
+  // quick return if not computing stats...
+  if (!compute_mean_) return;
 
-    ParGridFunction *meanUp = avg_families_[0].mean_fcn_;
-    ParGridFunction *rms = avg_families_[0].rms_fcn_;
+  assert(avg_families_.size() >= 1);
 
-    const FiniteElementCollection *fec = meanUp->ParFESpace()->FEColl();
+  // Loop through the families and add them to the paraview output
+  for (size_t i = 0; i < avg_families_.size(); i++) {
+    ParGridFunction *mean = avg_families_[i].mean_fcn_;
+    ParGridFunction *vari = avg_families_[i].rms_fcn_;
+
+    const FiniteElementCollection *fec = mean->ParFESpace()->FEColl();
     const int order = fec->GetOrder();
 
-    ParMesh *mesh = meanUp->ParFESpace()->GetParMesh();
+    ParMesh *mesh = mean->ParFESpace()->GetParMesh();
 
-    // "helper" spaces to index into meanUp
-    meanRho = new ParGridFunction(fes, meanUp->GetData());
-    meanV = new ParGridFunction(dfes, meanUp->GetData() + fes->GetNDofs());
-    meanP = new ParGridFunction(fes, meanUp->GetData() + (1 + nvel) * fes->GetNDofs());
+    // If not yet allocated paraview, do it
+    if (pvdc_ == nullptr) {
+      // TODO(trevilo): This approach ASSUMES that all stats are on
+      // the same mesh.  This is true for now, but should be
+      // generalized
+      pvdc_ = new ParaViewDataCollection(mean_output_name_, mesh);
+      pvdc_->SetLevelsOfDetail(order);
+      pvdc_->SetHighOrderOutput(true);
+      pvdc_->SetPrecision(8);
+    }
 
     // Register fields with paraview
-    pvdc_ = new ParaViewDataCollection(mean_output_name_, mesh);
-    pvdc_->SetLevelsOfDetail(order);
-    pvdc_->SetHighOrderOutput(true);
-    pvdc_->SetPrecision(8);
 
-    pvdc_->RegisterField("dens", meanRho);
-    pvdc_->RegisterField("vel", meanV);
-    pvdc_->RegisterField("press", meanP);
-    pvdc_->RegisterField("rms", rms);
+    // TODO(trevilo): Add a name to AveragingFamily so we can use it here
+    std::string mean_name("mean_");
+    mean_name += std::to_string(i);
+    pvdc_->RegisterField(mean_name.c_str(), mean);
+
+    if (vari != nullptr) {
+      std::string vari_name("vari_");
+      vari_name += std::to_string(i);
+      pvdc_->RegisterField(vari_name.c_str(), vari);
+    }
   }
 }
 
-void Averaging::addSampleMean(const int &iter, GasMixture *mixture) {
-  if (compute_mean_) {
-    assert(avg_families_.size() >= 1);
-    if (iter % sample_interval_ == 0 && iter >= step_start_mean_) {
-      if (iter == step_start_mean_ && rank0_) cout << "Starting mean calculation." << endl;
+void Averaging::initializeVizForM2ulPhyS(ParFiniteElementSpace *fes, ParFiniteElementSpace *dfes, int nvel) {
+  // quick return if not computing stats...
+  if (!compute_mean_) return;
 
-      if (ns_vari_ == 0) {
-        // *rms = 0.0;
-        *avg_families_[0].rms_fcn_ = 0.0;
+  assert(avg_families_.size() == 1);
+
+  ParGridFunction *meanUp = avg_families_[0].mean_fcn_;
+  ParGridFunction *rms = avg_families_[0].rms_fcn_;
+
+  const FiniteElementCollection *fec = meanUp->ParFESpace()->FEColl();
+  const int order = fec->GetOrder();
+
+  ParMesh *mesh = meanUp->ParFESpace()->GetParMesh();
+
+  // "helper" spaces to index into meanUp
+  meanRho = new ParGridFunction(fes, meanUp->GetData());
+  meanV = new ParGridFunction(dfes, meanUp->GetData() + fes->GetNDofs());
+  meanP = new ParGridFunction(fes, meanUp->GetData() + (1 + nvel) * fes->GetNDofs());
+
+  // Register fields with paraview
+  pvdc_ = new ParaViewDataCollection(mean_output_name_, mesh);
+  pvdc_->SetLevelsOfDetail(order);
+  pvdc_->SetHighOrderOutput(true);
+  pvdc_->SetPrecision(8);
+
+  pvdc_->RegisterField("dens", meanRho);
+  pvdc_->RegisterField("vel", meanV);
+  pvdc_->RegisterField("press", meanP);
+  pvdc_->RegisterField("rms", rms);
+}
+
+void Averaging::addSample(const int &iter, GasMixture *mixture) {
+  // quick return if not computing stats...
+  if (!compute_mean_) return;
+
+  assert(avg_families_.size() >= 1);
+
+  if (iter % sample_interval_ == 0 && iter >= step_start_mean_) {
+    if (iter == step_start_mean_ && rank0_) cout << "Starting mean calculation." << endl;
+
+    if (ns_vari_ == 0) {
+      // If we got here, then either this is our first time averaging
+      // or the variances have been restarted.  Either way, valid to
+      // set variances to zero.
+      for (size_t ifam = 0; ifam < avg_families_.size(); ifam++) {
+        *avg_families_[ifam].rms_fcn_ = 0.0;
+      }
+    }
+
+    if (mixture != nullptr) {
+      addSampleInternal(mixture);
+    } else {
+      addSampleInternal();
+    }
+    ns_mean_++;
+    ns_vari_++;
+  }
+}
+
+void Averaging::writeViz(const int &iter, const double &time, bool save_mean_hist) {
+  // quick return if not computing stats...
+  if (!compute_mean_) return;
+
+  if (save_mean_hist) {
+    pvdc_->SetCycle(iter);
+    pvdc_->SetTime(time);
+  }
+
+  pvdc_->Save();
+}
+
+void Averaging::addSampleInternal() {
+  // Assert that there is something to average.  In principle we don't
+  // need this, b/c the loop below is a no-op if there are no
+  // families.  However, if you got to this point, you're expecting to
+  // average something, so if there is nothing to average, we should
+  // complain rather than silently do nothing.
+  assert(avg_families_.size() >= 1);
+
+  // Loop through families that have been registered and compute means and variances
+  for (size_t ifam = 0; ifam < avg_families_.size(); ifam++) {
+    // Extract fields for use on device (when available)
+    AveragingFamily &fam = avg_families_[ifam];
+
+    const ParGridFunction *inst = fam.instantaneous_fcn_;
+    ParGridFunction *mean = fam.mean_fcn_;
+    ParGridFunction *vari = fam.rms_fcn_;
+
+    const double *d_inst = inst->Read();
+    double *d_mean = mean->ReadWrite();
+    double *d_vari = vari->ReadWrite();
+
+    // Extract size information for use on device
+    const int dof = mean->ParFESpace()->GetNDofs();  // dofs per scalar field
+    const int neq = mean->ParFESpace()->GetVDim();   // number of scalar variables in mean field
+
+    const int d_rms_start = fam.rms_start_index_;
+    const int d_rms_components = fam.rms_components_;
+
+    // Extract sample size information for use on device
+    double dSamplesMean = (double)ns_mean_;
+    double dSamplesRMS = (double)ns_vari_;
+
+    // "Loop" over all dofs and update statistics
+    MFEM_FORALL(n, dof, {
+      // Update mean
+      for (int eq = 0; eq < neq; eq++) {
+        const double uinst = d_inst[n + eq * dof];
+        const double umean = d_mean[n + eq * dof];
+        const double N_umean = dSamplesMean * umean;
+        d_mean[n + eq * dof] = (N_umean + uinst) / (dSamplesMean + 1);
       }
 
-      addSample(mixture);
-      ns_mean_++;
-      ns_vari_++;
-    }
+      // Update variances (only computed if we have a place to put them)
+      if (d_vari != nullptr) {
+        double val = 0.;
+        double delta_i = 0.;
+        double delta_j = 0.;
+        int rms_index = 0;
+
+        // Variances first (i.e., diagonal of the covariance matrix)
+        for (int i = d_rms_start; i < d_rms_start + d_rms_components; i++) {
+          const double uinst = d_inst[n + i * dof];
+          const double umean = d_mean[n + i * dof];
+          delta_i = (uinst - umean);
+          val = d_vari[n + rms_index * dof];
+          d_vari[n + rms_index * dof] = (val * dSamplesRMS + delta_i * delta_i) / (dSamplesRMS + 1);
+          rms_index++;
+        }
+
+        // Covariances second (i.e., off-diagonal components, if any)
+        for (int i = d_rms_start; i < d_rms_start + d_rms_components - 1; i++) {
+          const double uinst_i = d_inst[n + i * dof];
+          const double umean_i = d_mean[n + i * dof];
+          delta_i = uinst_i - umean_i;
+          for (int j = d_rms_start + 1; j < d_rms_start + d_rms_components; j++) {
+            const double uinst_j = d_inst[n + j * dof];
+            const double umean_j = d_mean[n + j * dof];
+            delta_j = uinst_j - umean_j;
+
+            val = d_vari[n + rms_index * dof];
+            d_vari[n + rms_index * dof] = (val * dSamplesRMS + delta_i * delta_j) / (dSamplesRMS + 1);
+            rms_index++;
+          }
+        }
+      }  // end variance
+    });
   }
 }
 
-void Averaging::write_meanANDrms_restart_files(const int &iter, const double &time, bool save_mean_hist) {
-  if (compute_mean_) {
-    if (save_mean_hist) {
-      pvdc_->SetCycle(iter);
-      pvdc_->SetTime(time);
-    }
-
-    pvdc_->Save();
-  }
-}
-
-void Averaging::addSample(GasMixture *mixture) {
+void Averaging::addSampleInternal(GasMixture *mixture) {
   // Assert that there is something to average.  In principle we don't
   // need this, b/c the loop below is a no-op if there are no
   // families.  However, if you got to this point, you're expecting to

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -80,21 +80,21 @@ class AveragingFamily {
   /** Variable index to "start" variances
    *
    * For example, if state vector is [rho, u, v, w, T] and you only
-   * want the velocity covariance matrix, rms_start_index_ should be 1
+   * want the velocity covariance matrix, vari_start_index_ should be 1
    */
-  int rms_start_index_;
+  int vari_start_index_;
 
   /** Number of variables for covariance calculation
    *
    * For example, if state vector is [rho, u, v, w, T] and you only
-   * want the velocity covariance matrix, rms_components_ should be
+   * want the velocity covariance matrix, vari_components_ should be
    * 3. This will lead to 6 covariance being computed (uu, vv, ww, uv,
    * uw, and vw).
    *
    * It is assumed that the variance variables are contiguous---i.e.,
    * there is no support for getting uT only.
    */
-  int rms_components_;
+  int vari_components_;
 
   /** Pointer to function containing the instantaneous field being averaged (not owned) */
   const ParGridFunction *instantaneous_fcn_;
@@ -103,47 +103,47 @@ class AveragingFamily {
   ParGridFunction *mean_fcn_;
 
   /** Pointer to variance field (owned) */
-  ParGridFunction *rms_fcn_;
+  ParGridFunction *vari_fcn_;
 
   /**
    * @brief Constructor
    *
-   * Notes: the mean and rms grid functions should be allocated before
+   * Notes: the mean and vari grid functions should be allocated before
    * constructing the AveragingFamily, but AveragingFamily then takes
    * ownership.
    */
-  AveragingFamily(std::string name, const ParGridFunction *instant, ParGridFunction *mean, ParGridFunction *rms,
-                  int rms_start_index = 0, int rms_components = 1) {
+  AveragingFamily(std::string name, const ParGridFunction *instant, ParGridFunction *mean, ParGridFunction *vari,
+                  int vari_start_index = 0, int vari_components = 1) {
     name_ = name;
-    rms_start_index_ = rms_start_index;
-    rms_components_ = rms_components;
+    vari_start_index_ = vari_start_index;
+    vari_components_ = vari_components;
     instantaneous_fcn_ = instant;
     mean_fcn_ = mean;
-    rms_fcn_ = rms;
+    vari_fcn_ = vari;
   }
 
   /// Move constructor (required for emplace_back)
   AveragingFamily(AveragingFamily &&fam) {
     this->name_ = fam.name_;
-    this->rms_start_index_ = fam.rms_start_index_;
-    this->rms_components_ = fam.rms_components_;
+    this->vari_start_index_ = fam.vari_start_index_;
+    this->vari_components_ = fam.vari_components_;
 
     // Copy the pointers
     this->instantaneous_fcn_ = fam.instantaneous_fcn_;
     this->mean_fcn_ = fam.mean_fcn_;
-    this->rms_fcn_ = fam.rms_fcn_;
+    this->vari_fcn_ = fam.vari_fcn_;
 
     // Set incoming mean_fcn_ to null, which ensures memory that
     // this->mean_fcn_ now points to is not deleted when the
     // destructor of fam is called
     fam.mean_fcn_ = nullptr;
-    fam.rms_fcn_ = nullptr;
+    fam.vari_fcn_ = nullptr;
   }
 
-  /// Destructor (deletes the mean and rms fields)
+  /// Destructor (deletes the mean and vari fields)
   ~AveragingFamily() {
     delete mean_fcn_;
-    delete rms_fcn_;
+    delete vari_fcn_;
   }
 };
 
@@ -197,12 +197,12 @@ class Averaging {
    *
    * @param name Name for the data being averaged (e.g., "temperature", or "primitive-state")
    * @param field_to_average Pointer to the instantaneous data that will be used to update the statistics
-   * @param compute_rms Set to true to compute variances.  Otherwise only mean is computed.
-   * @param rms_start_index Variable index at which to start variances (see AveragingFamily)
-   * @param rms_components Number of variables in variances (see AveragingFamily)
+   * @param compute_vari Set to true to compute variances.  Otherwise only mean is computed.
+   * @param vari_start_index Variable index at which to start variances (see AveragingFamily)
+   * @param vari_components Number of variables in variances (see AveragingFamily)
    */
-  void registerField(std::string name, const ParGridFunction *field_to_average, bool compute_rms = true,
-                     int rms_start_index = 0, int rms_components = 1);
+  void registerField(std::string name, const ParGridFunction *field_to_average, bool compute_vari = true,
+                     int vari_start_index = 0, int vari_components = 1);
 
   /**
    * @brief Initialize visualiztion for statistics
@@ -276,7 +276,7 @@ class Averaging {
   ParGridFunction *GetVariField(std::string name) {
     const int i = getFamilyIndex(name);
     assert(i >= 0);
-    return avg_families_[i].rms_fcn_;
+    return avg_families_[i].vari_fcn_;
   }
 
   int GetSamplesMean() { return ns_mean_; }

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -180,19 +180,53 @@ class Averaging {
 
   /**
    * @brief Initialize visualiztion for statistics
-   *
-   * Note: This method is current specific to M2ulPhyS
    */
-  void initializeViz(ParFiniteElementSpace *fes, ParFiniteElementSpace *dfes, int nvel);
+  void initializeViz();
+
+  /**
+   * @brief Add a sample to the statistics
+   *
+   * Checks iter to see if it is time to add a sample.  If not,
+   * returns.  If so, farms work out to appropriate addSampleInternal
+   * variant.
+   */
+  void addSample(const int &iter, GasMixture *mixture = nullptr);
+
+  /**
+   * @brief Write paraview visualization files with statistics
+   */
+  void writeViz(const int &iter, const double &time, bool save_mean_hist);
+
+  /**
+   * @brief Internal implementation of sample addition
+   *
+   * This method should be private, but is not b/c of a cuda
+   * requirement on device lambdas.  Instead of this method, you
+   * should call addSample (with mixture = nullptr).
+   */
+  void addSampleInternal();
+
+  /**
+   * @brief Internal implementation of sample addition (M2ulPhyS version)
+   *
+   * This method should be private, but is not b/c of a cuda
+   * requirement on device lambdas.  Instead of this method, you
+   * should call addSample (with mixture = a valid GasMixture object).
+   */
+  void addSampleInternal(GasMixture *mixture);
+
+  /**
+   * @brief Initialize visualiztion for statistics (M2ulPhyS version)
+   *
+   * Note: This method is included to provide backward compatibility
+   * with how stats viz files were originally labeled.  It should only
+   * be used inside M2ulPhyS.
+   */
+  void initializeVizForM2ulPhyS(ParFiniteElementSpace *fes, ParFiniteElementSpace *dfes, int nvel);
 
   // TODO(trevilo): Specific to single ParGridFunction case
   ParGridFunction *GetMeanUp() { return avg_families_[0].mean_fcn_; }
   ParGridFunction *GetRMS() { return avg_families_[0].rms_fcn_; }
-
-  void addSampleMean(const int &iter, GasMixture *mixture = nullptr);
-  void addSample(GasMixture *mixture);
-
-  void write_meanANDrms_restart_files(const int &iter, const double &time, bool save_mean_hist);
 
   int GetSamplesMean() { return ns_mean_; }
   int GetSamplesRMS() { return ns_vari_; }

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -257,13 +257,23 @@ class Averaging {
     return -1;
   }
 
-  ParGridFunction *GetMeanUp(std::string name) {
+  /**
+   * @brief Get pointer to mean field for a family
+   *
+   * @param name Name of the family
+   */
+  ParGridFunction *GetMeanField(std::string name) {
     const int i = getFamilyIndex(name);
     assert(i >= 0);
     return avg_families_[i].mean_fcn_;
   }
 
-  ParGridFunction *GetRMS(std::string name) {
+  /**
+   * @brief Get pointer to variance field for a family
+   *
+   * @param name Name of the family
+   */
+  ParGridFunction *GetVariField(std::string name) {
     const int i = getFamilyIndex(name);
     assert(i >= 0);
     return avg_families_[i].rms_fcn_;

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -50,10 +50,9 @@ class Averaging {
   // Primitive variables
   ParGridFunction *Up;
   ParMesh *mesh;
-  const FiniteElementCollection *fec;
-  const int num_equation;
-  const int dim;
-  const int nvel;
+  int num_equation;
+  int dim;
+  int nvel;
   RunConfiguration &config;
 
   // FES for RMS
@@ -82,9 +81,10 @@ class Averaging {
   void initiMeanAndRMS();
 
  public:
-  Averaging(ParGridFunction *_Up, ParMesh *_mesh, RunConfiguration &_config);
+  Averaging(RunConfiguration &_config);
   ~Averaging();
 
+  void registerField(ParGridFunction *field_to_average);
   void initializeViz(ParFiniteElementSpace *fes, ParFiniteElementSpace *dfes);
 
   void addSampleMean(const int &iter, GasMixture *mixture = nullptr);

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -59,8 +59,7 @@ class AveragingOptions {
   int step_start_mean_; /**< Time step at which to start computing stats */
 
   bool save_mean_history_;        /**< Whether to save viz files for the evolution of the mean */
-  bool enable_mean_continuation_; /**< Enable / disable continuation of the statistics calculations from a restart file
-                                   */
+  bool enable_mean_continuation_; /**< Enable / disable continuation of statistics calculations from restart file */
   bool zero_variances_;           /**< Enable / disable zeroing out the variances at the beginning of a run */
 
   void read(TPS::Tps *tps, std::string prefix = std::string(""));

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -91,9 +91,6 @@ class Averaging {
 
   void addSample_cpu();
 
-  Vector local_sums;
-  Vector tmp_vector;
-
  public:
   Averaging(ParGridFunction *_Up, ParMesh *_mesh, FiniteElementCollection *_fec, ParFiniteElementSpace *_fes,
             ParFiniteElementSpace *_dfes, ParFiniteElementSpace *_vfes, Equations &_eqSys, GasMixture *mixture,
@@ -116,14 +113,10 @@ class Averaging {
   void SetSamplesRMS(int &samples) { samplesRMS = samples; }
   void SetSamplesInterval(int &interval) { sampleInterval = interval; }
 
-  const double *getLocalSums();
-
   // GPU functions
 #ifdef _GPU_
   void addSample_gpu(ParGridFunction *meanUp, ParGridFunction *rms, int &samplesMean, GasMixture *mixture,
                      const ParGridFunction *Up, const int &Ndof, const int &dim, const int &num_equation);
-  static void sumValues_gpu(const Vector &meanUp, const Vector &rms, Vector &local_sums, Vector &tmp_vector,
-                            const int &num_equation, const int &dim);
 #endif  // _GPU_
 };
 

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -50,11 +50,11 @@ class AveragingFamily {
   int rms_start_index_;
   int rms_components_;
 
-  ParGridFunction *instantaneous_fcn_;
+  const ParGridFunction *instantaneous_fcn_;
   ParGridFunction *mean_fcn_;
   ParGridFunction *rms_fcn_;
 
-  AveragingFamily(ParGridFunction *instant, ParGridFunction *mean, ParGridFunction *rms, int rms_start_index = 0,
+  AveragingFamily(const ParGridFunction *instant, ParGridFunction *mean, ParGridFunction *rms, int rms_start_index = 0,
                   int rms_components = 1) {
     rms_start_index_ = rms_start_index;
     rms_components_ = rms_components;
@@ -110,7 +110,7 @@ class Averaging {
   Averaging(RunConfiguration &_config);
   ~Averaging();
 
-  void registerField(ParGridFunction *field_to_average, bool compute_rms = true, int rms_start_index = 0,
+  void registerField(const ParGridFunction *field_to_average, bool compute_rms = true, int rms_start_index = 0,
                      int rms_components = 1);
   void initializeViz(ParFiniteElementSpace *fes, ParFiniteElementSpace *dfes);
 

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -39,7 +39,6 @@
 
 #include "dataStructures.hpp"
 #include "equation_of_state.hpp"
-#include "mpi_groups.hpp"
 #include "run_configuration.hpp"
 #include "tps_mfem_wrap.hpp"
 
@@ -51,16 +50,13 @@ class Averaging {
   // Primitive variables
   ParGridFunction *Up;
   ParMesh *mesh;
-  FiniteElementCollection *fec;
+  const FiniteElementCollection *fec;
   ParFiniteElementSpace *fes;
   ParFiniteElementSpace *dfes;
-  ParFiniteElementSpace *vfes;
-  Equations &eqSystem;
-  const int &num_equation;
-  const int &dim;
+  const int num_equation;
+  const int dim;
   const int nvel;
   RunConfiguration &config;
-  MPI_Groups *groupsMPI;
 
   // FES for RMS
   ParFiniteElementSpace *rmsFes;
@@ -87,15 +83,11 @@ class Averaging {
 
   void initiMeanAndRMS();
 
-  void addSample_cpu(GasMixture *mixture);
-
-  // GPU functions
-  void addSample_gpu(GasMixture *mixture);
+  void addSample(GasMixture *mixture);
 
  public:
-  Averaging(ParGridFunction *_Up, ParMesh *_mesh, FiniteElementCollection *_fec, ParFiniteElementSpace *_fes,
-            ParFiniteElementSpace *_dfes, ParFiniteElementSpace *_vfes, Equations &_eqSys, const int &_num_equation,
-            const int &_dim, RunConfiguration &_config, MPI_Groups *_groupsMPI);
+  Averaging(ParGridFunction *_Up, ParMesh *_mesh, ParFiniteElementSpace *_fes, ParFiniteElementSpace *_dfes,
+            RunConfiguration &_config);
   ~Averaging();
 
   void addSampleMean(const int &iter, GasMixture *mixture = nullptr);

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -90,12 +90,12 @@ class Averaging {
  private:
   bool rank0_;
   std::vector<AveragingFamily> avg_families_;
-  RunConfiguration &config;
 
   // time averaged p, rho, vel (pointers to meanUp) for Visualization
   ParGridFunction *meanP, *meanRho, *meanV;
   ParGridFunction *meanScalar;
 
+  std::string mean_output_name_;
   ParaViewDataCollection *paraviewMean = NULL;
 
   int samplesMean;
@@ -107,15 +107,15 @@ class Averaging {
   bool computeMean;
 
  public:
-  Averaging(RunConfiguration &_config);
+  Averaging(RunConfiguration &config);
   ~Averaging();
 
   void registerField(const ParGridFunction *field_to_average, bool compute_rms = true, int rms_start_index = 0,
                      int rms_components = 1);
-  void initializeViz(ParFiniteElementSpace *fes, ParFiniteElementSpace *dfes);
+  void initializeViz(ParFiniteElementSpace *fes, ParFiniteElementSpace *dfes, int nvel);
 
   void addSampleMean(const int &iter, GasMixture *mixture = nullptr);
-  void write_meanANDrms_restart_files(const int &iter, const double &time);
+  void write_meanANDrms_restart_files(const int &iter, const double &time, bool save_mean_hist);
   void read_meanANDrms_restart_files();
 
   int GetSamplesMean() { return samplesMean; }

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -83,8 +83,6 @@ class Averaging {
 
   void initiMeanAndRMS();
 
-  void addSample(GasMixture *mixture);
-
  public:
   Averaging(ParGridFunction *_Up, ParMesh *_mesh, ParFiniteElementSpace *_fes, ParFiniteElementSpace *_dfes,
             RunConfiguration &_config);
@@ -105,6 +103,8 @@ class Averaging {
   void SetSamplesMean(int &samples) { samplesMean = samples; }
   void SetSamplesRMS(int &samples) { samplesRMS = samples; }
   void SetSamplesInterval(int &interval) { sampleInterval = interval; }
+
+  void addSample(GasMixture *mixture);
 };
 
 #endif  // AVERAGING_AND_RMS_HPP_

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -40,10 +40,31 @@
 
 // Forward declarations
 class GasMixture;
-class RunConfiguration;
+
+namespace TPS {
+class Tps;
+}
 
 using namespace mfem;
 using namespace std;
+
+/**
+ * @brief Options controlling behavior of Averaging class
+ */
+class AveragingOptions {
+ public:
+  AveragingOptions();
+
+  int sample_interval_; /**< Time steps between updating stats with a new sample */
+  int step_start_mean_; /**< Time step at which to start computing stats */
+
+  bool save_mean_history_;        /**< Whether to save viz files for the evolution of the mean */
+  bool enable_mean_continuation_; /**< Enable / disable continuation of the statistics calculations from a restart file
+                                   */
+  bool zero_variances_;           /**< Enable / disable zeroing out the variances at the beginning of a run */
+
+  void read(TPS::Tps *tps, std::string prefix = std::string(""));
+};
 
 /**
  * @brief Stores statistics fields (mean and variances) that are computed by Averaging
@@ -167,7 +188,7 @@ class Averaging {
 
  public:
   /// Constructor
-  Averaging(RunConfiguration &config);
+  Averaging(AveragingOptions &opts, std::string output_name);
 
   /// Destructor
   ~Averaging();

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -34,13 +34,13 @@
 
 #include <tps_config.h>
 
-#include <mfem/general/forall.hpp>
 #include <string>
 
-#include "dataStructures.hpp"
-#include "equation_of_state.hpp"
-#include "run_configuration.hpp"
 #include "tps_mfem_wrap.hpp"
+
+// Forward declarations
+class GasMixture;
+class RunConfiguration;
 
 using namespace mfem;
 using namespace std;
@@ -122,7 +122,6 @@ class AveragingFamily {
   }
 };
 
-
 /**
  * @brief Implements in situ statistics (mean and covariance) calculations
  *
@@ -136,28 +135,30 @@ class Averaging {
   bool rank0_;
 
   /// True if mean calculation is requested
-  bool computeMean;
+  bool compute_mean_;
 
   /// Time steps between updating stats with a new sample
-  int sampleInterval;
+  int sample_interval_;
 
   /// Time step at which to start computing stats
-  int startMean;
+  int step_start_mean_;
 
-  /// Samples used for the mean so far
-  int samplesMean;
+  /// Number of samples used for the mean so far
+  int ns_mean_;
 
-  /// Samples used for the variances so var
-  int samplesRMS;
+  /// Number of samples used for the variances so var
+  int ns_vari_;
 
   /// Visualization directory (i.e., paraview dumped to mean_output_name_)
   std::string mean_output_name_;
 
   /// mfem paraview data collection, used to write viz files
-  ParaViewDataCollection *paraviewMean = NULL;
+  ParaViewDataCollection *pvdc_ = nullptr;
 
   /// time averaged p, rho, vel (pointers to meanUp) for visualization (M2ulPhyS only!)
-  ParGridFunction *meanP, *meanRho, *meanV;
+  ParGridFunction *meanP = nullptr;
+  ParGridFunction *meanRho = nullptr;
+  ParGridFunction *meanV = nullptr;
 
  public:
   /// Constructor
@@ -193,14 +194,14 @@ class Averaging {
 
   void write_meanANDrms_restart_files(const int &iter, const double &time, bool save_mean_hist);
 
-  int GetSamplesMean() { return samplesMean; }
-  int GetSamplesRMS() { return samplesRMS; }
-  int GetSamplesInterval() { return sampleInterval; }
-  bool ComputeMean() { return computeMean; }
+  int GetSamplesMean() { return ns_mean_; }
+  int GetSamplesRMS() { return ns_vari_; }
+  int GetSamplesInterval() { return sample_interval_; }
+  bool ComputeMean() { return compute_mean_; }
 
-  void SetSamplesMean(int &samples) { samplesMean = samples; }
-  void SetSamplesRMS(int &samples) { samplesRMS = samples; }
-  void SetSamplesInterval(int &interval) { sampleInterval = interval; }
+  void SetSamplesMean(int &samples) { ns_mean_ = samples; }
+  void SetSamplesRMS(int &samples) { ns_vari_ = samples; }
+  void SetSamplesInterval(int &interval) { sample_interval_ = interval; }
 };
 
 #endif  // AVERAGING_AND_RMS_HPP_

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -51,8 +51,6 @@ class Averaging {
   ParGridFunction *Up;
   ParMesh *mesh;
   const FiniteElementCollection *fec;
-  ParFiniteElementSpace *fes;
-  ParFiniteElementSpace *dfes;
   const int num_equation;
   const int dim;
   const int nvel;
@@ -84,9 +82,10 @@ class Averaging {
   void initiMeanAndRMS();
 
  public:
-  Averaging(ParGridFunction *_Up, ParMesh *_mesh, ParFiniteElementSpace *_fes, ParFiniteElementSpace *_dfes,
-            RunConfiguration &_config);
+  Averaging(ParGridFunction *_Up, ParMesh *_mesh, RunConfiguration &_config);
   ~Averaging();
+
+  void initializeViz(ParFiniteElementSpace *fes, ParFiniteElementSpace *dfes);
 
   void addSampleMean(const int &iter, GasMixture *mixture = nullptr);
   void write_meanANDrms_restart_files(const int &iter, const double &time);

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -62,8 +62,6 @@ class Averaging {
   RunConfiguration &config;
   MPI_Groups *groupsMPI;
 
-  GasMixture *mixture;
-
   // FES for RMS
   ParFiniteElementSpace *rmsFes;
   int numRMS;
@@ -89,15 +87,15 @@ class Averaging {
 
   void initiMeanAndRMS();
 
-  void addSample_cpu();
+  void addSample_cpu(GasMixture *mixture);
 
  public:
   Averaging(ParGridFunction *_Up, ParMesh *_mesh, FiniteElementCollection *_fec, ParFiniteElementSpace *_fes,
-            ParFiniteElementSpace *_dfes, ParFiniteElementSpace *_vfes, Equations &_eqSys, GasMixture *mixture,
-            const int &_num_equation, const int &_dim, RunConfiguration &_config, MPI_Groups *_groupsMPI);
+            ParFiniteElementSpace *_dfes, ParFiniteElementSpace *_vfes, Equations &_eqSys, const int &_num_equation,
+            const int &_dim, RunConfiguration &_config, MPI_Groups *_groupsMPI);
   ~Averaging();
 
-  void addSampleMean(const int &iter);
+  void addSampleMean(const int &iter, GasMixture *mixture = nullptr);
   void write_meanANDrms_restart_files(const int &iter, const double &time);
   void read_meanANDrms_restart_files();
 

--- a/src/averaging_and_rms.hpp
+++ b/src/averaging_and_rms.hpp
@@ -89,6 +89,9 @@ class Averaging {
 
   void addSample_cpu(GasMixture *mixture);
 
+  // GPU functions
+  void addSample_gpu(GasMixture *mixture);
+
  public:
   Averaging(ParGridFunction *_Up, ParMesh *_mesh, FiniteElementCollection *_fec, ParFiniteElementSpace *_fes,
             ParFiniteElementSpace *_dfes, ParFiniteElementSpace *_vfes, Equations &_eqSys, const int &_num_equation,
@@ -110,12 +113,6 @@ class Averaging {
   void SetSamplesMean(int &samples) { samplesMean = samples; }
   void SetSamplesRMS(int &samples) { samplesRMS = samples; }
   void SetSamplesInterval(int &interval) { sampleInterval = interval; }
-
-  // GPU functions
-#ifdef _GPU_
-  void addSample_gpu(ParGridFunction *meanUp, ParGridFunction *rms, int &samplesMean, GasMixture *mixture,
-                     const ParGridFunction *Up, const int &Ndof, const int &dim, const int &num_equation);
-#endif  // _GPU_
 };
 
 #endif  // AVERAGING_AND_RMS_HPP_

--- a/src/flow.hpp
+++ b/src/flow.hpp
@@ -45,7 +45,7 @@ class Tps;
 
 // #include "loMach_options.hpp"
 #include "argon_transport.hpp"
-#include "averaging_and_rms.hpp"
+#include "averaging.hpp"
 #include "chemistry.hpp"
 #include "io.hpp"
 #include "mfem.hpp"

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -130,7 +130,7 @@ void M2ulPhyS::read_restart_files_hdf5(hid_t file, bool serialized_read) {
         samplesRMS = samplesMean;
       }
 
-      if (config.restartRMS == true) {
+      if (config.avg_opts_.zero_variances_ == true) {
         samplesRMS = 0;
       }
       average->SetSamplesRMS(samplesRMS);

--- a/src/run_configuration.cpp
+++ b/src/run_configuration.cpp
@@ -57,11 +57,6 @@ RunConfiguration::RunConfiguration() {
   restart_cycle = 0;
   singleRestartFile = false;
 
-  sampleInterval = 0;
-  startIter = 0;
-  restartMean = false;
-  meanHistEnable = false;
-
   itersOut = 50;
   workFluid = DRY_AIR;
   eqSystem = EULER;

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -40,6 +40,7 @@
 #include <utility>
 #include <vector>
 
+#include "averaging_and_rms.hpp"
 #include "dataStructures.hpp"
 #include "io.hpp"
 #include "tps_mfem_wrap.hpp"
@@ -54,6 +55,9 @@ class RunConfiguration {
  public:
   // IO options
   IOOptions io_opts_;
+
+  // Averaging options
+  AveragingOptions avg_opts_;
 
   // mesh file file
   string meshFile;
@@ -123,13 +127,6 @@ class RunConfiguration {
   // Restart from different order solution on same mesh.  New order
   // set by POL_ORDER, old order determined from restart file.
   bool singleRestartFile;
-
-  // mean and RMS
-  int sampleInterval;
-  int startIter;
-  bool restartMean;
-  bool restartRMS;
-  bool meanHistEnable;
 
   // working fluid. Options thus far
   // DRY_AIR
@@ -348,10 +345,10 @@ class RunConfiguration {
   int GetNumItersOutput() { return itersOut; }
   bool RoeRiemannSolver() const { return useRoe; }
 
-  int GetMeanStartIter() { return startIter; }
-  int GetMeanSampleInterval() { return sampleInterval; }
-  bool GetRestartMean() { return restartMean; }
-  bool isMeanHistEnabled() { return meanHistEnable; }
+  int GetMeanStartIter() { return avg_opts_.step_start_mean_; }
+  int GetMeanSampleInterval() { return avg_opts_.sample_interval_; }
+  bool GetRestartMean() { return avg_opts_.enable_mean_continuation_; }
+  bool isMeanHistEnabled() { return avg_opts_.save_mean_history_; }
 
   WorkingFluid GetWorkingFluid() { return workFluid; }
   double GetViscMult() { return visc_mult; }

--- a/src/run_configuration.hpp
+++ b/src/run_configuration.hpp
@@ -40,7 +40,7 @@
 #include <utility>
 #include <vector>
 
-#include "averaging_and_rms.hpp"
+#include "averaging.hpp"
 #include "dataStructures.hpp"
 #include "io.hpp"
 #include "tps_mfem_wrap.hpp"

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -29,8 +29,8 @@ EXTRA_DIST  = tap-driver.sh test_tps_splitcomm.py soln_differ inputs meshes lte-
               ref_solns/heatedBox/*.h5 \
 		      vpath.sh die.sh count_gpus.sh sniff_mpirun.sh \
 		      cyl3d.gpu.test cyl3d.mflow.gpu.test wedge.gpu.test \
-	          averages.gpu.test cyl3d.test cyl3d.gpu.python.test cyl3d.mflow.test cyl3d.dtconst.test \
-		      die.test averages.test wedge.test cyl3d.interp.test qms.rings.test qms.axisym.test \
+	          averaging.gpu.test cyl3d.test cyl3d.gpu.python.test cyl3d.mflow.test cyl3d.dtconst.test \
+		      die.test averaging.test wedge.test cyl3d.interp.test qms.rings.test qms.axisym.test \
 		      sponge_zone.test annulus.test pipe.test valgrind.test valgrind.suppressions \
 		      mms.euler.test reaction.test perfect_gas.test collision_integrals.test \
 	 	      argon_minimal.test argon_minimal.binary.test diffusion_wall.test \
@@ -50,7 +50,7 @@ if GPU_ENABLED
 TESTS += cyl3d.gpu.test \
 	 cyl3d.mflow.gpu.test \
 	 wedge.gpu.test \
-	 averages.gpu.test \
+	 averaging.gpu.test \
 	 argon_minimal.binary.test \
 	 diffusion_wall.test \
 	 reaction.test \
@@ -71,7 +71,7 @@ else
 TESTS += cyl3d.test \
 	 cyl3d.mflow.test \
 	 cyl3d.dtconst.test \
-	 averages.test \
+	 averaging.test \
 	 wedge.test \
 	 qms.rings.test \
 	 qms.axisym.test \

--- a/test/averaging.gpu.test
+++ b/test/averaging.gpu.test
@@ -1,55 +1,67 @@
 #!./bats
 # -*- mode: sh -*-
 
-TEST="averages"
+TEST="averaging"
 RUNFILE_A="inputs/input.cyl-2d.caseA.ini"
 RUNFILE_B="inputs/input.cyl-2d.caseB.ini"
 RUNFILE_C1="inputs/input.cyl-2d.caseC1.ini"
 RUNFILE_C2="inputs/input.cyl-2d.caseC2.ini"
 RUNFILE_D1="inputs/input.cyl-2d.caseD1.ini"
 RUNFILE_D2="inputs/input.cyl-2d.caseD2.ini"
+OPT=""
 
 setup() {
     SOLN_FILE=restart_output.sol.h5
     REF_FILE=ref_solns/cyl-2d.cpu.h5
     REF_FILE_REST=ref_solns/cyl-2d.meanRestart.cpu.h5
+    
+     # various GPU card detections
+    SKIP="ASPEED"
+    NUM_GPUS=`./count_gpus.sh`
+    MPIRUN=`./sniff_mpirun.sh`
 }
 
 @test "[$TEST] caseA: run serial case" {
     test -s $RUNFILE_A
     rm -f $SOLN_FILE
-    ../src/tps -run $RUNFILE_A
+    ../src/tps -run $RUNFILE_A $OPT
     test -s $SOLN_FILE
     ./soln_differ -a -d 2 $SOLN_FILE $REF_FILE
-
+    
     rm -f $SOLN_FILE
 }
 
 @test "[$TEST] caseB: run parallel case" {
+
+    [ $NUM_GPUS -ge 4 ] || skip "Four GPUs not available" 
+    
     test -s $RUNFILE_B
-    mpirun -n 4 ../src/tps -run $RUNFILE_B
+    $MPIRUN -n 4 ../src/tps -run $RUNFILE_B $OPT
     test -s $SOLN_FILE
     ./soln_differ -a -r -d 2 $SOLN_FILE $REF_FILE
-
+    
     rm -f $SOLN_FILE
 }
 
 @test "[$TEST] caseC: restart from a serialized solution" {
+
+    [ $NUM_GPUS -ge 4 ] || skip "Four GPUs not available" 
+    
     test -s $RUNFILE_C1
-    mpirun -n 4 ../src/tps -run $RUNFILE_C1
-    ../src/tps -run $RUNFILE_C2
+    $MPIRUN -n 4 ../src/tps -run $RUNFILE_C1 $OPT
+    ../src/tps -run $RUNFILE_C2 $OPT
     test -s $SOLN_FILE
     ./soln_differ -a -d 2 $SOLN_FILE $REF_FILE
-
+    
     rm -f $SOLN_FILE
 }
 
 @test "[$TEST] caseD: restart from solution without averaged data" {
     test -s $RUNFILE_D1
-    ../src/tps -run $RUNFILE_D1
-    ../src/tps -run $RUNFILE_D2
+    ../src/tps -run $RUNFILE_D1 $OPT
+    ../src/tps -run $RUNFILE_D2 $OPT
     test -s $SOLN_FILE
     ./soln_differ -a -d 2 $SOLN_FILE $REF_FILE_REST
-
+    
     rm -f $SOLN_FILE
 }

--- a/test/averaging.test
+++ b/test/averaging.test
@@ -1,67 +1,55 @@
 #!./bats
 # -*- mode: sh -*-
 
-TEST="averages"
+TEST="averaging"
 RUNFILE_A="inputs/input.cyl-2d.caseA.ini"
 RUNFILE_B="inputs/input.cyl-2d.caseB.ini"
 RUNFILE_C1="inputs/input.cyl-2d.caseC1.ini"
 RUNFILE_C2="inputs/input.cyl-2d.caseC2.ini"
 RUNFILE_D1="inputs/input.cyl-2d.caseD1.ini"
 RUNFILE_D2="inputs/input.cyl-2d.caseD2.ini"
-OPT=""
 
 setup() {
     SOLN_FILE=restart_output.sol.h5
     REF_FILE=ref_solns/cyl-2d.cpu.h5
     REF_FILE_REST=ref_solns/cyl-2d.meanRestart.cpu.h5
-    
-     # various GPU card detections
-    SKIP="ASPEED"
-    NUM_GPUS=`./count_gpus.sh`
-    MPIRUN=`./sniff_mpirun.sh`
 }
 
 @test "[$TEST] caseA: run serial case" {
     test -s $RUNFILE_A
     rm -f $SOLN_FILE
-    ../src/tps -run $RUNFILE_A $OPT
+    ../src/tps -run $RUNFILE_A
     test -s $SOLN_FILE
     ./soln_differ -a -d 2 $SOLN_FILE $REF_FILE
-    
+
     rm -f $SOLN_FILE
 }
 
 @test "[$TEST] caseB: run parallel case" {
-
-    [ $NUM_GPUS -ge 4 ] || skip "Four GPUs not available" 
-    
     test -s $RUNFILE_B
-    $MPIRUN -n 4 ../src/tps -run $RUNFILE_B $OPT
+    mpirun -n 4 ../src/tps -run $RUNFILE_B
     test -s $SOLN_FILE
     ./soln_differ -a -r -d 2 $SOLN_FILE $REF_FILE
-    
+
     rm -f $SOLN_FILE
 }
 
 @test "[$TEST] caseC: restart from a serialized solution" {
-
-    [ $NUM_GPUS -ge 4 ] || skip "Four GPUs not available" 
-    
     test -s $RUNFILE_C1
-    $MPIRUN -n 4 ../src/tps -run $RUNFILE_C1 $OPT
-    ../src/tps -run $RUNFILE_C2 $OPT
+    mpirun -n 4 ../src/tps -run $RUNFILE_C1
+    ../src/tps -run $RUNFILE_C2
     test -s $SOLN_FILE
     ./soln_differ -a -d 2 $SOLN_FILE $REF_FILE
-    
+
     rm -f $SOLN_FILE
 }
 
 @test "[$TEST] caseD: restart from solution without averaged data" {
     test -s $RUNFILE_D1
-    ../src/tps -run $RUNFILE_D1 $OPT
-    ../src/tps -run $RUNFILE_D2 $OPT
+    ../src/tps -run $RUNFILE_D1
+    ../src/tps -run $RUNFILE_D2
     test -s $SOLN_FILE
     ./soln_differ -a -d 2 $SOLN_FILE $REF_FILE_REST
-    
+
     rm -f $SOLN_FILE
 }

--- a/test/soln_differ
+++ b/test/soln_differ
@@ -76,13 +76,16 @@ if [ $averages == "yes" ]; then
    if [ $dim -eq 3 ]; then
      h5diff ${report} --relative=${relTolrhoE}  $file1 $file2 /meanSolution/mean-w   || exit 1
    fi
-   
+
    h5diff ${report} --delta=${absTolrhovel}  $file1 $file2 /rmsData/uu   || exit 1
    h5diff ${report} --delta=${absTolrhovel}  $file1 $file2 /rmsData/vv   || exit 1
-   h5diff ${report} --delta=${absTolrhovel}  $file1 $file2 /rmsData/ww   || exit 1
    h5diff ${report} --delta=${absTolrhovel}  $file1 $file2 /rmsData/uv   || exit 1
-   h5diff ${report} --delta=${absTolrhovel}  $file1 $file2 /rmsData/uw   || exit 1
-   h5diff ${report} --delta=${absTolrhovel}  $file1 $file2 /rmsData/vw   || exit 1
+
+   if [ $dim -eq 3 ]; then
+       h5diff ${report} --delta=${absTolrhovel}  $file1 $file2 /rmsData/ww   || exit 1
+       h5diff ${report} --delta=${absTolrhovel}  $file1 $file2 /rmsData/uw   || exit 1
+       h5diff ${report} --delta=${absTolrhovel}  $file1 $file2 /rmsData/vw   || exit 1
+   fi
 fi
 
 # Check species densities (rho-Y*) if requested

--- a/test/valgrind.test
+++ b/test/valgrind.test
@@ -5,6 +5,7 @@ TEST="valgrind"
 RUNFILE="inputs/input.dtconst.2iters.cyl.ini"
 LOMACH_RUNFILE="inputs/lomach.tgv2d.ini"
 HEAT_RUNFILE="inputs/input.heatedBox.ini"
+RUNFILE_AVG="inputs/input.cyl-2d.caseA.ini"
 EXE="../src/tps"
 LIBTOOL_RUN="../libtool --mode=execute"
 VALGRIND="valgrind --suppressions=valgrind.suppressions --tool=memcheck --leak-check=full --error-exitcode=1"
@@ -49,4 +50,9 @@ setup() {
     run $LIBTOOL_RUN $VALGRIND $EXE -run tmp.runfile.ini
     rm tmp.runfile.ini
     [[ "${status}" -eq 0 ]]
+}
+
+@test "[$TEST] run tps with input -> $RUNFILE_AVG under valgrind" {
+    test -s $RUNFILE_AVG
+    $LIBTOOL_RUN $VALGRIND $EXE -run $RUNFILE_AVG
 }


### PR DESCRIPTION
This PR is intended to make the `Averaging` class reusable outside of `M2ulPhyS`.  The eventual goal is to use it in `LoMachSolver` as well, although that is not done here.  To enable this usage, the class has been redesigned so that the user can add fields (i.e., `ParGridFunctions`) that will be averaged using the new `registerField` method.  In the current usage in `M2ulPhyS`, this is only called once, to add the entire primitive state, since it is stored as a single `ParGridFunction`.  However, the redesigned class also supports the expected usage in `LoMachSolver`, where it is expected that each component model class (e.g., `Tomboulides`) will add its own fields to the `Averaging` object, in much the same way that each component adds its own fields to the IO and Paraview outputs.

closes #247