### PR TITLE
Bug fix of minimum mesh size for timestep calcs

### DIFF
--- a/src/mesh_base.cpp
+++ b/src/mesh_base.cpp
@@ -230,15 +230,14 @@ void MeshBase::initializeMesh() {
   }
 
   // Determine the minimum element size.
-  double hmin, hmax;
   {
     double local_hmin = 1.0e18;
     for (int i = 0; i < pmesh_->GetNE(); i++) {
       local_hmin = min(pmesh_->GetElementSize(i, 1), local_hmin);
     }
-    MPI_Allreduce(&local_hmin, &hmin, 1, MPI_DOUBLE, MPI_MIN, pmesh_->GetComm());
+    MPI_Allreduce(&local_hmin, &hmin_, 1, MPI_DOUBLE, MPI_MIN, pmesh_->GetComm());
   }
-  if (rank0_) cout << "Minimum element size: " << hmin << "m" << endl;
+  if (rank0_) cout << "Minimum element size: " << hmin_ << "m" << endl;
 
   // maximum size
   {
@@ -246,9 +245,9 @@ void MeshBase::initializeMesh() {
     for (int i = 0; i < pmesh_->GetNE(); i++) {
       local_hmax = max(pmesh_->GetElementSize(i, 1), local_hmax);
     }
-    MPI_Allreduce(&local_hmax, &hmax, 1, MPI_DOUBLE, MPI_MAX, pmesh_->GetComm());
+    MPI_Allreduce(&local_hmax, &hmax_, 1, MPI_DOUBLE, MPI_MAX, pmesh_->GetComm());
   }
-  if (rank0_) cout << "Maximum element size: " << hmax << "m" << endl;
+  if (rank0_) cout << "Maximum element size: " << hmax_ << "m" << endl;
 
   fec_ = new H1_FECollection(order_);
   fes_ = new ParFiniteElementSpace(pmesh_, fec_);

--- a/src/mesh_base.hpp
+++ b/src/mesh_base.hpp
@@ -73,7 +73,7 @@ class MeshBase {
   int *local_to_global_element_ = nullptr;
 
   // min/max element size
-  double hmin, hmax;
+  double hmin_, hmax_;
 
   // domain extent
   double xmin_, ymin_, zmin_;
@@ -101,7 +101,7 @@ class MeshBase {
   virtual ParGridFunction *getGridScale() { return gridScale_; }
   virtual ParGridFunction *getWallDistance() { return distance_; }
   virtual int getDofSize() { return sDof_; }
-  virtual double getMinGridScale() { return hmin; }
+  virtual double getMinGridScale() { return hmin_; }
   virtual Array<int> getPartition() { return partitioning_; }
   // virtual int getDim() final { return dim_; }
 


### PR DESCRIPTION
Removed double declaration of hmin/hmax which caused the hmin used in loMach dt calcs to be zero.  