### PR TITLE
Enable variable p restarts on low Mach path

### DIFF
--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -722,7 +722,7 @@ void CaloricallyPerfectThermoChem::computeExplicitTempConvectionOP(bool extrap) 
 }
 
 void CaloricallyPerfectThermoChem::initializeIO(IODataOrganizer &io) {
-  io.registerIOFamily("Temperature", "/temperature", &Tn_gf_, false);
+  io.registerIOFamily("Temperature", "/temperature", &Tn_gf_, true, true, sfec_);
   io.registerIOVar("/temperature", "temperature", 0);
 }
 

--- a/src/tomboulides.cpp
+++ b/src/tomboulides.cpp
@@ -1000,13 +1000,13 @@ void Tomboulides::initializeOperators() {
 }
 
 void Tomboulides::initializeIO(IODataOrganizer &io) const {
-  io.registerIOFamily("Velocity", "/velocity", u_curr_gf_, false);
+  io.registerIOFamily("Velocity", "/velocity", u_curr_gf_, true, true, vfec_);
   io.registerIOVar("/velocity", "x-comp", 0);
   if (dim_ >= 2) io.registerIOVar("/velocity", "y-comp", 1);
   if (dim_ == 3) io.registerIOVar("/velocity", "z-comp", 2);
 
   if (axisym_) {
-    io.registerIOFamily("Velocity azimuthal", "/swirl", utheta_gf_, false);
+    io.registerIOFamily("Velocity azimuthal", "/swirl", utheta_gf_, true, true, pfec_);
     io.registerIOVar("/swirl", "swirl", 0);
   }
 }


### PR DESCRIPTION
This PR corrects a mistake in the restart implementation on the low Mach path that inadvertantly disabled variable order restarts.