### PR TITLE
Variable density and viscosity extensions to `Tomboulides`

### DIFF
--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -173,6 +173,7 @@ void CaloricallyPerfectThermoChem::initializeSelf() {
   Qt_.SetSize(sfes_truevsize);
   Qt_ = 0.0;
   Qt_gf_.SetSpace(sfes_);
+  Qt_gf_ = 0.0;
 
   Tn_.SetSize(sfes_truevsize);
   Tn_next_.SetSize(sfes_truevsize);

--- a/src/tomboulides.cpp
+++ b/src/tomboulides.cpp
@@ -113,7 +113,7 @@ Tomboulides::Tomboulides(mfem::ParMesh *pmesh, int vorder, int porder, temporalS
       if (type == "viscous_isothermal" || type == "viscous_adiabatic" || type == "viscous" || type == "no-slip") {
         Array<int> wall_attr(pmesh_->bdr_attributes.Max());
         wall_attr = 0;
-        wall_attr[patch] = 1;
+        wall_attr[patch-1] = 1;
 
         Vector zero(dim_);
         zero = 0.0;

--- a/src/tomboulides.cpp
+++ b/src/tomboulides.cpp
@@ -83,6 +83,13 @@ Tomboulides::Tomboulides(mfem::ParMesh *pmesh, int vorder, int porder, temporalS
   if (tps != nullptr) {
     // if we have Tps object, use it to set other options...
 
+    // Gravity
+    assert(dim_ >= 2);
+    Vector zerog(dim_);
+    zerog = 0.0;
+    gravity_.SetSize(dim_);
+    tps->getVec("loMach/gravity", gravity_, dim_, zerog);
+
     // Initial condition function... options are
     // 1) "" (Empty string), velocity initialized to zero
     // 2) "tgv2d", velocity initialized using vel_exact_tgv2d function
@@ -210,23 +217,8 @@ void Tomboulides::initializeSelf() {
 
   toThermoChem_interface_.velocity = u_next_gf_;
 
-  // NEEDS TO BE ADDED
-  // toTurbModel_interface.gradU = gradU_gf_;
-  // toTurbModel_interface.gradV = gradV_gf_;
-  // toTurbModel_interface.gradW = gradW_gf_;
-
-  // Add gravity forcing
-  assert(dim_ >= 2);
-  Vector gravity(dim_);
-  gravity = 0.0;
-
-  // TODO(trevilo): Get gravity from input file.  For now, hardcoded
-  // to usual value acting in -y direction.
-  // double *g = gravity.HostWrite();
-  // g[1] = -9.81;
-
-  // NB: ForcingTerm_T takes ownership of this vector.  Do not delete it.
-  gravity_vec_ = new VectorConstantCoefficient(gravity);
+  // Gravity
+  gravity_vec_ = new VectorConstantCoefficient(gravity_);
   Array<int> domain_attr(pmesh_->attributes.Max());
   domain_attr = 1;
 

--- a/src/tomboulides.cpp
+++ b/src/tomboulides.cpp
@@ -120,7 +120,7 @@ Tomboulides::Tomboulides(mfem::ParMesh *pmesh, int vorder, int porder, temporalS
       if (type == "viscous_isothermal" || type == "viscous_adiabatic" || type == "viscous" || type == "no-slip") {
         Array<int> wall_attr(pmesh_->bdr_attributes.Max());
         wall_attr = 0;
-        wall_attr[patch-1] = 1;
+        wall_attr[patch - 1] = 1;
 
         Vector zero(dim_);
         zero = 0.0;
@@ -326,7 +326,7 @@ void Tomboulides::initializeOperators() {
   Qt_coeff_ = new GridFunctionCoefficient(thermo_interface_->thermal_divergence);
   gradmu_Qt_coeff_ = new ScalarVectorProductCoefficient(*Qt_coeff_, *grad_mu_coeff_);
 
-  S_poisson_coeff_ = new VectorSumCoefficient(*twoS_gradmu_coeff_, *gradmu_Qt_coeff_, 1.0, -2./3);
+  S_poisson_coeff_ = new VectorSumCoefficient(*twoS_gradmu_coeff_, *gradmu_Qt_coeff_, 1.0, -2. / 3);
   S_mom_coeff_ = new VectorSumCoefficient(*graduT_gradmu_coeff_, *gradmu_Qt_coeff_, 1.0, -1.0);
 
   // Integration rules (only used if numerical_integ_ is true).  When

--- a/src/tomboulides.hpp
+++ b/src/tomboulides.hpp
@@ -159,6 +159,7 @@ class Tomboulides final : public FlowBase {
   mfem::ParBilinearForm *L_iorho_form_ = nullptr;  // \int (1/\rho) \nabla \phi_i \cdot \nabla \phi_j
   mfem::ParLinearForm *forcing_form_ = nullptr;    // \int \phi_i f
   mfem::ParNonlinearForm *Nconv_form_ = nullptr;   // \int \vphi_i \cdot [(u \cdot \nabla) u]
+  mfem::ParBilinearForm *Ms_form_ = nullptr;       // mass matrix = \int \vphi_i \cdot \vphi_j
   mfem::ParBilinearForm *Mv_form_ = nullptr;       // mass matrix = \int \vphi_i \cdot \vphi_j
   mfem::ParMixedBilinearForm *D_form_ = nullptr;   // divergence = \int \phi_i \nabla \cdot \vphi_j
   mfem::ParMixedBilinearForm *G_form_ = nullptr;   // gradient = \int \vphi_i \cdot \nabla \phi_j
@@ -169,6 +170,7 @@ class Tomboulides final : public FlowBase {
 
   // mfem operator objects
   mfem::OperatorHandle L_iorho_op_;
+  mfem::OperatorHandle Ms_op_;
   mfem::OperatorHandle Mv_op_;
   mfem::OperatorHandle Mv_rho_op_;
   mfem::OperatorHandle D_op_;
@@ -204,6 +206,10 @@ class Tomboulides final : public FlowBase {
   mfem::Vector resp_vec_;
   mfem::Vector p_vec_;
   mfem::Vector resu_vec_;
+  mfem::Vector Qt_vec_;
+  mfem::Vector grad_Qt_vec_;
+  mfem::Vector rho_vec_;
+  mfem::Vector mu_vec_;
 
   // miscellaneous
   double volume_;

--- a/src/tomboulides.hpp
+++ b/src/tomboulides.hpp
@@ -49,6 +49,7 @@ struct temporalSchemeCoefficients;
 
 #include "dirichlet_bc_helper.hpp"
 #include "split_flow_base.hpp"
+#include "utils.hpp"
 
 /// Container for forcing terms to be added to velocity equation
 class ForcingTerm_T {
@@ -156,6 +157,17 @@ class Tomboulides final : public FlowBase {
   mfem::VectorGridFunctionCoefficient *pp_div_coeff_ = nullptr;
   mfem::GridFunctionCoefficient *mult_coeff_ = nullptr;
 
+  mfem::GradientGridFunctionCoefficient *grad_mu_coeff_ = nullptr;
+  mfem::GradientVectorGridFunctionCoefficient *grad_u_next_coeff_ = nullptr;
+  mfem::TransposeMatrixCoefficient *grad_u_next_transp_coeff_ = nullptr;
+  mfem::MatrixVectorProductCoefficient *gradu_gradmu_coeff_ = nullptr;
+  mfem::MatrixVectorProductCoefficient *graduT_gradmu_coeff_ = nullptr;
+  mfem::VectorSumCoefficient *twoS_gradmu_coeff_ = nullptr;
+  mfem::GridFunctionCoefficient *Qt_coeff_ = nullptr;
+  mfem::ScalarVectorProductCoefficient *gradmu_Qt_coeff_ = nullptr;
+  mfem::VectorSumCoefficient *S_poisson_coeff_ = nullptr;
+  mfem::VectorSumCoefficient *S_mom_coeff_ = nullptr;
+
   // mfem "form" objects used to create operators
   mfem::ParBilinearForm *L_iorho_form_ = nullptr;  // \int (1/\rho) \nabla \phi_i \cdot \nabla \phi_j
   mfem::ParLinearForm *forcing_form_ = nullptr;    // \int \phi_i f
@@ -167,7 +179,9 @@ class Tomboulides final : public FlowBase {
   mfem::ParBilinearForm *Mv_rho_form_ = nullptr;   // mass matrix (density weighted) = \int \rho \vphi_i \cdot \vphi_j
   mfem::ParBilinearForm *Hv_form_ = nullptr;
   mfem::ParLinearForm *pp_div_bdr_form_ = nullptr;
-  mfem::ParLinearForm *u_bdr_form_;
+  mfem::ParLinearForm *u_bdr_form_ = nullptr;
+  mfem::ParLinearForm *S_poisson_form_ = nullptr;
+  mfem::ParLinearForm *S_mom_form_ = nullptr;
 
   // mfem operator objects
   mfem::OperatorHandle L_iorho_op_;
@@ -186,6 +200,9 @@ class Tomboulides final : public FlowBase {
 
   mfem::Solver *Mv_inv_pc_ = nullptr;
   mfem::CGSolver *Mv_inv_ = nullptr;
+
+  mfem::Solver *Mv_rho_inv_pc_ = nullptr;
+  mfem::CGSolver *Mv_rho_inv_ = nullptr;
 
   mfem::Solver *Hv_inv_pc_ = nullptr;
   mfem::CGSolver *Hv_inv_ = nullptr;
@@ -211,6 +228,8 @@ class Tomboulides final : public FlowBase {
   mfem::Vector grad_Qt_vec_;
   mfem::Vector rho_vec_;
   mfem::Vector mu_vec_;
+  mfem::Vector ress_vec_;
+  mfem::Vector S_poisson_vec_;
 
   // miscellaneous
   double volume_;

--- a/src/tomboulides.hpp
+++ b/src/tomboulides.hpp
@@ -112,6 +112,7 @@ class Tomboulides final : public FlowBase {
   std::string ic_string_;
 
   // Object used to build forcing
+  mfem::Vector gravity_;
   mfem::VectorConstantCoefficient *gravity_vec_;
   std::vector<ForcingTerm_T> forcing_terms_;
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1031,3 +1031,48 @@ void Orthogonalize(Vector &v, MPI_Comm comm) {
 
   v -= global_sum / static_cast<double>(global_size);
 }
+
+namespace mfem {
+GradientVectorGridFunctionCoefficient::GradientVectorGridFunctionCoefficient(const GridFunction *gf)
+    : MatrixCoefficient((gf) ? gf->VectorDim() : 0) {
+  GridFunc = gf;
+}
+
+void GradientVectorGridFunctionCoefficient::SetGridFunction(const GridFunction *gf) {
+  GridFunc = gf;
+  const int dim = (gf) ? gf->VectorDim() : 0;
+  height = width = dim;
+}
+
+void GradientVectorGridFunctionCoefficient::Eval(DenseMatrix &G, ElementTransformation &T, const IntegrationPoint &ip) {
+  Mesh *gf_mesh = GridFunc->FESpace()->GetMesh();
+  if (T.mesh->GetNE() == gf_mesh->GetNE()) {
+    GridFunc->GetVectorGradient(T, G);
+  } else {
+    IntegrationPoint coarse_ip;
+
+    // NB: In mfem/fem/coefficients.cpp, the function RefinedToCoarse is defined.  Here we reproduce it explicitly.
+    //
+    // ElementTransformation *coarse_T = RefinedToCoarse(*gf_mesh, T, ip, coarse_ip);
+    Mesh &fine_mesh = *T.mesh;
+    // Get the element transformation of the coarse element containing the
+    // fine element.
+    int fine_element = T.ElementNo;
+    const CoarseFineTransformations &cf = fine_mesh.GetRefinementTransforms();
+    int coarse_element = cf.embeddings[fine_element].parent;
+    ElementTransformation *coarse_T = gf_mesh->GetElementTransformation(coarse_element);
+    // Transform the integration point from fine element coordinates to coarse
+    // element coordinates.
+    Geometry::Type geom = T.GetGeometryType();
+    IntegrationPointTransformation fine_to_coarse;
+    IsoparametricTransformation &emb_tr = fine_to_coarse.Transf;
+    emb_tr.SetIdentityTransformation(geom);
+    emb_tr.SetPointMat(cf.point_matrices[geom](cf.embeddings[fine_element].matrix));
+    fine_to_coarse.Transform(ip, coarse_ip);
+    coarse_T->SetIntPoint(&coarse_ip);
+
+    GridFunc->GetVectorGradient(*coarse_T, G);
+  }
+}
+
+}  // namespace mfem

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -181,4 +181,30 @@ void EliminateRHS(Operator &A, ConstrainedOperator &constrainedA, const Array<in
  */
 void Orthogonalize(Vector &v, MPI_Comm comm);
 
+// Adding to the mfem namespace
+namespace mfem {
+
+/// Matrix coefficient defined as the Gradient of a Vector GridFunction
+class GradientVectorGridFunctionCoefficient : public MatrixCoefficient {
+ protected:
+  const GridFunction *GridFunc;
+
+ public:
+  /** @brief Construct the coefficient with a scalar grid function @a gf. The
+      grid function is not owned by the coefficient. */
+  GradientVectorGridFunctionCoefficient(const GridFunction *gf);
+
+  /// Set the scalar grid function.
+  void SetGridFunction(const GridFunction *gf);
+
+  /// Get the scalar grid function.
+  const GridFunction *GetGridFunction() const { return GridFunc; }
+
+  /// Evaluate the gradient vector coefficient at @a ip.
+  virtual void Eval(DenseMatrix &G, ElementTransformation &T, const IntegrationPoint &ip);
+
+  virtual ~GradientVectorGridFunctionCoefficient() {}
+};
+}  // namespace mfem
+
 #endif  // UTILS_HPP_

--- a/test/.gitattributes
+++ b/test/.gitattributes
@@ -51,3 +51,5 @@ ref_solns/heatedBox filter=lfs diff=lfs merge=lfs -text
 ref_solns/heatedBox/restart_output.sol.h5 filter=lfs diff=lfs merge=lfs -text
 ref_solns/spongeBox/restart_output.sol.h5 filter=lfs diff=lfs merge=lfs -text
 meshes/spongeBox.msh filter=lfs diff=lfs merge=lfs -text
+ref_solns/lequere-varmu/restart_output-lequere-varmu.sol.h5 filter=lfs diff=lfs merge=lfs -text
+ref_solns/lequere-varmu/reference-lequere-varmu.sol.h5 filter=lfs diff=lfs merge=lfs -text

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -27,6 +27,7 @@ EXTRA_DIST  = tap-driver.sh test_tps_splitcomm.py soln_differ inputs meshes lte-
 			  ref_solns/reaction/*.h5 ref_solns/noSGM1K/*.h5 ref_solns/smag1K_1/*.h5 \
 			  ref_solns/sigma1K_1/*.h5 ref_solns/plate150K/*.h5 ref_solns/plate150K_1step/*.h5 \
               ref_solns/heatedBox/*.h5 ref_solns/spongeBox/*.h5 \
+	      ref_solns/lequere-varmu/*.h5 \
 		      vpath.sh die.sh count_gpus.sh sniff_mpirun.sh \
 		      cyl3d.gpu.test cyl3d.mflow.gpu.test wedge.gpu.test \
 	          averaging.gpu.test cyl3d.test cyl3d.gpu.python.test cyl3d.mflow.test cyl3d.dtconst.test \
@@ -41,7 +42,7 @@ EXTRA_DIST  = tap-driver.sh test_tps_splitcomm.py soln_differ inputs meshes lte-
 		      tabulated.test lte_mixture.test distance_fcn.test \
               sgsSmag.test sgsSigma.test heatEq.test sponge.test plate.test pipe.mix.test lte2noneq-restart.test \
               coupled-3d.interface.test plasma.axisym.test plasma.axisym.lte1d.test \
-	      lomach-flow.test
+	      lomach-flow.test lomach-lequere.test
 
 TESTS = vpath.sh
 XFAIL_TESTS =
@@ -102,7 +103,8 @@ TESTS += cyl3d.test \
 	 coupled-3d.interface.test \
 	 plasma.axisym.test \
 	 plasma.axisym.lte1d.test \
-	 lomach-flow.test
+	 lomach-flow.test \
+	 lomach-lequere.test
 
 if PYTHON_ENABLED
 TESTS += cyl3d.python.test \

--- a/test/inputs/lomach.lequere.constmu.ini
+++ b/test/inputs/lomach.lequere.constmu.ini
@@ -6,8 +6,9 @@ mesh = meshes/inline-quad.mesh
 scale-mesh = 4.6030710338096165e-02  # Set L such that Ra = 1e6
 ref_levels = 2
 order = 3
-maxIters = 1000
-outputFreq = 10000
+maxIters = 20000
+outputFreq = 100
+timingFreq = 100
 flow-solver = tomboulides
 thermo-solver = calorically-perfect
 ambientPressure = 101325.0
@@ -39,27 +40,27 @@ solverRelTolerance = 1.0e-12
 numWalls = 4
 
 [boundaryConditions/wall1]
-patch = 0
+patch = 1
 type = viscous_adiabatic
 velocity = '0.0 0.0'
 
 [boundaryConditions/wall2]
-patch = 1
-type = viscous_isothermal
-velocity = '0.0 0.0'
-temperature = 960.0
-
-[boundaryConditions/wall3]
-patch = 3
+patch = 2
 type = viscous_isothermal
 velocity = '0.0 0.0'
 temperature = 240.0
+
+[boundaryConditions/wall3]
+patch = 4
+type = viscous_isothermal
+velocity = '0.0 0.0'
+temperature = 960.0
 
 # patches are out of order on purpose. Because of this ordering, this
 # patch, which has the driving wall (the lid) is added to the BC list
 # last, which means that the top corner points are set to u = [1,0].
 [boundaryConditions/wall4]
-patch = 2
+patch = 3
 type = viscous_adiabatic
 velocity = '0.0 0.0'
 

--- a/test/inputs/lomach.lequere.constmu.ini
+++ b/test/inputs/lomach.lequere.constmu.ini
@@ -1,0 +1,65 @@
+[solver]
+type = loMach
+
+[loMach]
+mesh = meshes/inline-quad.mesh
+scale-mesh = 4.6030710338096165e-02  # Set L such that Ra = 1e6
+ref_levels = 2
+order = 3
+maxIters = 1000
+outputFreq = 10000
+flow-solver = tomboulides
+thermo-solver = calorically-perfect
+ambientPressure = 101325.0
+
+[loMach/calperfect]
+viscosity-model = constant
+constant-visc/mu0 = 1.68e-5
+Rgas = 287.0
+Prandtl = 0.71
+gamma = 1.4
+
+[initialConditions]
+temperature = 600.0
+
+[io]
+outdirBase = output-lequere-constmu
+#enableRestart = True
+
+# Set bdfOrder = 1 for restart testing purposes
+[time]
+enableConstantTimestep = True
+dt_fixed = 1e-3
+integrator = curlcurl
+bdfOrder = 1
+maxSolverIteration = 200
+solverRelTolerance = 1.0e-12
+
+[boundaryConditions]
+numWalls = 4
+
+[boundaryConditions/wall1]
+patch = 0
+type = viscous_adiabatic
+velocity = '0.0 0.0'
+
+[boundaryConditions/wall2]
+patch = 1
+type = viscous_isothermal
+velocity = '0.0 0.0'
+temperature = 960.0
+
+[boundaryConditions/wall3]
+patch = 3
+type = viscous_isothermal
+velocity = '0.0 0.0'
+temperature = 240.0
+
+# patches are out of order on purpose. Because of this ordering, this
+# patch, which has the driving wall (the lid) is added to the BC list
+# last, which means that the top corner points are set to u = [1,0].
+[boundaryConditions/wall4]
+patch = 2
+type = viscous_adiabatic
+velocity = '0.0 0.0'
+

--- a/test/inputs/lomach.lequere.constmu.ini
+++ b/test/inputs/lomach.lequere.constmu.ini
@@ -12,6 +12,7 @@ timingFreq = 100
 flow-solver = tomboulides
 thermo-solver = calorically-perfect
 ambientPressure = 101325.0
+gravity = '0.0 -9.81'
 
 [loMach/calperfect]
 viscosity-model = constant

--- a/test/inputs/lomach.lequere.constmu.ini
+++ b/test/inputs/lomach.lequere.constmu.ini
@@ -4,8 +4,8 @@ type = loMach
 [loMach]
 mesh = meshes/inline-quad.mesh
 scale-mesh = 4.6030710338096165e-02  # Set L such that Ra = 1e6
-ref_levels = 2
-order = 3
+ref_levels = 3
+order = 2
 maxIters = 20000
 outputFreq = 100
 timingFreq = 100
@@ -33,7 +33,7 @@ outdirBase = output-lequere-constmu
 enableConstantTimestep = True
 dt_fixed = 1e-3
 integrator = curlcurl
-bdfOrder = 1
+bdfOrder = 3
 maxSolverIteration = 200
 solverRelTolerance = 1.0e-12
 

--- a/test/inputs/lomach.lequere.varmu.ini
+++ b/test/inputs/lomach.lequere.varmu.ini
@@ -6,12 +6,13 @@ mesh = meshes/inline-quad.mesh
 scale-mesh = 6.7066216143287755e-02  # Set L such that Ra = 1e6
 ref_levels = 3
 order = 2
-maxIters = 20000
+maxIters = 20100
 outputFreq = 100
-timingFreq = 100
+timingFreq = 10
 flow-solver = tomboulides
 thermo-solver = calorically-perfect
-ambientPressure = 101325.0
+#ambientPressure = 101325.0  # fresh start
+ambientPressure = 94288.655347695822
 gravity = '0.0 -9.81'
 
 [loMach/calperfect]
@@ -28,14 +29,15 @@ temperature = 600.0
 
 [io]
 outdirBase = output-lequere-varmu
-#enableRestart = True
+enableRestart = True
 
 # Set bdfOrder = 1 for restart testing purposes
 [time]
 enableConstantTimestep = True
 dt_fixed = 1e-3
 integrator = curlcurl
-bdfOrder = 3
+#bdfOrder = 3
+bdfOrder = 1
 maxSolverIteration = 200
 solverRelTolerance = 1.0e-12
 

--- a/test/inputs/lomach.lequere.varmu.ini
+++ b/test/inputs/lomach.lequere.varmu.ini
@@ -1,0 +1,69 @@
+[solver]
+type = loMach
+
+[loMach]
+mesh = meshes/inline-quad.mesh
+scale-mesh = 6.7066216143287755e-02  # Set L such that Ra = 1e6
+ref_levels = 3
+order = 2
+maxIters = 20000
+outputFreq = 100
+timingFreq = 100
+flow-solver = tomboulides
+thermo-solver = calorically-perfect
+ambientPressure = 101325.0
+gravity = '0.0 -9.81'
+
+[loMach/calperfect]
+Rgas = 287.0
+Prandtl = 0.71
+gamma = 1.4
+viscosity-model = sutherland
+calperfect/sutherland/mu0 = 1.68e-5
+calperfect/sutherland/T0 = 273.0
+calperfect/sutherland/S0 = 110.5
+
+[initialConditions]
+temperature = 600.0
+
+[io]
+outdirBase = output-lequere-varmu
+#enableRestart = True
+
+# Set bdfOrder = 1 for restart testing purposes
+[time]
+enableConstantTimestep = True
+dt_fixed = 1e-3
+integrator = curlcurl
+bdfOrder = 3
+maxSolverIteration = 200
+solverRelTolerance = 1.0e-12
+
+[boundaryConditions]
+numWalls = 4
+
+[boundaryConditions/wall1]
+patch = 1
+type = viscous_adiabatic
+velocity = '0.0 0.0'
+
+[boundaryConditions/wall2]
+patch = 2
+type = viscous_isothermal
+velocity = '0.0 0.0'
+temperature = 240.0
+
+[boundaryConditions/wall3]
+patch = 4
+type = viscous_isothermal
+velocity = '0.0 0.0'
+temperature = 960.0
+
+# patches are out of order on purpose. Because of this ordering, this
+# patch, which has the driving wall (the lid) is added to the BC list
+# last, which means that the top corner points are set to u = [1,0].
+[boundaryConditions/wall4]
+patch = 3
+type = viscous_adiabatic
+velocity = '0.0 0.0'
+

--- a/test/inputs/lomach.lid.ini
+++ b/test/inputs/lomach.lid.ini
@@ -30,17 +30,17 @@ solverRelTolerance = 1.0e-12
 numWalls = 4
 
 [boundaryConditions/wall1]
-patch = 0
-type = viscous
-velocity = '0.0 0.0'
-
-[boundaryConditions/wall2]
 patch = 1
 type = viscous
 velocity = '0.0 0.0'
 
+[boundaryConditions/wall2]
+patch = 2
+type = viscous
+velocity = '0.0 0.0'
+
 [boundaryConditions/wall3]
-patch = 3
+patch = 4
 type = viscous
 velocity = '0.0 0.0'
 
@@ -48,7 +48,7 @@ velocity = '0.0 0.0'
 # patch, which has the driving wall (the lid) is added to the BC list
 # last, which means that the top corner points are set to u = [1,0].
 [boundaryConditions/wall4]
-patch = 2
+patch = 3
 type = viscous
 velocity = '1.0 0.0'
 

--- a/test/lomach-lequere.test
+++ b/test/lomach-lequere.test
@@ -1,0 +1,31 @@
+#!./bats
+# -*- mode: sh -*-
+
+TEST="lomach-lequere"
+
+EXE="../src/tps"
+
+setup() {
+    RESTART="ref_solns/lequere-varmu/restart_output-lequere-varmu.sol.h5"
+    RUNFILE="inputs/lomach.lequere.varmu.ini"
+    REF_SOLN="ref_solns/lequere-varmu/reference-lequere-varmu.sol.h5"
+    SOLN_FILE="restart_output-lequere-varmu.sol.h5"
+}
+
+@test "[$TEST] Le Quere low Mach, thermally-driven cavity regression with variable viscosity" {
+    # NB: There is a restart issue for closed domain cases (see #256).
+    # When this is resolved, this regression test will need to be
+    # updated (b/c the reference solution will change).
+
+    rm -f $SOLN_FILE
+
+    # run
+    cp $RESTART .
+    $EXE --runFile $RUNFILE
+
+    # check
+    h5diff -r --relative=1e-16 $SOLN_FILE $REF_SOLN /temperature/temperature
+    h5diff -r --relative=1e-16 $SOLN_FILE $REF_SOLN /velocity/x-comp
+    h5diff -r --relative=1e-16 $SOLN_FILE $REF_SOLN /velocity/y-comp
+}
+

--- a/test/ref_solns/lequere-varmu/reference-lequere-varmu.sol.h5
+++ b/test/ref_solns/lequere-varmu/reference-lequere-varmu.sol.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:348f996ac34024f2c68037a6e3b3ccd1e91cafb2dd69e685a08ab2b5c1e7d6b5
+size 106352

--- a/test/ref_solns/lequere-varmu/restart_output-lequere-varmu.sol.h5
+++ b/test/ref_solns/lequere-varmu/restart_output-lequere-varmu.sol.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e64cbb1824733703c7fe41808864287af38e9686436ca296a0a7baa75dec763
+size 106352

--- a/test/valgrind.suppressions
+++ b/test/valgrind.suppressions
@@ -10,6 +10,32 @@
 }
 
 {
+   <mpi-finalize-skip-2>
+   Memcheck:Cond
+   fun:MPIDI_OFI_mpi_finalize_hook
+   fun:MPID_Finalize
+   fun:PMPI_Finalize
+   fun:_ZN4mfem3Mpi8FinalizeEv
+   fun:_ZN4mfem3MpiD1Ev
+   fun:__run_exit_handlers
+   fun:exit
+   fun:(below main)
+}
+
+{
+   <mpi-finalize-skip-3>
+   Memcheck:Cond
+   fun:MPIDI_OFI_mpi_finalize_hook
+   fun:MPID_Finalize
+   fun:PMPI_Finalize
+   fun:_ZN4mfem3Mpi8FinalizeEv
+   fun:_ZN4mfem3MpiD1Ev
+   fun:__run_exit_handlers
+   fun:exit
+   fun:(below main)
+}
+
+{
    <mpi-finalize-skip-4realz>
    Memcheck:Cond
    fun:MPIDI_OFI_mpi_finalize_hook
@@ -22,6 +48,7 @@
    fun:exit
    fun:(below main)
 }
+
 
 {
    <grvy-parse-leak>


### PR DESCRIPTION
This PR adds support for variable density (from thermal effects, i.e., low Mach variable density) and viscosity to the `Tomboulides` class.  It is assumed that the thermal divergence (i.e., Qt) and dynamic viscosity fields are computed externally to the `Tomboulides` class and provided via a `thermoChemToFlow` object, which is part of the `FlowBase` class, from which `Tomboulides` derives.

This PR needs testing prior to merge.  Specifically, the intent is to add regression testing based on the benchmark case from Le Quere et al, "Modelling of a natural convection flows with large temperature differences: A benchmark problem for low Mach number solvers.  Part 1. Reference solutions.", ESAIM: M2AN, v. 39, n. 3, 2005, pp. 609--616.
[(link)](https://www.cambridge.org/core/journals/esaim-mathematical-modelling-and-numerical-analysis/article/abs/modelling-of-natural-convection-flows-with-large-temperature-differences-a-benchmark-problem-for-low-mach-number-solvers-part-1-reference-solutions/114CEBBC04CD332C911B45F65972A262)

closes #248