### PR TITLE
Fixes and testing for `Tomboulides` class in gpu builds

### DIFF
--- a/src/tomboulides.cpp
+++ b/src/tomboulides.cpp
@@ -253,10 +253,13 @@ void Tomboulides::initializeSelf() {
 
   mu_total_gf_ = new ParGridFunction(pfes_);
 
-  pp_div_rad_comp_gf_ = new ParGridFunction(pfes_, *pp_div_gf_);
-  u_next_rad_comp_gf_ = new ParGridFunction(pfes_, *u_next_gf_);
+  // pp_div_rad_comp_gf_ = new ParGridFunction(pfes_, *pp_div_gf_);
+  // u_next_rad_comp_gf_ = new ParGridFunction(pfes_, *u_next_gf_);
 
   if (axisym_) {
+    pp_div_rad_comp_gf_ = new ParGridFunction(pfes_);
+    u_next_rad_comp_gf_ = new ParGridFunction(pfes_);
+
     utheta_gf_ = new ParGridFunction(pfes_);
     utheta_next_gf_ = new ParGridFunction(pfes_);
   }
@@ -1365,7 +1368,19 @@ void Tomboulides::step() {
   // Add axisymmetric "forcing" term to rhs
   if (axisym_) {
     pp_div_gf_->HostRead();
+    {
+      // Copy radial components of pp_div_gf_.  We should be able to
+      // just make pp_div_rad_comp_gf_ wrap pp_div_gf_, but that is
+      // causing problems (that aren't understood) on some gpu
+      // systems.  As a workaround, we copy instead.
+      auto d_pp_div_rad = pp_div_rad_comp_gf_->Write();
+      auto d_pp_div = pp_div_gf_->Read();
+      MFEM_FORALL(i, pp_div_rad_comp_gf_->Size(), {
+          d_pp_div_rad[i] = d_pp_div[i];
+        });
+    }
     pp_div_rad_comp_gf_->HostRead();
+
     Faxi_poisson_form_->Update();
     Faxi_poisson_form_->Assemble();
     Faxi_poisson_form_->ParallelAssemble(Faxi_poisson_vec_);
@@ -1469,6 +1484,18 @@ void Tomboulides::step() {
   evaluateVelocityGradient();
 
   if (axisym_) {
+    u_next_gf_->HostRead();
+    {
+      // Copy radial components of u_next_gf_.  Same comments here
+      // about pp_div_rad_comp_gf_ above.
+      auto d_u_next_rad = u_next_rad_comp_gf_->Write();
+      auto d_u_next = u_next_gf_->Read();
+      MFEM_FORALL(i, u_next_rad_comp_gf_->Size(), {
+          d_u_next_rad[i] = d_u_next[i];
+        });
+    }
+    u_next_rad_comp_gf_->HostRead();
+
     // Update the Helmholtz operator and inverse
     Hv_bdfcoeff_.constant = coeff_.bd0 / dt;
     Hs_form_->Update();

--- a/src/tomboulides.cpp
+++ b/src/tomboulides.cpp
@@ -1364,6 +1364,8 @@ void Tomboulides::step() {
 
   // Add axisymmetric "forcing" term to rhs
   if (axisym_) {
+    pp_div_gf_->HostRead();
+    pp_div_rad_comp_gf_->HostRead();
     Faxi_poisson_form_->Update();
     Faxi_poisson_form_->Assemble();
     Faxi_poisson_form_->ParallelAssemble(Faxi_poisson_vec_);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -705,7 +705,12 @@ void ComputeCurl3D(const ParGridFunction &u, ParGridFunction &cu) {
   zones_per_vdof.SetSize(fes->GetVSize());
   zones_per_vdof = 0;
 
-  cu = 0.0;
+  // Force data copy to host (b/c host data used below)
+  u.HostRead();
+
+  // Initialize curl
+  cu = 0.0;            // On device (if present)
+  cu.HostReadWrite();  // Copy to host and invalidate device data (b/c host written to below)
 
   // Local interpolation.
   int elndofs;
@@ -920,7 +925,12 @@ void ComputeCurl2D(const ParGridFunction &u, ParGridFunction &cu, bool assume_sc
   zones_per_vdof.SetSize(fes->GetVSize());
   zones_per_vdof = 0;
 
-  cu = 0.0;
+  // Force data copy to host (b/c host data used below)
+  u.HostRead();
+
+  // Initialize curl
+  cu = 0.0;            // On device (if present)
+  cu.HostReadWrite();  // Copy to host and invalidate device data (b/c host written to below)
 
   // Local interpolation.
   int elndofs;
@@ -1010,7 +1020,12 @@ void ComputeCurlAxi(const ParGridFunction &u, ParGridFunction &cu, bool assume_s
   zones_per_vdof.SetSize(cfes->GetVSize());
   zones_per_vdof = 0;
 
-  cu = 0.0;
+  // Force data copy to host (b/c host data used below)
+  u.HostRead();
+
+  // Initialize curl
+  cu = 0.0;            // On device (if present)
+  cu.HostReadWrite();  // Copy to host and invalidate device data (b/c host written to below)
 
   // Local interpolation.
   int elndofs;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -69,7 +69,10 @@ TESTS += cyl3d.gpu.test \
 	 heatEq.test \
          plate.test \
 	 pipe.mix.test \
-	 plasma.axisym.lte1d.test
+	 plasma.axisym.lte1d.test \
+         sgsLoMach.test \
+	 lomach-flow.test \
+	 lomach-lequere.test
 
 if PYTHON_ENABLED
 TESTS += cyl3d.gpu.python.test


### PR DESCRIPTION
This PR adds some bug fixes and testing for the low Mach flow solver in gpu builds.  Three notes:

1. Much of the work of the flow solver is not offloaded to the gpu yet, so there is development to do to get better performance.  This is left for a separate PR, but this PR establishes some regression tests that can be used during that effort.
2. Some tolerances had to be relaxed (namely in `lomach-lequere.test`), which is expected b/c the environment is different from that where the regression tests were established.
3. Non-deterministic behavior (at levels below the tolerances) has been observed in gpu builds (specifically cuda; hip has not been examined yet).  This is attributed to non-determinism in linear algebra, specifically `cusparse_SpMV` using `CUSPARSE_SPMV_CSR_ALG1` (see documentation [here](https://docs.nvidia.com/cuda/cusparse/#cusparsespmv)) but this should be examined more carefully.