### PR TITLE
Ramped external data

### DIFF
--- a/src/gaussianInterpExtData.cpp
+++ b/src/gaussianInterpExtData.cpp
@@ -49,9 +49,10 @@
 using namespace mfem;
 using namespace mfem::common;
 
-GaussianInterpExtData::GaussianInterpExtData(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &coeff, TPS::Tps *tps)
-  : tpsP_(tps), loMach_opts_(loMach_opts), pmesh_(pmesh), coeff_(coeff) {
-  nprocs_ = pmesh_->GetNRanks();  
+GaussianInterpExtData::GaussianInterpExtData(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts,
+                                             temporalSchemeCoefficients &coeff, TPS::Tps *tps)
+    : tpsP_(tps), loMach_opts_(loMach_opts), pmesh_(pmesh), coeff_(coeff) {
+  nprocs_ = pmesh_->GetNRanks();
   rank_ = pmesh_->GetMyRank();
   rank0_ = (pmesh_->GetMyRank() == 0);
   order_ = loMach_opts->order;
@@ -62,14 +63,15 @@ GaussianInterpExtData::GaussianInterpExtData(mfem::ParMesh *pmesh, LoMachOptions
   int numInlets;
   tpsP_->getInput("boundaryConditions/numInlets", numInlets, 0);
 
-  if (rank0_) std::cout << "Checking for requested interpolated inlet data over " << numInlets << " inlet(s)..." << endl;  
+  if (rank0_)
+    std::cout << "Checking for requested interpolated inlet data over " << numInlets << " inlet(s)..." << endl;
   for (int i = 1; i <= numInlets; i++) {
     std::string type;
     std::string basepath("boundaryConditions/inlet" + std::to_string(i));
     tpsP_->getRequiredInput((basepath + "/type").c_str(), type);
     if (type == "interpolate") {
       if (rank0_) std::cout << "...interpolation specified" << endl;
-      tpsP_->getInput((basepath + "/rampSteps").c_str(), rampSteps_, 1);      
+      tpsP_->getInput((basepath + "/rampSteps").c_str(), rampSteps_, 1);
       if (isInterpInlet_) {
         // If we've already set isInterpInlet_, then user requested
         // multiple interpolation BCs, which is not supported
@@ -117,7 +119,7 @@ void GaussianInterpExtData::initializeSelf() {
   velocity_gf_ = 0.0;
   vel0_gf_.SetSpace(vfes_);
   vel0_gf_ = 0.0;
-  
+
   // exports
   toThermoChem_interface_.Tdata = &temperature_gf_;
   toFlow_interface_.Udata = &velocity_gf_;
@@ -145,7 +147,7 @@ void GaussianInterpExtData::setup() {
 
   double *Tdata = temperature_gf_.HostReadWrite();
   double *Udata = velocity_gf_.HostReadWrite();
-  double *U0 = vel0_gf_.HostReadWrite();  
+  double *U0 = vel0_gf_.HostReadWrite();
   double *hcoords = coordsDof.HostReadWrite();
 
   struct inlet_profile {
@@ -262,25 +264,24 @@ void GaussianInterpExtData::setup() {
   // TODO(swh): dont need to fill entire gf, just appropriate face
   // NB: be careful with GetNBE (see comments in mfem/mesh/mesh.hpp)
   // MPI_Barrier(vfes_->GetComm());
-  //std::cout << " starting actual interp..." << endl;
+  // std::cout << " starting actual interp..." << endl;
 
-  //for (int np = 0; np < nprocs_; np++) {
-  //  MPI_Barrier(vfes_->GetComm());
-  //  if (rank_ != np) { continue; }
-  //  std::cout << "Working on rank " << np+1 << " of " << nprocs_ << "..." << endl;
-  
-  //for (int n = 0; n < Sdof_; n++) {  
+  // for (int np = 0; np < nprocs_; np++) {
+  //   MPI_Barrier(vfes_->GetComm());
+  //   if (rank_ != np) { continue; }
+  //   std::cout << "Working on rank " << np+1 << " of " << nprocs_ << "..." << endl;
+
+  // for (int n = 0; n < Sdof_; n++) {
   for (int be = 0; be < pmesh_->GetNBE(); be++) {
     Array<int> vdofs;
     sfes_->GetBdrElementVDofs(be, vdofs);
     for (int i = 0; i < vdofs.Size(); i++) {
-      
       // index in gf of bndry element
       int n = vdofs[i];
       if (n >= Sdof_) {
-         std::cout << " BAD: " << n << " of " << Sdof_ << " dofs" <<endl;	
+        std::cout << " BAD: " << n << " of " << Sdof_ << " dofs" << endl;
       }
-  
+
       double xp[3];
       for (int d = 0; d < dim_; d++) {
         xp[d] = hcoords[n + d * Sdof_];
@@ -332,9 +333,8 @@ void GaussianInterpExtData::setup() {
           continue;
         }
 
-        dist = sqrt( (xp[0] - inlet[j].x) * (xp[0] - inlet[j].x)
-		   + (xp[1] - inlet[j].y) * (xp[1] - inlet[j].y)
-                   + (xp[2] - inlet[j].z) * (xp[2] - inlet[j].z) );
+        dist = sqrt((xp[0] - inlet[j].x) * (xp[0] - inlet[j].x) + (xp[1] - inlet[j].y) * (xp[1] - inlet[j].y) +
+                    (xp[2] - inlet[j].z) * (xp[2] - inlet[j].z));
 
         // gaussian interpolation
         if (dist <= 1.5 * radius) {
@@ -363,7 +363,8 @@ void GaussianInterpExtData::setup() {
         Udata[n + 1 * Sdof_] = val_v / wt_tot;
         Udata[n + 2 * Sdof_] = val_w / wt_tot;
         Tdata[n] = val_T / wt_tot;
-	//std::cout << n << ") interpolated data: " << Udata[n + 0 * Sdof_] << " " << Udata[n + 1 * Sdof_] << " " << Udata[n + 2 * Sdof_] << endl;
+        // std::cout << n << ") interpolated data: " << Udata[n + 0 * Sdof_] << " " << Udata[n + 1 * Sdof_] << " " <<
+        // Udata[n + 2 * Sdof_] << endl;
       } else {
         Udata[n + 0 * Sdof_] = 0.0;
         Udata[n + 1 * Sdof_] = 0.0;
@@ -375,31 +376,30 @@ void GaussianInterpExtData::setup() {
       U0[n + 0 * Sdof_] = Udata[n + 0 * Sdof_];
       U0[n + 1 * Sdof_] = Udata[n + 1 * Sdof_];
       U0[n + 2 * Sdof_] = Udata[n + 2 * Sdof_];
-      
     }
   }
-  //MPI_Barrier(vfes_->GetComm());
-  //std::cout << " done with interpolation!" << endl;
+  // MPI_Barrier(vfes_->GetComm());
+  // std::cout << " done with interpolation!" << endl;
 
   //}
-  
 }
 
 void GaussianInterpExtData::step() {
   // empty for now, use for any updates/modifications
   // during simulation e.g. ramping up with time
-  //double *Tdata = temperature_gf_.HostReadWrite();
+  // double *Tdata = temperature_gf_.HostReadWrite();
 
-  if (!isInterpInlet_) { return; }
-    
+  if (!isInterpInlet_) {
+    return;
+  }
+
   double *Udata = velocity_gf_.HostReadWrite();
-  double *U0 = vel0_gf_.HostReadWrite();  
+  double *U0 = vel0_gf_.HostReadWrite();
 
   // only addressing velocity for now and assume ic is zero
-  for (int eq = 0; eq < dim_; eq++) {  
+  for (int eq = 0; eq < dim_; eq++) {
     for (int i = 0; i < Sdof_; i++) {
-      Udata[i + eq * Sdof_] = U0[i + eq * Sdof_] * std::min(double(coeff_.nStep)/double(rampSteps_), 1.0);
+      Udata[i + eq * Sdof_] = U0[i + eq * Sdof_] * std::min(double(coeff_.nStep) / double(rampSteps_), 1.0);
     }
   }
-  
 }

--- a/src/gaussianInterpExtData.cpp
+++ b/src/gaussianInterpExtData.cpp
@@ -261,17 +261,7 @@ void GaussianInterpExtData::setup() {
   */
   double radius = 1.0;
 
-  // TODO(swh): dont need to fill entire gf, just appropriate face
   // NB: be careful with GetNBE (see comments in mfem/mesh/mesh.hpp)
-  // MPI_Barrier(vfes_->GetComm());
-  // std::cout << " starting actual interp..." << endl;
-
-  // for (int np = 0; np < nprocs_; np++) {
-  //   MPI_Barrier(vfes_->GetComm());
-  //   if (rank_ != np) { continue; }
-  //   std::cout << "Working on rank " << np+1 << " of " << nprocs_ << "..." << endl;
-
-  // for (int n = 0; n < Sdof_; n++) {
   for (int be = 0; be < pmesh_->GetNBE(); be++) {
     Array<int> vdofs;
     sfes_->GetBdrElementVDofs(be, vdofs);
@@ -279,7 +269,9 @@ void GaussianInterpExtData::setup() {
       // index in gf of bndry element
       int n = vdofs[i];
       if (n >= Sdof_) {
-        std::cout << " BAD: " << n << " of " << Sdof_ << " dofs" << endl;
+        std::cout << " ERROR: problem with GetNBE in external data interpolation " << n << " of " << Sdof_ << " dofs"
+                  << endl;
+        exit(1);
       }
 
       double xp[3];
@@ -347,15 +339,16 @@ void GaussianInterpExtData::setup() {
         }
 
         // nearest, just for testing
-        // if(dist <= distMin) {
-        //  wt_tot = 1.0;
-        //   val_rho = inlet[j].rho;
-        //   val_u = inlet[j].u;
-        //   val_v = inlet[j].v;
-        //   val_w = inlet[j].w;
-        //   val_T = inlet[j].temp;
-        //   iCount = 1;
-        // }
+        /*
+        if(dist <= distMin) {
+          wt_tot = 1.0;
+          val_u = inlet[j].u;
+          val_v = inlet[j].v;
+          val_w = inlet[j].w;
+          val_T = inlet[j].temp;
+          iCount = 1;
+        }
+        */
       }
 
       if (wt_tot > 0.0) {
@@ -363,8 +356,6 @@ void GaussianInterpExtData::setup() {
         Udata[n + 1 * Sdof_] = val_v / wt_tot;
         Udata[n + 2 * Sdof_] = val_w / wt_tot;
         Tdata[n] = val_T / wt_tot;
-        // std::cout << n << ") interpolated data: " << Udata[n + 0 * Sdof_] << " " << Udata[n + 1 * Sdof_] << " " <<
-        // Udata[n + 2 * Sdof_] << endl;
       } else {
         Udata[n + 0 * Sdof_] = 0.0;
         Udata[n + 1 * Sdof_] = 0.0;
@@ -378,10 +369,6 @@ void GaussianInterpExtData::setup() {
       U0[n + 2 * Sdof_] = Udata[n + 2 * Sdof_];
     }
   }
-  // MPI_Barrier(vfes_->GetComm());
-  // std::cout << " done with interpolation!" << endl;
-
-  //}
 }
 
 void GaussianInterpExtData::step() {

--- a/src/gaussianInterpExtData.hpp
+++ b/src/gaussianInterpExtData.hpp
@@ -94,7 +94,7 @@ class GaussianInterpExtData : public ExternalDataBase {
   // Assumed to be externally managed and determined, so just get a
   // reference here.
   const temporalSchemeCoefficients &coeff_;
-  
+
   // to-be used fro time or timestep dep bc
   // double dt;
   // double time;
@@ -116,13 +116,14 @@ class GaussianInterpExtData : public ExternalDataBase {
 
   ParGridFunction temperature_gf_;
   ParGridFunction velocity_gf_;
-  ParGridFunction vel0_gf_;  
+  ParGridFunction vel0_gf_;
 
   // gradual increase of external bc over multiple steps
   int rampSteps_;
 
  public:
-  GaussianInterpExtData(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &coeff, TPS::Tps *tps);
+  GaussianInterpExtData(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &coeff,
+                        TPS::Tps *tps);
   virtual ~GaussianInterpExtData();
 
   void initializeSelf();

--- a/src/gaussianInterpExtData.hpp
+++ b/src/gaussianInterpExtData.hpp
@@ -38,6 +38,9 @@ namespace TPS {
 class Tps;
 }
 
+// forward-declaration of struct hold temporal coefficients (loMach.hpp)
+struct temporalSchemeCoefficients;
+
 #include <tps_config.h>
 
 #include <iostream>
@@ -84,8 +87,14 @@ class GaussianInterpExtData : public ExternalDataBase {
   // The order of the scalar spaces
   int order_;
 
+  // dimension of mesh
   int dim_;
 
+  // Coefficients necessary to take a time step (including dt).
+  // Assumed to be externally managed and determined, so just get a
+  // reference here.
+  const temporalSchemeCoefficients &coeff_;
+  
   // to-be used fro time or timestep dep bc
   // double dt;
   // double time;
@@ -107,9 +116,13 @@ class GaussianInterpExtData : public ExternalDataBase {
 
   ParGridFunction temperature_gf_;
   ParGridFunction velocity_gf_;
+  ParGridFunction vel0_gf_;  
+
+  // gradual increase of external bc over multiple steps
+  int rampSteps_;
 
  public:
-  GaussianInterpExtData(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, TPS::Tps *tps);
+  GaussianInterpExtData(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &coeff, TPS::Tps *tps);
   virtual ~GaussianInterpExtData();
 
   void initializeSelf();

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -107,7 +107,7 @@ void LoMachSolver::initialize() {
   if (!loMach_opts_.io_opts_.enable_restart_) {
     temporal_coeff_.time = 0.;
     iter = 0;
-    temporal_coeff_.nStep = iter;    
+    temporal_coeff_.nStep = iter;
   }
 
   //-----------------------------------------------------
@@ -351,7 +351,7 @@ void LoMachSolver::solveStep() {
 
   if (loMach_opts_.ts_opts_.integrator_type_ == LoMachTemporalOptions::CURL_CURL) {
     SetTimeIntegrationCoefficients(iter - iter_start_);
-    extData_->step();    
+    extData_->step();
     thermo_->step();
     flow_->step();
     turbModel_->step();
@@ -363,7 +363,7 @@ void LoMachSolver::solveStep() {
 
   UpdateTimestepHistory(temporal_coeff_.dt);
   temporal_coeff_.time += temporal_coeff_.dt;
-  temporal_coeff_.nStep = iter;      
+  temporal_coeff_.nStep = iter;
   iter++;
 
   if ((iter % loMach_opts_.timing_frequency_) == 0) {

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -107,6 +107,7 @@ void LoMachSolver::initialize() {
   if (!loMach_opts_.io_opts_.enable_restart_) {
     temporal_coeff_.time = 0.;
     iter = 0;
+    temporal_coeff_.nStep = iter;    
   }
 
   //-----------------------------------------------------
@@ -134,7 +135,7 @@ void LoMachSolver::initialize() {
   sponge_ = new GeometricSponge(pmesh_, &loMach_opts_, tpsP_);
 
   // Instantiate external data
-  extData_ = new GaussianInterpExtData(pmesh_, &loMach_opts_, tpsP_);
+  extData_ = new GaussianInterpExtData(pmesh_, &loMach_opts_, temporal_coeff_, tpsP_);
 
   // Instantiate turbulence model
   if (loMach_opts_.turb_opts_.turb_model_type_ == TurbulenceModelOptions::SMAGORINSKY) {
@@ -350,6 +351,7 @@ void LoMachSolver::solveStep() {
 
   if (loMach_opts_.ts_opts_.integrator_type_ == LoMachTemporalOptions::CURL_CURL) {
     SetTimeIntegrationCoefficients(iter - iter_start_);
+    extData_->step();    
     thermo_->step();
     flow_->step();
     turbModel_->step();
@@ -361,6 +363,7 @@ void LoMachSolver::solveStep() {
 
   UpdateTimestepHistory(temporal_coeff_.dt);
   temporal_coeff_.time += temporal_coeff_.dt;
+  temporal_coeff_.nStep = iter;      
   iter++;
 
   if ((iter % loMach_opts_.timing_frequency_) == 0) {

--- a/src/loMach.hpp
+++ b/src/loMach.hpp
@@ -76,6 +76,9 @@ struct temporalSchemeCoefficients {
   // Current time
   double time;
 
+  // Current step
+  int nStep;
+  
   // Time step
   double dt;
 

--- a/src/loMach.hpp
+++ b/src/loMach.hpp
@@ -78,7 +78,7 @@ struct temporalSchemeCoefficients {
 
   // Current step
   int nStep;
-  
+
   // Time step
   double dt;
 


### PR DESCRIPTION
Adding support for ramping external data over a set number of steps.  Requires adding an extData_ step in LoMach.  With no interpolated data, this step will do nothing.  Will be useful for future conditions such as feeding in  3D turbulence as an inlet.