### PR TITLE
Algebraic RANS closure for the low Mach path

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,7 +39,8 @@ cxx_sources          = averaging.cpp faceGradientIntegration.cpp M2ulPhyS.cpp rh
                        lte_transport_properties.cpp mixing_length_transport.cpp tps2Boltzmann.cpp  M2ulPhyS2Boltzmann.cpp \
                        pybindings.cpp gslib_interpolator.cpp loMach.cpp loMachIO.cpp loMach_options.cpp calorically_perfect.cpp \
 	               thermo_chem_base.cpp split_flow_base.cpp tomboulides.cpp dirichlet_bc_helper.cpp \
-                       sponge_base.cpp geometricSponge.cpp gaussianInterpExtData.cpp turb_model_base.cpp algebraicSubgridModels.cpp
+                       sponge_base.cpp geometricSponge.cpp gaussianInterpExtData.cpp turb_model_base.cpp \
+                       algebraicSubgridModels.cpp algebraic_rans.cpp
 
 mfem_extra_sources   = ../utils/mfem_extras/pfem_extras.cpp
 
@@ -55,7 +56,7 @@ headers              = averaging.hpp equation_of_state.hpp transport_properties.
                        loMach.hpp loMach_options.hpp calorically_perfect.hpp \
 		       thermo_chem_base.hpp split_flow_base.hpp tomboulides.hpp dirichlet_bc_helper.hpp \
                        sponge_base.hpp geometricSponge.hpp externalData_base.hpp gaussianInterpExtData.hpp \
-                       turb_model_base.hpp algebraicSubgridModels.hpp
+                       turb_model_base.hpp algebraicSubgridModels.hpp algebraic_rans.hpp
 
 mfem_extra_headers   = ../utils/mfem_extras/pfem_extras.hpp
 

