### PR TITLE
Enable serialized restart capability for the low Mach solvers

### DIFF
--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -211,7 +211,8 @@ void LoMachSolver::initialize() {
 
   const bool restart_serial =
       (loMach_opts_.io_opts_.restart_serial_read_ || loMach_opts_.io_opts_.restart_serial_write_);
-  ioData.initializeSerial(rank0_, restart_serial, serial_mesh_, locToGlobElem, &partitioning_);
+  ioData.initializeSerial(rank0_, restart_serial, serial_mesh_, meshData_->getLocalToGlobalElementMap(),
+                          &partitioning_);
   // MPI_Barrier(groupsMPI->getTPSCommWorld());
   if (verbose) grvy_printf(ginfo, "ioData.init thingy...\n");
 

--- a/src/loMach.hpp
+++ b/src/loMach.hpp
@@ -132,9 +132,6 @@ class LoMachSolver : public TPS::Solver {
   int dim_;
   int nvel_;
 
-  // mapping from local to global element index
-  int *locToGlobElem = nullptr;
-
   // total number of mesh elements (serial)
   int nelemGlobal_;
 

--- a/src/mesh_base.cpp
+++ b/src/mesh_base.cpp
@@ -175,9 +175,13 @@ void MeshBase::initializeMesh() {
     if (rank0_) grvy_printf(ginfo, "Total # of mesh elements = %i\n", nelemGlobal_);
 
     if (nprocs_ > 1) {
-      assert(!loMach_opts_->io_opts_.restart_serial_read_);
-      // TODO(trevilo): Add support for serial read/write
-      partitioning_file_hdf5("read", groupsMPI, nelemGlobal_, partitioning_);
+      if (loMach_opts_->io_opts_.restart_serial_read_) {
+        assert(serial_mesh_->Conforming());
+        partitioning_ = Array<int>(serial_mesh_->GeneratePartitioning(nprocs_, defaultPartMethod), nelemGlobal_);
+        partitioning_file_hdf5("write", groupsMPI, nelemGlobal_, partitioning_);
+      } else {
+        partitioning_file_hdf5("read", groupsMPI, nelemGlobal_, partitioning_);
+      }
     }
 
   } else {

--- a/src/mesh_base.hpp
+++ b/src/mesh_base.hpp
@@ -69,6 +69,9 @@ class MeshBase {
   Array<int> partitioning_;
   const int defaultPartMethod = 1;
 
+  // mapping from local to global element index
+  int *local_to_global_element_ = nullptr;
+
   // min/max element size
   double hmin, hmax;
 
@@ -101,5 +104,7 @@ class MeshBase {
   virtual double getMinGridScale() { return hmin; }
   virtual Array<int> getPartition() { return partitioning_; }
   // virtual int getDim() final { return dim_; }
+
+  int *getLocalToGlobalElementMap() const { return local_to_global_element_; }
 };
 #endif  // MESH_BASE_HPP_

--- a/test/inputs/lomach.lid.ini
+++ b/test/inputs/lomach.lid.ini
@@ -16,6 +16,7 @@ outputFreq = 10000
 [io]
 outdirBase = output-lid
 #enableRestart = True
+#restartMode = singleFileReadWrite
 
 # Set bdfOrder = 1 for restart testing purposes
 [time]

--- a/test/lomach-flow.test
+++ b/test/lomach-flow.test
@@ -22,6 +22,8 @@ setup() {
 
     RUNFILE_PIPE_ARANS="inputs/lomach.pipe.arans.ini"
     REF_SOLN_PIPE_ARANS="ref_solns/pipe/restart_output-pipe-arans.sol.h5"
+
+    MPIRUN=`./sniff_mpirun.sh`
 }
 
 @test "[$TEST] check convergence for 2D Taylor-Green case using p = 1" {
@@ -105,6 +107,35 @@ setup() {
         sed 's/#enableRestart = True/enableRestart = True/' > $RUNFILE_LID_MOD
     run $EXE --runFile $RUNFILE_LID_MOD
     [[ ${status} -eq 0 ]]
+
+    # check solutions are the same!
+    h5diff -r --delta=1e-12 restart_output-lid.sol.h5 restart_output-lid.sol.2.h5
+
+    # delete intermediate files
+    rm -f restart_output-lid*.h5
+    rm $RUNFILE_LID_MOD
+}
+
+@test "[$TEST] verify consistent serialized restart for Tomboulides with lid-driven cavity with 2 mpi ranks" {
+    # Runs 2 iter on 2 mpi ranks using restartMode = singleFileReadWrite
+    cat $RUNFILE_LID | sed 's/maxIters = 1000/maxIters = 2/' | \
+        sed 's/outputFreq = 10000/outputFreq = 1/' | \
+        sed 's/#restartMode = singleFileReadWrite/restartMode = singleFileReadWrite/' > $RUNFILE_LID_MOD
+    $MPIRUN -n 2 $EXE --runFile $RUNFILE_LID_MOD
+    mv restart_output-lid.sol.h5 restart_output-lid.sol.2.h5
+
+    # Run 1 iter (from 0 IC)
+    cat $RUNFILE_LID | sed 's/maxIters = 1000/maxIters = 1/' | \
+        sed 's/outputFreq = 10000/outputFreq = 1/' |
+        sed 's/#restartMode = singleFileReadWrite/restartMode = singleFileReadWrite/' > $RUNFILE_LID_MOD
+    $MPIRUN -n 2 $EXE --runFile $RUNFILE_LID_MOD
+
+    # Run 1 more (from restart)
+    cat $RUNFILE_LID | sed 's/maxIters = 1000/maxIters = 2/' | \
+        sed 's/outputFreq = 10000/outputFreq = 1/' | \
+        sed 's/#enableRestart = True/enableRestart = True/' | \
+        sed 's/#restartMode = singleFileReadWrite/restartMode = singleFileReadWrite/' > $RUNFILE_LID_MOD
+    $MPIRUN -n 2 $EXE --runFile $RUNFILE_LID_MOD
 
     # check solutions are the same!
     h5diff -r --delta=1e-12 restart_output-lid.sol.h5 restart_output-lid.sol.2.h5


### PR DESCRIPTION
This PR adds support for serialized restarts (i.e., using `io/restartMode = {singleFileRead,singleFileWrite,singleFileReadWrite}`) for the low Mach solvers.  Because the low Mach solvers use H1-conforming elements rather than DG, some of the underlying functionality in `IOFamily` had to be generalized.  Specifically, the function `IOFamily::readDistributeSerializedVariable` was refactored to ensure that the unpack operation is valid for H1 elements in addition to DG.