### PR TITLE
Screen output upgrades for low Mach

### DIFF
--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -983,6 +983,16 @@ void CaloricallyPerfectThermoChem::computeQtTO() {
   Qt_gf_.SetFromTrueDofs(Qt_);
 }
 
+void CaloricallyPerfectThermoChem::screenHeader(std::vector<std::string> &header) const {
+  header.resize(1);
+  header[0] = "P/P0";
+}
+
+void CaloricallyPerfectThermoChem::screenValues(std::vector<double> &values) {
+  values.resize(1);
+  values[0] = thermo_pressure_ / ambient_pressure_;
+}
+
 #if 0
 // Temporarily remove viscous sponge capability.  This sould be housed
 // in a separate class that we just instantiate and call, rather than

--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -984,13 +984,17 @@ void CaloricallyPerfectThermoChem::computeQtTO() {
 }
 
 void CaloricallyPerfectThermoChem::screenHeader(std::vector<std::string> &header) const {
-  header.resize(1);
-  header[0] = "P/P0";
+  if (!domain_is_open_) {
+    header.resize(1);
+    header[0] = "P/P0";
+  }
 }
 
 void CaloricallyPerfectThermoChem::screenValues(std::vector<double> &values) {
-  values.resize(1);
-  values[0] = thermo_pressure_ / ambient_pressure_;
+  if (!domain_is_open_) {
+    values.resize(1);
+    values[0] = thermo_pressure_ / ambient_pressure_;
+  }
 }
 
 #if 0

