### PR TITLE
external data for BCs in tomboulides fix

### DIFF
--- a/src/algebraicSubgridModels.cpp
+++ b/src/algebraicSubgridModels.cpp
@@ -122,7 +122,9 @@ void AlgebraicSubgridModels::initializeSelf() {
 }
 
 void AlgebraicSubgridModels::initializeOperators() {
-  // empty for algebraic models
+  // By calling step here, we initialize the subgrid viscosity using
+  // the initial velocity gradient
+  this->step();
 }
 
 void AlgebraicSubgridModels::initializeViz(ParaViewDataCollection &pvdc) {

--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -335,7 +335,7 @@ void CaloricallyPerfectThermoChem::initializeSelf() {
     attr_outlet = 0;
 
     // No code for this yet, so die if detected
-    assert(numOutlets == 0);
+    // assert(numOutlets == 0);
 
     // But... outlets will just get homogeneous Neumann on T, so
     // basically need to do nothing.

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -241,9 +241,9 @@ void LoMachSolver::initialize() {
   sponge_->setup();
 
   // Finish initializing operators
+  flow_->initializeOperators();
   turbModel_->setup();
   turbModel_->initializeOperators();
-  flow_->initializeOperators();
   thermo_->initializeOperators();
   // if(rank0_) {std::cout << "check: ops set..." << endl;}
 

--- a/src/tomboulides.cpp
+++ b/src/tomboulides.cpp
@@ -71,6 +71,7 @@ void Orthogonalize(Vector &v, const ParFiniteElementSpace *pfes) {
 
 Tomboulides::Tomboulides(mfem::ParMesh *pmesh, int vorder, int porder, temporalSchemeCoefficients &coeff, TPS::Tps *tps)
     : gll_rules(0, Quadrature1D::GaussLobatto),
+      tpsP_(tps),
       pmesh_(pmesh),
       vorder_(vorder),
       porder_(porder),
@@ -108,170 +109,14 @@ Tomboulides::Tomboulides(mfem::ParMesh *pmesh, int vorder, int porder, temporalS
     }
 
     // Use "numerical integration" (i.e., under-integrate so that mass matrix is diagonal)
+    // NOTE: this should default to false as it is generally not safe, but much of the
+    // test results rely on it being true
     tps->getInput("loMach/tomboulides/numerical-integ", numerical_integ_, true);
 
     // Can't use numerical integration with axisymmetric b/c it
     // locates quadrature points on the axis, which can lead to
     // singular mass matrices and evaluations of 1/r = 1/0.
     if (axisym_) assert(!numerical_integ_);
-
-    // Gravity
-    assert(dim_ >= 2);
-    Vector zerog(dim_);
-    zerog = 0.0;
-    gravity_.SetSize(dim_);
-    tps->getVec("loMach/gravity", gravity_, dim_, zerog);
-
-    // Initial condition function... options are
-    // 1) "" (Empty string), velocity initialized to zero
-    // 2) "tgv2d", velocity initialized using vel_exact_tgv2d function
-    // 3) "constant", TODO(trevilo) implement options to read constant
-    tps->getInput("loMach/tomboulides/ic", ic_string_, std::string(""));
-
-    // Boundary conditions
-    // number of BC regions defined
-    int numWalls, numInlets, numOutlets;
-    tps->getInput("boundaryConditions/numWalls", numWalls, 0);
-    tps->getInput("boundaryConditions/numInlets", numInlets, 0);
-    tps->getInput("boundaryConditions/numOutlets", numOutlets, 0);
-
-    // Inlet BCs (Dirichlet on velocity)
-    for (int i = 1; i <= numInlets; i++) {
-      int patch;
-      std::string type;
-      std::string basepath("boundaryConditions/inlet" + std::to_string(i));
-
-      tps->getRequiredInput((basepath + "/patch").c_str(), patch);
-      tps->getRequiredInput((basepath + "/type").c_str(), type);
-
-      if (type == "uniform") {
-        Array<int> inlet_attr(pmesh_->bdr_attributes.Max());
-        inlet_attr = 0;
-        inlet_attr[patch - 1] = 1;
-
-        Vector zero(dim_);
-        zero = 0.0;
-
-        Vector velocity_value(dim_);
-        tps->getVec((basepath + "/velocity").c_str(), velocity_value, dim_, zero);
-
-        if (pmesh_->GetMyRank() == 0) {
-          std::cout << "Tomboulides: Setting uniform Dirichlet velocity on patch = " << patch << std::endl;
-        }
-        addVelDirichletBC(velocity_value, inlet_attr);
-
-        if (axisym_) {
-          double swirl;
-          tps->getInput((basepath + "/swirl").c_str(), swirl, 0.0);
-          addSwirlDirichletBC(swirl, inlet_attr);
-        }
-
-      } else if (type == "interpolate") {
-        Array<int> inlet_attr(pmesh_->bdr_attributes.Max());
-        inlet_attr = 0;
-        inlet_attr[patch - 1] = 1;
-        velocity_field_ = new VectorGridFunctionCoefficient(extData_interface_->Udata);
-        if (pmesh_->GetMyRank() == 0) {
-          std::cout << "Tomboulides: Setting interpolated Dirichlet velocity on patch = " << patch << std::endl;
-        }
-        addVelDirichletBC(velocity_field_, inlet_attr);
-
-        // axisymmetric not testsed with interpolation BCs yet.  For now, just stop.
-        assert(!axisym_);
-
-      } else if (type == "fully-developed-pipe") {
-        Array<int> inlet_attr(pmesh_->bdr_attributes.Max());
-        inlet_attr = 0;
-        inlet_attr[patch - 1] = 1;
-
-        if (pmesh_->GetMyRank() == 0) {
-          std::cout << "Tomboulides: Setting uniform inlet velocity on patch = " << patch << std::endl;
-        }
-        addVelDirichletBC(vel_exact_pipe, inlet_attr);
-
-        if (axisym_) {
-          addSwirlDirichletBC(0.0, inlet_attr);
-        }
-      } else {
-        if (pmesh_->GetMyRank() == 0) {
-          std::cout << "Tomboulides: When reading " << basepath << ", encountered inlet type = " << type << std::endl;
-          std::cout << "Tomboulides: Tomboulides flow solver does not support this type." << std::endl;
-        }
-        assert(false);
-        exit(1);
-      }
-    }
-
-    // Wall Bcs
-    for (int i = 1; i <= numWalls; i++) {
-      int patch;
-      std::string type;
-      std::string basepath("boundaryConditions/wall" + std::to_string(i));
-
-      tps->getRequiredInput((basepath + "/patch").c_str(), patch);
-      tps->getRequiredInput((basepath + "/type").c_str(), type);
-
-      if (type == "viscous_isothermal" || type == "viscous_adiabatic" || type == "viscous" || type == "no-slip") {
-        Array<int> wall_attr(pmesh_->bdr_attributes.Max());
-        wall_attr = 0;
-        wall_attr[patch - 1] = 1;
-
-        Vector zero(dim_);
-        zero = 0.0;
-
-        Vector velocity_value(dim_);
-        tps->getVec((basepath + "/velocity").c_str(), velocity_value, dim_, zero);
-
-        if (pmesh_->GetMyRank() == 0) {
-          std::cout << "Tomboulides: Setting Dirichlet velocity on patch = " << patch << std::endl;
-        }
-        addVelDirichletBC(velocity_value, wall_attr);
-
-        if (axisym_) {
-          double swirl;
-          tps->getInput((basepath + "/swirl").c_str(), swirl, 0.0);
-          addSwirlDirichletBC(swirl, wall_attr);
-        }
-      } else {
-        if (pmesh_->GetMyRank() == 0) {
-          std::cout << "Tomboulides: When reading " << basepath << ", encountered wall type = " << type << std::endl;
-          std::cout << "Tomboulides: Tomboulides flow solver does not support this type." << std::endl;
-        }
-        assert(false);
-        exit(1);
-      }
-    }
-
-    // Outlet BCs
-    for (int i = 1; i <= numOutlets; i++) {
-      int patch;
-      std::string type;
-      std::string basepath("boundaryConditions/outlet" + std::to_string(i));
-
-      tps->getRequiredInput((basepath + "/patch").c_str(), patch);
-      tps->getRequiredInput((basepath + "/type").c_str(), type);
-
-      if (type == "uniform") {
-        Array<int> outlet_attr(pmesh_->bdr_attributes.Max());
-        outlet_attr = 0;
-        outlet_attr[patch - 1] = 1;
-
-        double pback;
-        tps->getInput((basepath + "/pressure").c_str(), pback, 0.0);
-
-        if (pmesh_->GetMyRank() == 0) {
-          std::cout << "Tomboulides: Setting uniform outlet pressure on patch = " << patch << std::endl;
-        }
-        addPresDirichletBC(pback, outlet_attr);
-      } else {
-        if (pmesh_->GetMyRank() == 0) {
-          std::cout << "Tomboulides: When reading " << basepath << ", encountered outlet type = " << type << std::endl;
-          std::cout << "Tomboulides: Tomboulides flow solver does not support this type." << std::endl;
-        }
-        assert(false);
-        exit(1);
-      }
-    }
   }
 }
 
@@ -440,6 +285,11 @@ void Tomboulides::initializeSelf() {
   toTurbModel_interface_.gradW = gradW_gf_;
 
   // Gravity
+  assert(dim_ >= 2);
+  Vector zerog(dim_);
+  zerog = 0.0;
+  gravity_.SetSize(dim_);
+  tpsP_->getVec("loMach/gravity", gravity_, dim_, zerog);
   gravity_vec_ = new VectorConstantCoefficient(gravity_);
   Array<int> domain_attr(pmesh_->attributes.Max());
   domain_attr = 1;
@@ -527,6 +377,12 @@ void Tomboulides::initializeSelf() {
     utheta_next_vec_ = 0.0;
   }
 
+  // Initial condition function... options are
+  // 1) "" (Empty string), velocity initialized to zero
+  // 2) "tgv2d", velocity initialized using vel_exact_tgv2d function
+  // 3) "constant", TODO(trevilo) implement options to read constant
+  tpsP_->getInput("loMach/tomboulides/ic", ic_string_, std::string(""));
+
   // set IC if we have one at this point
   if (!ic_string_.empty()) {
     if (ic_string_ == "tgv2d") {
@@ -534,6 +390,156 @@ void Tomboulides::initializeSelf() {
       VectorFunctionCoefficient u_excoeff(2, vel_exact_tgv2d);
       u_excoeff.SetTime(0.0);
       u_curr_gf_->ProjectCoefficient(u_excoeff);
+    }
+  }
+
+  // Boundary conditions
+  // number of BC regions defined
+  int numWalls, numInlets, numOutlets;
+  tpsP_->getInput("boundaryConditions/numWalls", numWalls, 0);
+  tpsP_->getInput("boundaryConditions/numInlets", numInlets, 0);
+  tpsP_->getInput("boundaryConditions/numOutlets", numOutlets, 0);
+
+  // Inlet BCs (Dirichlet on velocity)
+  for (int i = 1; i <= numInlets; i++) {
+    int patch;
+    std::string type;
+    std::string basepath("boundaryConditions/inlet" + std::to_string(i));
+
+    tpsP_->getRequiredInput((basepath + "/patch").c_str(), patch);
+    tpsP_->getRequiredInput((basepath + "/type").c_str(), type);
+
+    MPI_Barrier(vfes_->GetComm());
+    if (type == "uniform") {
+      if (pmesh_->GetMyRank() == 0) {
+        std::cout << "Tomboulides: Setting uniform Dirichlet velocity on patch = " << patch << std::endl;
+      }
+      Array<int> inlet_attr(pmesh_->bdr_attributes.Max());
+      inlet_attr = 0;
+      inlet_attr[patch - 1] = 1;
+
+      Vector zero(dim_);
+      zero = 0.0;
+
+      Vector velocity_value(dim_);
+      tpsP_->getVec((basepath + "/velocity").c_str(), velocity_value, dim_, zero);
+
+      addVelDirichletBC(velocity_value, inlet_attr);
+
+      if (axisym_) {
+        double swirl;
+        tpsP_->getInput((basepath + "/swirl").c_str(), swirl, 0.0);
+        addSwirlDirichletBC(swirl, inlet_attr);
+      }
+
+    } else if (type == "interpolate") {
+      if (pmesh_->GetMyRank() == 0) {
+        std::cout << "Tomboulides: Setting interpolated Dirichlet velocity on patch = " << patch << std::endl;
+      }
+      Array<int> inlet_attr(pmesh_->bdr_attributes.Max());
+      inlet_attr = 0;
+      inlet_attr[patch - 1] = 1;
+
+      velocity_field_ = new VectorGridFunctionCoefficient(extData_interface_->Udata);
+      addVelDirichletBC(velocity_field_, inlet_attr);
+
+      // axisymmetric not testsed with interpolation BCs yet.  For now, just stop.
+      assert(!axisym_);
+
+    } else if (type == "fully-developed-pipe") {
+      if (pmesh_->GetMyRank() == 0) {
+        std::cout << "Tomboulides: Setting uniform inlet velocity on patch = " << patch << std::endl;
+      }
+      Array<int> inlet_attr(pmesh_->bdr_attributes.Max());
+      inlet_attr = 0;
+      inlet_attr[patch - 1] = 1;
+
+      addVelDirichletBC(vel_exact_pipe, inlet_attr);
+
+      if (axisym_) {
+        addSwirlDirichletBC(0.0, inlet_attr);
+      }
+    } else {
+      if (pmesh_->GetMyRank() == 0) {
+        std::cout << "Tomboulides: When reading " << basepath << ", encountered inlet type = " << type << std::endl;
+        std::cout << "Tomboulides: Tomboulides flow solver does not support this type." << std::endl;
+      }
+      assert(false);
+      exit(1);
+    }
+  }
+
+  // Wall Bcs
+  for (int i = 1; i <= numWalls; i++) {
+    int patch;
+    std::string type;
+    std::string basepath("boundaryConditions/wall" + std::to_string(i));
+
+    tpsP_->getRequiredInput((basepath + "/patch").c_str(), patch);
+    tpsP_->getRequiredInput((basepath + "/type").c_str(), type);
+
+    if (type == "viscous_isothermal" || type == "viscous_adiabatic" || type == "viscous" || type == "no-slip") {
+      if (pmesh_->GetMyRank() == 0) {
+        std::cout << "Tomboulides: Setting Dirichlet velocity on patch = " << patch << std::endl;
+      }
+
+      Array<int> wall_attr(pmesh_->bdr_attributes.Max());
+      wall_attr = 0;
+      wall_attr[patch - 1] = 1;
+
+      Vector zero(dim_);
+      zero = 0.0;
+
+      Vector velocity_value(dim_);
+      tpsP_->getVec((basepath + "/velocity").c_str(), velocity_value, dim_, zero);
+
+      addVelDirichletBC(velocity_value, wall_attr);
+
+      if (axisym_) {
+        double swirl;
+        tpsP_->getInput((basepath + "/swirl").c_str(), swirl, 0.0);
+        addSwirlDirichletBC(swirl, wall_attr);
+      }
+    } else {
+      if (pmesh_->GetMyRank() == 0) {
+        std::cout << "Tomboulides: When reading " << basepath << ", encountered wall type = " << type << std::endl;
+        std::cout << "Tomboulides: Tomboulides flow solver does not support this type." << std::endl;
+      }
+      assert(false);
+      exit(1);
+    }
+  }
+
+  // Outlet BCs
+  for (int i = 1; i <= numOutlets; i++) {
+    if (rank0_) std::cout << "Caught outlet" << std::endl;
+    int patch;
+    std::string type;
+    std::string basepath("boundaryConditions/outlet" + std::to_string(i));
+
+    tpsP_->getRequiredInput((basepath + "/patch").c_str(), patch);
+    tpsP_->getRequiredInput((basepath + "/type").c_str(), type);
+
+    if (type == "uniform") {
+      if (rank0_) std::cout << "attempting to apply uniform pressure outlet" << patch << std::endl;
+      Array<int> outlet_attr(pmesh_->bdr_attributes.Max());
+      outlet_attr = 0;
+      outlet_attr[patch - 1] = 1;
+
+      double pback;
+      tpsP_->getInput((basepath + "/pressure").c_str(), pback, 0.0);
+
+      if (pmesh_->GetMyRank() == 0) {
+        std::cout << "Tomboulides: Setting uniform outlet pressure on patch = " << patch << std::endl;
+      }
+      addPresDirichletBC(pback, outlet_attr);
+    } else {
+      if (pmesh_->GetMyRank() == 0) {
+        std::cout << "Tomboulides: When reading " << basepath << ", encountered outlet type = " << type << std::endl;
+        std::cout << "Tomboulides: Tomboulides flow solver does not support this type." << std::endl;
+      }
+      assert(false);
+      exit(1);
     }
   }
 }

--- a/src/tomboulides.hpp
+++ b/src/tomboulides.hpp
@@ -383,6 +383,9 @@ class Tomboulides final : public FlowBase {
 
   /// Compute maximum velocity magnitude anywhere in the domain
   double maxVelocityMagnitude();
+
+  /// Compute Galerkin projection of velocity gradient
+  void evaluateVelocityGradient();
 };
 
 #endif  // TOMBOULIDES_HPP_

--- a/src/tomboulides.hpp
+++ b/src/tomboulides.hpp
@@ -81,7 +81,7 @@ class Tomboulides final : public FlowBase {
 
   // Options
   // TODO(trevilo): hardcoded for testing.  Need to set based on input file.
-  bool numerical_integ_ = true;
+  bool numerical_integ_ = false;
   bool partial_assembly_ = false;
 
   int pressure_solve_pl_ = 0;
@@ -99,6 +99,9 @@ class Tomboulides final : public FlowBase {
 
   // To use "numerical integration", quadrature rule must persist
   mfem::IntegrationRules gll_rules;
+
+  // Options-related structures
+  TPS::Tps *tpsP_ = nullptr;
 
   // Basic info needed to create fem spaces
   mfem::ParMesh *pmesh_;

--- a/test/ref_solns/lequere-varmu/reference-lequere-varmu.sol.h5
+++ b/test/ref_solns/lequere-varmu/reference-lequere-varmu.sol.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:348f996ac34024f2c68037a6e3b3ccd1e91cafb2dd69e685a08ab2b5c1e7d6b5
-size 106352
+oid sha256:992d58bb5010f3576f13fd076f2b2ab67b4ead1536b627d7e05649c6acfccc87
+size 106416

--- a/test/ref_solns/sgsLoMach/restart_output.sol.h5
+++ b/test/ref_solns/sgsLoMach/restart_output.sol.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ad58b195ad850b25f46bfa1647147353f23189e3bf691c8e2ad7565a3ab17d8
+oid sha256:a1d285d59acd77b7cc383d646e8b2ddf10b1da771dad96bf0a5f46afa08df0bc
 size 78744


### PR DESCRIPTION
Moved tomboulides bc's from constructor to initialize to allow use of external data.  tomboulides now keeps  a tspP_.