### PR TITLE
Fix turbulence model initialization

### DIFF
--- a/src/algebraicSubgridModels.cpp
+++ b/src/algebraicSubgridModels.cpp
@@ -122,7 +122,9 @@ void AlgebraicSubgridModels::initializeSelf() {
 }
 
 void AlgebraicSubgridModels::initializeOperators() {
-  // empty for algebraic models
+  // By calling step here, we initialize the subgrid viscosity using
+  // the initial velocity gradient
+  this->step();
 }
 
 void AlgebraicSubgridModels::initializeViz(ParaViewDataCollection &pvdc) {

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -241,9 +241,9 @@ void LoMachSolver::initialize() {
   sponge_->setup();
 
   // Finish initializing operators
+  flow_->initializeOperators();
   turbModel_->setup();
   turbModel_->initializeOperators();
-  flow_->initializeOperators();
   thermo_->initializeOperators();
   // if(rank0_) {std::cout << "check: ops set..." << endl;}
 

--- a/src/tomboulides.hpp
+++ b/src/tomboulides.hpp
@@ -383,6 +383,9 @@ class Tomboulides final : public FlowBase {
 
   /// Compute maximum velocity magnitude anywhere in the domain
   double maxVelocityMagnitude();
+
+  /// Compute Galerkin projection of velocity gradient
+  void evaluateVelocityGradient();
 };
 
 #endif  // TOMBOULIDES_HPP_

--- a/test/ref_solns/lequere-varmu/reference-lequere-varmu.sol.h5
+++ b/test/ref_solns/lequere-varmu/reference-lequere-varmu.sol.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:348f996ac34024f2c68037a6e3b3ccd1e91cafb2dd69e685a08ab2b5c1e7d6b5
-size 106352
+oid sha256:992d58bb5010f3576f13fd076f2b2ab67b4ead1536b627d7e05649c6acfccc87
+size 106416

--- a/test/ref_solns/sgsLoMach/restart_output.sol.h5
+++ b/test/ref_solns/sgsLoMach/restart_output.sol.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ad58b195ad850b25f46bfa1647147353f23189e3bf691c8e2ad7565a3ab17d8
+oid sha256:a1d285d59acd77b7cc383d646e8b2ddf10b1da771dad96bf0a5f46afa08df0bc
 size 78744


### PR DESCRIPTION
This PR includes fixes to ensure that the the subgrid viscosity provided by the `AlgebraicSubgridModels` class is properly initialized.  There two sets of substantive changes:

1) Changes to ensure that the velocity gradient grid functions are properly initialized by the `Tomboulides` class, namely that the velocity gradients are consistent with the initial velocity field.
2) Changes to ensure that the subgrid viscosity is properly initialized by the `AlgebraicSubgridModels` class.

Prior to these fixes, the subgrid viscosity could be used uninitialized during the first time step.