--- a/src/calorically_perfect.hpp
+++ b/src/calorically_perfect.hpp
@@ -215,6 +215,9 @@ class CaloricallyPerfectThermoChem : public ThermoChemModelBase {
   void initializeIO(IODataOrganizer &io) final;
   void initializeViz(ParaViewDataCollection &pvdc) final;
 
+  void screenHeader(std::vector<std::string> &header) const final;
+  void screenValues(std::vector<double> &values) final;
+
   // Functions added here
   void updateThermoP();
   void extrapolateState();

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -486,6 +486,14 @@ void LoMachSolver::solveBegin() {
     std::cout << "Starting main loop, from " << iter_start_ << " to " << loMach_opts_.max_steps_ << endl;
   }
 
+  std::vector<std::string> flow_header;
+  flow_->screenHeader(flow_header);
+
+  // NB: Called on all ranks, but only rank 0 prints.  We assume any
+  // necessary communication is handled by the flow class
+  std::vector<double> flow_screen_values;
+  flow_->screenValues(flow_screen_values);
+
   if (rank0_) {
     // TODO(trevilo): Add state summary
     std::cout << std::endl;
@@ -493,6 +501,10 @@ void LoMachSolver::solveBegin() {
     std::cout << std::setw(13) << "Time ";
     std::cout << std::setw(13) << "dt ";
     std::cout << std::setw(13) << "Wtime/Step ";
+    for (size_t i = 0; i < flow_header.size(); i++) {
+      std::cout << std::setw(12) << flow_header[i] << " ";
+    }
+
     std::cout << std::endl;
     std::cout << "#==================================================================" << std::endl;
 
@@ -500,6 +512,9 @@ void LoMachSolver::solveBegin() {
     std::cout << std::setw(10) << std::scientific << temporal_coeff_.time << " ";
     std::cout << std::setw(10) << std::scientific << temporal_coeff_.dt << " ";
     std::cout << std::setw(10) << std::scientific << 0.0 << " ";
+    for (size_t i = 0; i < flow_screen_values.size(); i++) {
+      std::cout << std::setw(10) << std::scientific << flow_screen_values[i] << " ";
+    }
     std::cout << std::endl;
   }
 }
@@ -528,12 +543,20 @@ void LoMachSolver::solveStep() {
     double max_time_per_step = 0.0;
     MPI_Reduce(&time_per_step, &max_time_per_step, 1, MPI_DOUBLE, MPI_MAX, 0, groupsMPI->getTPSCommWorld());
 
+    // NB: Called on all ranks, but only rank 0 prints.  We assume any
+    // necessary communication is handled by the flow class
+    std::vector<double> flow_screen_values;
+    flow_->screenValues(flow_screen_values);
+
     if (rank0_) {
       // TODO(trevilo): Add state summary
       std::cout << std::setw(10) << iter << " ";
       std::cout << std::setw(10) << std::scientific << temporal_coeff_.time << " ";
       std::cout << std::setw(10) << std::scientific << temporal_coeff_.dt << " ";
       std::cout << std::setw(10) << std::scientific << max_time_per_step << " ";
+      for (size_t i = 0; i < flow_screen_values.size(); i++) {
+        std::cout << std::setw(10) << std::scientific << flow_screen_values[i] << " ";
+      }
       std::cout << std::endl;
     }
   }

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -486,11 +486,17 @@ void LoMachSolver::solveBegin() {
     std::cout << "Starting main loop, from " << iter_start_ << " to " << loMach_opts_.max_steps_ << endl;
   }
 
+  std::vector<std::string> thermo_header;
+  thermo_->screenHeader(thermo_header);
+
   std::vector<std::string> flow_header;
   flow_->screenHeader(flow_header);
 
   // NB: Called on all ranks, but only rank 0 prints.  We assume any
   // necessary communication is handled by the flow class
+  std::vector<double> thermo_screen_values;
+  thermo_->screenValues(thermo_screen_values);
+
   std::vector<double> flow_screen_values;
   flow_->screenValues(flow_screen_values);
 
@@ -501,6 +507,9 @@ void LoMachSolver::solveBegin() {
     std::cout << std::setw(13) << "Time ";
     std::cout << std::setw(13) << "dt ";
     std::cout << std::setw(13) << "Wtime/Step ";
+    for (size_t i = 0; i < thermo_header.size(); i++) {
+      std::cout << std::setw(12) << thermo_header[i] << " ";
+    }
     for (size_t i = 0; i < flow_header.size(); i++) {
       std::cout << std::setw(12) << flow_header[i] << " ";
     }
@@ -512,6 +521,9 @@ void LoMachSolver::solveBegin() {
     std::cout << std::setw(10) << std::scientific << temporal_coeff_.time << " ";
     std::cout << std::setw(10) << std::scientific << temporal_coeff_.dt << " ";
     std::cout << std::setw(10) << std::scientific << 0.0 << " ";
+    for (size_t i = 0; i < thermo_screen_values.size(); i++) {
+      std::cout << std::setw(10) << std::scientific << thermo_screen_values[i] << " ";
+    }
     for (size_t i = 0; i < flow_screen_values.size(); i++) {
       std::cout << std::setw(10) << std::scientific << flow_screen_values[i] << " ";
     }
@@ -545,6 +557,9 @@ void LoMachSolver::solveStep() {
 
     // NB: Called on all ranks, but only rank 0 prints.  We assume any
     // necessary communication is handled by the flow class
+    std::vector<double> thermo_screen_values;
+    thermo_->screenValues(thermo_screen_values);
+
     std::vector<double> flow_screen_values;
     flow_->screenValues(flow_screen_values);
 
@@ -554,6 +569,9 @@ void LoMachSolver::solveStep() {
       std::cout << std::setw(10) << std::scientific << temporal_coeff_.time << " ";
       std::cout << std::setw(10) << std::scientific << temporal_coeff_.dt << " ";
       std::cout << std::setw(10) << std::scientific << max_time_per_step << " ";
+      for (size_t i = 0; i < thermo_screen_values.size(); i++) {
+        std::cout << std::setw(10) << std::scientific << thermo_screen_values[i] << " ";
+      }
       for (size_t i = 0; i < flow_screen_values.size(); i++) {
         std::cout << std::setw(10) << std::scientific << flow_screen_values[i] << " ";
       }

--- a/src/split_flow_base.hpp
+++ b/src/split_flow_base.hpp
@@ -91,6 +91,22 @@ class FlowBase {
   virtual void initializeIO(IODataOrganizer &io) const {}
   virtual void initializeViz(mfem::ParaViewDataCollection &pvdc) const {}
 
+  /**
+   * @brief Header strings for screen dump
+   *
+   * Provides a hook for derived classes to pass a set of header
+   * strings that will be printed to the screen
+   */
+  virtual void screenHeader(std::vector<std::string> &header) const { header.resize(0); }
+
+  /**
+   * @brief Values for screen dump
+   *
+   * Provides values that will be printed to the screen at user requested
+   * frequency (as often as each iteration).
+   */
+  virtual void screenValues(std::vector<double> &values) { values.resize(0); }
+
   /// Interface object, provides fields necessary for the thermochemistry model
   flowToThermoChem toThermoChem_interface_;
 

--- a/src/thermo_chem_base.hpp
+++ b/src/thermo_chem_base.hpp
@@ -119,6 +119,22 @@ class ThermoChemModelBase {
   virtual void initializeViz(mfem::ParaViewDataCollection &pvdc) {}
 
   /**
+   * @brief Header strings for screen dump
+   *
+   * Provides a hook for derived classes to pass a set of header
+   * strings that will be printed to the screen
+   */
+  virtual void screenHeader(std::vector<std::string> &header) const { header.resize(0); }
+
+  /**
+   * @brief Values for screen dump
+   *
+   * Provides values that will be printed to the screen at user requested
+   * frequency (as often as each iteration).
+   */
+  virtual void screenValues(std::vector<double> &values) { values.resize(0); }
+
+  /**
    * @brief Initialize data from the flow class
    *
    * Initialize fields that the thermochemistry model needs from the

--- a/src/tomboulides.hpp
+++ b/src/tomboulides.hpp
@@ -354,6 +354,18 @@ class Tomboulides final : public FlowBase {
   /// Advance
   void step() final;
 
+  void screenHeader(std::vector<std::string> &header) const final {
+    int nprint = 1;
+    header.resize(nprint);
+    header[0] = std::string("Max vel.");
+  }
+
+  void screenValues(std::vector<double> &values) final {
+    int nprint = 1;
+    values.resize(nprint);
+    values[0] = maxVelocityMagnitude();
+  }
+
   mfem::ParGridFunction *getCurrentVelocity() final { return u_curr_gf_; }
 
   /// Evaluate error (only when exact solution is known)
@@ -369,6 +381,9 @@ class Tomboulides final : public FlowBase {
 
   /// Add constant swirl
   void addSwirlDirichletBC(double ut, mfem::Array<int> &attr);
+
+  /// Compute maximum velocity magnitude anywhere in the domain
+  double maxVelocityMagnitude();
 };
 
 #endif  // TOMBOULIDES_HPP_


### PR DESCRIPTION
This PR adds a mechanism for the low Mach solver to echo information from the physics classes to the screen.  So far, we have just a minimal working example for the flow and thermo classes.

TODO before merging:

- [x] Revise `CaloricallyPerfectThermoChem` to only print pressure ratio for closed domain cases (since it is trivially 1 for open domains)