--- a/src/algebraic_rans.cpp
+++ b/src/algebraic_rans.cpp
@@ -59,6 +59,24 @@ AlgebraicRans::AlgebraicRans(Mesh *smesh, ParMesh *pmesh, const Array<int> &part
   // Build a list of wall patches based on BCs
   Array<int> wall_patch_list;
 
+  int num_walls;
+  tps->getInput("boundaryConditions/numWalls", num_walls, 0);
+
+  // Wall Bcs
+  for (int i = 1; i <= num_walls; i++) {
+    int patch;
+    std::string type;
+    std::string basepath("boundaryConditions/wall" + std::to_string(i));
+
+    tps->getRequiredInput((basepath + "/patch").c_str(), patch);
+    tps->getRequiredInput((basepath + "/type").c_str(), type);
+
+    // NB: Only catch "no-slip" type walls here
+    if (type == "viscous_isothermal" || type == "viscous_adiabatic" || type == "viscous" || type == "no-slip") {
+      wall_patch_list.Append(patch);
+    }
+  }
+
   // Evaluate the (serial) distance function
   evaluateDistanceSerial(*smesh, wall_patch_list, coordinates, serial_distance);
 

--- a/src/algebraic_rans.cpp
+++ b/src/algebraic_rans.cpp
@@ -1,0 +1,99 @@
+// -----------------------------------------------------------------------------------bl-
+// BSD 3-Clause License
+//
+// Copyright (c) 2020-2022, The PECOS Development Team, University of Texas at Austin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// -----------------------------------------------------------------------------------el-
+/** @file
+ * @copydoc algebraic_rans.hpp
+ */
+
+#include "algebraic_rans.hpp"
+
+using namespace mfem;
+
+AlgebraicRans::AlgebraicRans(Mesh *smesh, ParMesh *pmesh, const Array<int> &partitioning, int order, TPS::Tps *tps)
+    : pmesh_(pmesh), order_(order) {
+  // Serial FE space for scalar variable
+  sfec_ = new H1_FECollection(order_);
+  sfes_ = new ParFiniteElementSpace(pmesh_, sfec_);
+
+  FiniteElementSpace serial_fes(smesh, sfec_);
+  GridFunction serial_distance(&serial_fes);
+
+  // Get coordinates from serial mesh
+  if (smesh->GetNodes() == NULL) {
+    smesh->SetCurvature(1);
+  }
+
+  int dim = smesh->Dimension();
+  FiniteElementSpace tmp_dfes(smesh, sfec_, dim, Ordering::byNODES);
+  GridFunction coordinates(&tmp_dfes);
+  smesh->GetNodes(coordinates);
+
+  // Build a list of wall patches based on BCs
+  Array<int> wall_patch_list;
+
+  // Evaluate the (serial) distance function
+  evaluateDistanceSerial(*smesh, wall_patch_list, coordinates, serial_distance);
+
+  // If necessary, parallelize distance function
+  distance_ = new ParGridFunction(pmesh, &serial_distance, partitioning.HostRead());
+  if (partitioning.HostRead() == nullptr) {
+    *distance_ = serial_distance;
+  }
+
+  // Necessary?
+  // distance_->ParFESpace()->ExchangeFaceNbrData();
+  // distance_->ExchangeFaceNbrData();
+}
+
+AlgebraicRans::~AlgebraicRans() {
+  // Alloced in initializeSelf
+  delete mut_;
+
+  // Alloced in ctor
+  delete distance_;
+  delete sfes_;
+  delete sfec_;
+}
+
+void AlgebraicRans::initializeSelf() {
+  mut_ = new ParGridFunction(sfes_);
+  *mut_ = 0.0;
+
+  toFlow_interface_.eddy_viscosity = mut_;
+  toThermoChem_interface_.eddy_viscosity = mut_;
+}
+
+void AlgebraicRans::initializeViz(mfem::ParaViewDataCollection &pvdc) {
+  pvdc.RegisterField("muT", mut_);
+  pvdc.RegisterField("distance", distance_);
+}
+
+void AlgebraicRans::step() {}

--- a/src/algebraic_rans.hpp
+++ b/src/algebraic_rans.hpp
@@ -48,12 +48,24 @@ class AlgebraicRans : public TurbModelBase {
  protected:
   mfem::ParMesh *pmesh_ = nullptr;
   int order_;
+  int dim_;
+  bool axisym_;
+
+  double max_mixing_length_;
+  double kappa_von_karman_;
 
   mfem::FiniteElementCollection *sfec_ = nullptr;
   mfem::ParFiniteElementSpace *sfes_ = nullptr;
 
+  mfem::FiniteElementCollection *vfec_ = nullptr;
+  mfem::ParFiniteElementSpace *vfes_ = nullptr;
+
+  mfem::ParGridFunction *vorticity_gf_ = nullptr;
+  mfem::ParGridFunction *swirl_vorticity_gf_ = nullptr;
+
   mfem::ParGridFunction *mut_ = nullptr;
   mfem::ParGridFunction *distance_ = nullptr;
+  mfem::ParGridFunction *ell_mix_gf_ = nullptr;
 
  public:
   /// Constructor
@@ -64,10 +76,9 @@ class AlgebraicRans : public TurbModelBase {
   virtual ~AlgebraicRans();
 
   /**
-   * @brief Initialize the model-owned data.
+   * @brief Allocate the eddy viscosity
    *
-   * Here, the model-owned data are the eddy viscosity and the
-   * distance function.
+   * Initialized to zero b/c the required interface fields are cannot be assumed valid yet.
    */
   void initializeSelf() override;
 
@@ -77,7 +88,14 @@ class AlgebraicRans : public TurbModelBase {
   void initializeViz(mfem::ParaViewDataCollection &pvdc) override;
 
   /**
-   * @brief Take a single time step
+   * @brief Initialize the eddy viscosity.
+   *
+   * Compute the eddy viscosity by calling "step".
+   */
+  void initializeOperators() override { this->step(); }
+
+  /**
+   * @brief Compute the current eddy viscosity using the current velocity field.
    */
   void step() override;
 

--- a/src/algebraic_rans.hpp
+++ b/src/algebraic_rans.hpp
@@ -1,0 +1,92 @@
+// -----------------------------------------------------------------------------------bl-
+// BSD 3-Clause License
+//
+// Copyright (c) 2020-2022, The PECOS Development Team, University of Texas at Austin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// -----------------------------------------------------------------------------------el-
+#ifndef ALGEBRAIC_RANS_HPP_
+#define ALGEBRAIC_RANS_HPP_
+/** @file
+ * @brief Contains class implementing algebraic RANS model capabilities
+ */
+
+#include "tps.hpp"
+#include "tps_mfem_wrap.hpp"
+#include "turb_model_base.hpp"
+
+/**
+ * Provides algebraic RANS models to compute eddy viscosity
+ * to be used for time split schemes, such as those available through
+ * LoMachSolver
+ */
+class AlgebraicRans : public TurbModelBase {
+ protected:
+  mfem::ParMesh *pmesh_ = nullptr;
+  int order_;
+
+  mfem::FiniteElementCollection *sfec_ = nullptr;
+  mfem::ParFiniteElementSpace *sfes_ = nullptr;
+
+  mfem::ParGridFunction *mut_ = nullptr;
+  mfem::ParGridFunction *distance_ = nullptr;
+
+ public:
+  /// Constructor
+  AlgebraicRans(mfem::Mesh *smesh, mfem::ParMesh *pmesh, const mfem::Array<int> &partitioning, int order,
+                TPS::Tps *tps);
+
+  /// Destructor
+  virtual ~AlgebraicRans();
+
+  /**
+   * @brief Initialize the model-owned data.
+   *
+   * Here, the model-owned data are the eddy viscosity and the
+   * distance function.
+   */
+  void initializeSelf() override;
+
+  /**
+   * @brief Add eddy viscosity and distance function to the visualization output
+   */
+  void initializeViz(mfem::ParaViewDataCollection &pvdc) override;
+
+  /**
+   * @brief Take a single time step
+   */
+  void step() override;
+
+  /**
+   * @brief No-op for this class
+   */
+  void setup() override {}
+
+  mfem::ParGridFunction *getCurrentEddyViscosity() override { return mut_; }
+};
+
+#endif  // ALGEBRAIC_RANS_HPP_

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -44,6 +44,7 @@
 #include <limits>
 
 #include "algebraicSubgridModels.hpp"
+#include "algebraic_rans.hpp"
 #include "calorically_perfect.hpp"
 #include "gaussianInterpExtData.hpp"
 #include "geometricSponge.hpp"

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -330,12 +330,14 @@ void LoMachSolver::initialize() {
   // Instantiate external data
   extData_ = new GaussianInterpExtData(pmesh_, &loMach_opts_, tpsP_);
 
-  // TODO(trevilo): Add support for turbulence modeling
-  if (loMach_opts_.sgs_opts_.sgs_model_type_ == SubGridModelOptions::SMAGORINSKY) {
+  // Instantiate turbulence model
+  if (loMach_opts_.turb_opts_.turb_model_type_ == TurbulenceModelOptions::SMAGORINSKY) {
     turbModel_ = new AlgebraicSubgridModels(pmesh_, &loMach_opts_, tpsP_, 1);
-  } else if (loMach_opts_.sgs_opts_.sgs_model_type_ == SubGridModelOptions::SIGMA) {
+  } else if (loMach_opts_.turb_opts_.turb_model_type_ == TurbulenceModelOptions::SIGMA) {
     turbModel_ = new AlgebraicSubgridModels(pmesh_, &loMach_opts_, tpsP_, 2);
-  } else if (loMach_opts_.sgs_opts_.sgs_model_type_ == SubGridModelOptions::NONE) {
+  } else if (loMach_opts_.turb_opts_.turb_model_type_ == TurbulenceModelOptions::ALGEBRAIC_RANS) {
+    turbModel_ = new AlgebraicRans(serial_mesh_, pmesh_, partitioning_, loMach_opts_.order, tpsP_);
+  } else if (loMach_opts_.turb_opts_.turb_model_type_ == TurbulenceModelOptions::NONE) {
     // default
     turbModel_ = new ZeroTurbModel(pmesh_, loMach_opts_.order);
   } else {
@@ -345,8 +347,6 @@ void LoMachSolver::initialize() {
     }
     exit(ERROR);
   }
-  // Turbulence modeling not supported yet
-  // assert(loMach_opts_.sgs_opts_.sgs_model_type_ == SubGridModelOptions::NONE);
 
   // Instantiate thermochemical model
   if (loMach_opts_.thermo_solver == "constant-property") {
@@ -880,8 +880,8 @@ void LoMachSolver::parseSolverOptions() {
   tpsP_->getInput("loMach/outputFreq", loMach_opts_.output_frequency_, 50);
   tpsP_->getInput("loMach/timingFreq", loMach_opts_.timing_frequency_, 100);
 
-  // SGS model options
-  loMach_opts_.sgs_opts_.read(tpsP_, std::string("loMach"));
+  // Turbulence model options
+  loMach_opts_.turb_opts_.read(tpsP_, std::string("loMach"));
 
   // time integration controls
   loMach_opts_.ts_opts_.read(tpsP_);

--- a/src/loMach_options.cpp
+++ b/src/loMach_options.cpp
@@ -34,15 +34,17 @@
 
 #include "tps.hpp"
 
-SubGridModelOptions::SubGridModelOptions() : sgs_model_string_("none"), sgs_model_constant_(0.0), exclude_mean_(false) {
-  sgs_model_map_["none"] = NONE;
-  sgs_model_map_["smagorinsky"] = SMAGORINSKY;
-  sgs_model_map_["sigma"] = SIGMA;
+TurbulenceModelOptions::TurbulenceModelOptions()
+    : turb_model_string_("none"), turb_model_constant_(0.0), exclude_mean_(false) {
+  turb_model_map_["none"] = NONE;
+  turb_model_map_["smagorinsky"] = SMAGORINSKY;
+  turb_model_map_["sigma"] = SIGMA;
+  turb_model_map_["algebraic-rans"] = ALGEBRAIC_RANS;
 
-  sgs_model_type_ = sgs_model_map_[sgs_model_string_];
+  turb_model_type_ = turb_model_map_[turb_model_string_];
 }
 
-void SubGridModelOptions::read(TPS::Tps *tps, std::string prefix) {
+void TurbulenceModelOptions::read(TPS::Tps *tps, std::string prefix) {
   // At the moment, SGS model options are under either "flow" or
   // "loMach", so we must have a prefix
   assert(!prefix.empty());
@@ -52,22 +54,26 @@ void SubGridModelOptions::read(TPS::Tps *tps, std::string prefix) {
     basename = prefix + "/";
   }
 
-  tps->getInput((basename + "sgsModel").c_str(), sgs_model_string_, std::string("none"));
+  // Accept either sgsModel or turb-model
+  tps->getInput((basename + "sgsModel").c_str(), turb_model_string_, std::string("none"));
+  if (turb_model_string_ == "none") {
+    tps->getInput((basename + "turb-model").c_str(), turb_model_string_, std::string("none"));
+  }
   tps->getInput((basename + "sgsExcludeMean").c_str(), exclude_mean_, false);
 
   // Set model type
-  sgs_model_type_ = sgs_model_map_[sgs_model_string_];
+  turb_model_type_ = turb_model_map_[turb_model_string_];
 
   // Set default constant based on model type
-  double default_sgs_const = 0.;
-  if (sgs_model_type_ == SMAGORINSKY) {
-    default_sgs_const = 0.12;
-  } else if (sgs_model_type_ == SIGMA) {
-    default_sgs_const = 0.135;
+  double default_turb_const = 0.;
+  if (turb_model_type_ == SMAGORINSKY) {
+    default_turb_const = 0.12;
+  } else if (turb_model_type_ == SIGMA) {
+    default_turb_const = 0.135;
   }
 
   // Get model constant (set to default if not present)
-  tps->getInput((basename + "sgsModelConstant").c_str(), sgs_model_constant_, default_sgs_const);
+  tps->getInput((basename + "sgsModelConstant").c_str(), turb_model_constant_, default_turb_const);
 }
 
 LoMachTemporalOptions::LoMachTemporalOptions()

--- a/src/loMach_options.hpp
+++ b/src/loMach_options.hpp
@@ -43,18 +43,18 @@ namespace TPS {
 class Tps;
 }
 
-class SubGridModelOptions {
+class TurbulenceModelOptions {
  public:
-  SubGridModelOptions();
+  TurbulenceModelOptions();
   void read(TPS::Tps *tps, std::string prefix = std::string(""));
 
-  enum SubGridModelType { NONE, SMAGORINSKY, SIGMA };
+  enum TurbulenceModelType { NONE, SMAGORINSKY, SIGMA, ALGEBRAIC_RANS };
 
-  std::string sgs_model_string_;
-  std::map<std::string, SubGridModelType> sgs_model_map_;
-  SubGridModelType sgs_model_type_;
+  std::string turb_model_string_;
+  std::map<std::string, TurbulenceModelType> turb_model_map_;
+  TurbulenceModelType turb_model_type_;
 
-  double sgs_model_constant_;
+  double turb_model_constant_;
   bool exclude_mean_;
 };
 
@@ -92,7 +92,7 @@ class LoMachOptions {
   LoMachTemporalOptions ts_opts_;
 
   // SGS-related options
-  SubGridModelOptions sgs_opts_;
+  TurbulenceModelOptions turb_opts_;
 
   // Mesh-related options
   std::string mesh_file; /**< Mesh filename */

--- a/src/split_flow_base.hpp
+++ b/src/split_flow_base.hpp
@@ -51,6 +51,11 @@ struct flowToThermoChem {
 };
 
 struct flowToTurbModel {
+  const mfem::ParGridFunction *velocity = nullptr;
+
+  bool swirl_supported = false;
+  const mfem::ParGridFunction *swirl = nullptr;
+
   const mfem::ParGridFunction *gradU = nullptr;
   const mfem::ParGridFunction *gradV = nullptr;
   const mfem::ParGridFunction *gradW = nullptr;

--- a/src/tomboulides.cpp
+++ b/src/tomboulides.cpp
@@ -427,6 +427,11 @@ void Tomboulides::initializeSelf() {
     toThermoChem_interface_.swirl = utheta_next_gf_;
   }
 
+  toTurbModel_interface_.velocity = u_next_gf_;
+  if (axisym_) {
+    toTurbModel_interface_.swirl_supported = true;
+    toTurbModel_interface_.swirl = utheta_next_gf_;
+  }
   toTurbModel_interface_.gradU = gradU_gf_;
   toTurbModel_interface_.gradV = gradV_gf_;
   toTurbModel_interface_.gradW = gradW_gf_;

--- a/src/tomboulides.hpp
+++ b/src/tomboulides.hpp
@@ -164,6 +164,9 @@ class Tomboulides final : public FlowBase {
   mfem::ParGridFunction *utheta_next_gf_ = nullptr;
   mfem::ParGridFunction *u_next_rad_comp_gf_ = nullptr;
 
+  /// "total" viscosity, including fluid, turbulence, sponge
+  mfem::ParGridFunction *mu_total_gf_ = nullptr;
+
   /// mfem::Coefficients used in forming necessary operators
   mfem::GridFunctionCoefficient *rho_coeff_ = nullptr;
   mfem::RatioCoefficient *iorho_coeff_ = nullptr;
@@ -172,10 +175,6 @@ class Tomboulides final : public FlowBase {
   mfem::ConstantCoefficient Hv_bdfcoeff_;
   mfem::ProductCoefficient *rho_over_dt_coeff_ = nullptr;
   mfem::GridFunctionCoefficient *mu_coeff_ = nullptr;
-  mfem::GridFunctionCoefficient *mut_coeff_ = nullptr;
-  mfem::GridFunctionCoefficient *mult_coeff_ = nullptr;
-  mfem::SumCoefficient *mu_sum_coeff_ = nullptr;
-  mfem::ProductCoefficient *mu_total_coeff_ = nullptr;
   mfem::VectorGridFunctionCoefficient *pp_div_coeff_ = nullptr;
 
   mfem::GradientGridFunctionCoefficient *grad_mu_coeff_ = nullptr;
@@ -311,6 +310,11 @@ class Tomboulides final : public FlowBase {
    * @brief Zero the mean of the input function
    */
   void meanZero(mfem::ParGridFunction &v);
+
+  /**
+   * @brief Update total viscosity using latest inputs
+   */
+  void updateTotalViscosity();
 
  public:
   /// Constructor

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -160,12 +160,12 @@ void multScalarVectorIP(Vector A, Vector *C, int dim = 3);
 void setScalarFromVector(Vector A, int ind, Vector *C);
 
 /// Compute \f$\nabla \times \nabla \times u\f$ for \f$u \in (H^1)^2\f$.
-void ComputeCurl2D(ParGridFunction &u, ParGridFunction &cu, bool assume_scalar = false);
+void ComputeCurl2D(const ParGridFunction &u, ParGridFunction &cu, bool assume_scalar = false);
 
-void ComputeCurlAxi(ParGridFunction &u, ParGridFunction &cu, bool assume_scalar = false);
+void ComputeCurlAxi(const ParGridFunction &u, ParGridFunction &cu, bool assume_scalar = false);
 
 /// Compute \f$\nabla \times \nabla \times u\f$ for \f$u \in (H^1)^3\f$.
-void ComputeCurl3D(ParGridFunction &u, ParGridFunction &cu);
+void ComputeCurl3D(const ParGridFunction &u, ParGridFunction &cu);
 
 void vectorGrad3D(ParGridFunction &u, ParGridFunction &gu, ParGridFunction &gv, ParGridFunction &gw);
 void scalarGrad3D(ParGridFunction &u, ParGridFunction &gu);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -30,6 +30,7 @@ EXTRA_DIST  = tap-driver.sh test_tps_splitcomm.py soln_differ inputs meshes lte-
               ref_solns/sgsLoMach/*.h5 \
 	      ref_solns/lequere-varmu/*.h5 \
 	      ref_solns/taylor-couette/*.h5 \
+	      ref_solns/pipe/*.h5 \
 		      vpath.sh die.sh count_gpus.sh sniff_mpirun.sh \
 		      cyl3d.gpu.test cyl3d.mflow.gpu.test wedge.gpu.test \
 	          averaging.gpu.test cyl3d.test cyl3d.gpu.python.test cyl3d.mflow.test cyl3d.dtconst.test \

--- a/test/inputs/lomach.pipe.arans.ini
+++ b/test/inputs/lomach.pipe.arans.ini
@@ -5,25 +5,31 @@ type = loMach
 axisymmetric = true
 mesh = meshes/axi-pipe.msh
 ref_levels = 0
-flow-solver = tomboulides
-order = 1
-maxIters = 1000
+order = 2
+maxIters = 200
 outputFreq = 100
 timingFreq = 10
+flow-solver = tomboulides
+thermo-solver = constant-property
+constprop/rho = 1.0
+constprop/mu = 1e-4
+turb-model = algebraic-rans
+algebraic-rans/max-mixing-length = 0.2
+algebraic-rans/von-karman = 0.41
 
 [loMach/tomboulides]
 numerical-integ = false
 
 [io]
-outdirBase = output-pipe-lam
+outdirBase = output-pipe-arans
 #enableRestart = True
 
 # Set bdfOrder = 1 for restart testing purposes
 [time]
 enableConstantTimestep = True
-dt_fixed = 0.1
+dt_fixed = 0.05
 integrator = curlcurl
-bdfOrder = 1
+bdfOrder = 3
 maxSolverIteration = 200
 solverRelTolerance = 1.0e-12
 

--- a/test/lomach-flow.test
+++ b/test/lomach-flow.test
@@ -15,9 +15,13 @@ setup() {
     RUNFILE_LID_MOD="inputs/lomach.lid.mod.ini"
 
     RUNFILE_PIPE="inputs/lomach.pipe.ini"
+    REF_SOLN_PIPE="ref_solns/pipe/restart_output-pipe-lam.sol.h5"
 
     RUNFILE_TC="inputs/lomach.taylor.couette.ini"
     REF_SOLN_TC="ref_solns/taylor-couette/restart_output-tc.Re100.h5"
+
+    RUNFILE_PIPE_ARANS="inputs/lomach.pipe.arans.ini"
+    REF_SOLN_PIPE_ARANS="ref_solns/pipe/restart_output-pipe-arans.sol.h5"
 }
 
 @test "[$TEST] check convergence for 2D Taylor-Green case using p = 1" {
@@ -113,6 +117,9 @@ setup() {
 @test "[$TEST] check that fully developed pipe (axisymmetric) runs" {
     run $EXE --runFile $RUNFILE_PIPE
     [[ ${status} -eq 0 ]]
+    test -s restart_output-pipe-lam.sol.h5
+    h5diff -r --delta=1e-16 restart_output-pipe-lam.sol.h5 $REF_SOLN_PIPE /velocity
+    h5diff -r --delta=1e-16 restart_output-pipe-lam.sol.h5 $REF_SOLN_PIPE /swirl
 }
 
 @test "[$TEST] check that Taylor-Couette (axisymmetric, with swirl) runs and verify result" {
@@ -121,4 +128,12 @@ setup() {
     test -s restart_output-tc.sol.h5
     h5diff -r --delta=1e-16 restart_output-tc.sol.h5 $REF_SOLN_TC /velocity
     h5diff -r --delta=1e-16 restart_output-tc.sol.h5 $REF_SOLN_TC /swirl
+}
+
+@test "[$TEST] check pipe (axisymmetric) flow with algebraic rans model" {
+    run $EXE --runFile $RUNFILE_PIPE_ARANS
+    [[ ${status} -eq 0 ]]
+    test -s restart_output-pipe-arans.sol.h5
+    h5diff -r --delta=1e-16 restart_output-pipe-arans.sol.h5 $REF_SOLN_PIPE_ARANS /velocity
+    h5diff -r --delta=1e-16 restart_output-pipe-arans.sol.h5 $REF_SOLN_PIPE_ARANS /swirl
 }

--- a/test/ref_solns/.gitattributes
+++ b/test/ref_solns/.gitattributes
@@ -4,3 +4,5 @@ plasma.lte2d.final.h5 filter=lfs diff=lfs merge=lfs -text
 plasma.lte2d.restart.h5 filter=lfs diff=lfs merge=lfs -text
 ref_solns/heatedBox/restart_output.sol.h5 filter=lfs diff=lfs merge=lfs -text
 taylor-couette/restart_output-tc.Re100.h5 filter=lfs diff=lfs merge=lfs -text
+pipe/restart_output-pipe-lam.sol.h5 filter=lfs diff=lfs merge=lfs -text
+pipe/restart_output-pipe-arans.sol.h5 filter=lfs diff=lfs merge=lfs -text

--- a/test/ref_solns/pipe/restart_output-pipe-arans.sol.h5
+++ b/test/ref_solns/pipe/restart_output-pipe-arans.sol.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a29d7decef0a098b2b86ea5cab326b107c862d80e4bc394f9da814ed1f828679
+size 56432

--- a/test/ref_solns/pipe/restart_output-pipe-lam.sol.h5
+++ b/test/ref_solns/pipe/restart_output-pipe-lam.sol.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fe39fdee999551ea2e82c2e492f0cafd8567e9c0bae0066a02063e05cac8bc4
+size 18416

--- a/test/ref_solns/sgsLoMach/restart_output.sol.h5
+++ b/test/ref_solns/sgsLoMach/restart_output.sol.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:136c60405aa0bc6f51a6ae7cebe16b97e4fd87e87d3bc02db114ace934fa02be
+oid sha256:822e811b553e772688706c574e628cfed52240a51db2585896f0bee012a2cf03
 size 78680


### PR DESCRIPTION
This PR implements the simplest possible algebraic eddy viscosity model in the structure of the low Mach path (i.e., as a class called `AlgebraicRans` that derives from `TurbModelBase`).

The PR also includes minor bug fixes in `Tomboulides` to ensure that the correct viscosity (i.e., the combination of the fluid viscosity, the eddy viscosity, and the sponge) is used in the variable viscosity terms.