### PR TITLE
simple auto-periodic option

### DIFF
--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -165,7 +165,7 @@ void LoMachSolver::initialize() {
     }
     if (loMach_opts_.periodicX || loMach_opts_.periodicY || loMach_opts_.periodicZ) {
       loMach_opts_.periodic = true;
-    }    
+    }
   }
 
   // Generate serial mesh, making it periodic if requested

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -163,6 +163,9 @@ void LoMachSolver::initialize() {
     if (loMach_opts_.periodicZ) {
       loMach_opts_.z_trans = zmax_ - zmin_;
     }
+    if (loMach_opts_.periodicX || loMach_opts_.periodicY || loMach_opts_.periodicZ) {
+      loMach_opts_.periodic = true;
+    }    
   }
 
   // Generate serial mesh, making it periodic if requested

--- a/src/loMach.hpp
+++ b/src/loMach.hpp
@@ -144,8 +144,8 @@ class LoMachSolver : public TPS::Solver {
   double hmin, hmax;
 
   // domain extent
-  double xmin, ymin, zmin;
-  double xmax, ymax, zmax;
+  double xmin_, ymin_, zmin_;
+  double xmax_, ymax_, zmax_;
 
   /// Scalar \f$H^1\f$ finite element collection.
   FiniteElementCollection *sfec_ = nullptr;

--- a/src/loMach_options.hpp
+++ b/src/loMach_options.hpp
@@ -99,10 +99,14 @@ class LoMachOptions {
   double scale_mesh;
   int ref_levels; /**< Number of uniform mesh refinements */
 
+  // Periodic domain
   bool periodic;
   double x_trans;
   double y_trans;
   double z_trans;
+  bool periodicX;
+  bool periodicY;
+  bool periodicZ;
 
   // FEM
   int order; /**< Element order */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -43,7 +43,7 @@ EXTRA_DIST  = tap-driver.sh test_tps_splitcomm.py soln_differ inputs meshes lte-
 		      tabulated.test lte_mixture.test distance_fcn.test \
               sgsSmag.test sgsSigma.test heatEq.test sponge.test plate.test pipe.mix.test lte2noneq-restart.test \
               coupled-3d.interface.test plasma.axisym.test plasma.axisym.lte1d.test \
-	      lomach-flow.test lomach-lequere.test interpInlet.test sgsLoMach.test
+	      lomach-flow.test lomach-lequere.test interpInlet.test sgsLoMach.test autoPeriodic.test
 
 TESTS = vpath.sh
 XFAIL_TESTS =
@@ -107,7 +107,8 @@ TESTS += cyl3d.test \
 	 plasma.axisym.lte1d.test \
 	 lomach-flow.test \
 	 lomach-lequere.test \
-         interpInlet.test
+         interpInlet.test \
+         autoPeriodic.test
 
 if PYTHON_ENABLED
 TESTS += cyl3d.python.test \

--- a/test/autoPeriodic.test
+++ b/test/autoPeriodic.test
@@ -1,0 +1,30 @@
+#!./bats
+# -*- mode: sh -*-
+
+TEST="flatBox"
+RUNFILE="inputs/input.autoPeriodic.ini"
+EXE="../src/tps"
+RESTART="ref_solns/sgsLoMach/restart_output.sol.h5"
+
+setup() {
+    SOLN_FILE=restart_output.sol.h5
+    REF_FILE=ref_solns/sgsLoMach/restart_output.sol.h5
+}
+
+@test "[$TEST] check for input file $RUNFILE" {
+    test -s $RUNFILE
+}
+
+@test "[$TEST] run tps with input -> $RUNFILE" {
+    rm -rf output/*
+    rm -f $SOLN_FILE
+    run $EXE --runFile $RUNFILE
+    [[ ${status} -eq 0 ]]
+    test -s $SOLN_FILE
+}
+
+@test "[$TEST] verify tps output with input -> $RUNFILE" {
+    test -s $SOLN_FILE
+    test -s $REF_FILE
+    h5diff -r --delta=1e-12 $SOLN_FILE $REF_FILE /velocity
+}

--- a/test/inputs/input.autoPeriodic.ini
+++ b/test/inputs/input.autoPeriodic.ini
@@ -1,0 +1,52 @@
+[solver]
+type = loMach
+
+[loMach]
+flow-solver = tomboulides
+mesh = meshes/flatBox.msh
+uOrder = 1
+pOrder = 1
+nOrder = 1
+maxIters = 10
+outputFreq = 10
+fluid = dry_air
+refLength = 0.05
+equation_system = navier-stokes
+enablePressureForcing = False
+constantViscosity = 1.552e-5
+constantDensity = 1.1839
+enableGravity = False
+openSystem = True
+ambientPressure = 101326.
+sgsModel = smagorinsky
+sgsModelConstant = 0.09
+
+[loMach/tomboulides]
+ic = tgv2d
+
+[io]
+outdirBase = output
+
+[time]
+cfl = 0.5
+dt_fixed = 1.0e-3
+maxSolverIteration = 1000
+solverRelTolerance = 1.0e-12
+
+[initialConditions]
+rho = 1.1839
+rhoU = 0.
+rhoV = 0.
+rhoW = 0.
+temperature = 298.15
+
+[boundaryConditions]
+numWalls = 0
+numInlets = 0
+numOutlets = 0
+
+[periodicity]
+enablePeriodic = True
+periodicX = True
+periodicY = True
+periodicZ = True


### PR DESCRIPTION
Small addition to determine domain size and allow specification of periodicity via: 

[periodicity]
periodicX = True
periodicY = True
periodicZ = True

instead of having to specify specific translation.  Maintains backwards compatibility but will override translations if both methods are used.  