### PR TITLE
Add support for `Averaging` to the low Mach path

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,4 @@ test/ref_solns/plate150K_1step/restart_output.sol.h5 filter=lfs diff=lfs merge=l
 test/ref_solns/interpInlet/restart_output.sol.h5 filter=lfs diff=lfs merge=lfs -text
 test/meshes/spongeBox.msh filter=lfs diff=lfs merge=lfs -text
 test/ref_solns/sgsLoMach/restart_output.sol.h5 filter=lfs diff=lfs merge=lfs -text
+test/ref_solns/aveLoMach/restart_output.sol.h5 filter=lfs diff=lfs merge=lfs -text

--- a/src/averaging.cpp
+++ b/src/averaging.cpp
@@ -286,8 +286,8 @@ void Averaging::addSampleInternal() {
     const int dof = mean->ParFESpace()->GetNDofs();  // dofs per scalar field
     const int neq = mean->ParFESpace()->GetVDim();   // number of scalar variables in mean field
 
-    int d_vari_start;
-    int d_vari_components;
+    int d_vari_start = 0;
+    int d_vari_components = 0;
     if (vari != nullptr) {
       d_vari_start = fam.vari_start_index_;
       d_vari_components = fam.vari_components_;

--- a/src/averaging.cpp
+++ b/src/averaging.cpp
@@ -75,6 +75,10 @@ Averaging::Averaging(AveragingOptions &opts, std::string output_name) {
 
   mean_output_name_ = "mean_";
   mean_output_name_.append(output_name);
+
+  enable_mean_continuation_ = opts.enable_mean_continuation_;
+  zero_variances_ = opts.zero_variances_;
+  
 }
 
 Averaging::~Averaging() {
@@ -199,13 +203,31 @@ void Averaging::addSample(const int &iter, GasMixture *mixture) {
 
   assert(avg_families_.size() >= 1);
 
-  if (iter % sample_interval_ == 0 && iter >= step_start_mean_) {
-    if (iter == step_start_mean_ && rank0_) cout << "Starting mean calculation." << endl;
+  if (!enable_mean_continuation_) {
+    ns_mean_ = 0;
+    enable_mean_continuation_ = true;
+  }
 
+  if (zero_variances_) {
+    ns_vari_ = 0;
+    zero_variances_ = false;
+  }
+  
+  if (iter % sample_interval_ == 0 && iter >= step_start_mean_) {
+    if (iter == step_start_mean_ && rank0_) cout << "Starting mean calculation at iter " << iter << endl;
+
+    if (ns_mean_ == 0) {
+      for (size_t ifam = 0; ifam < avg_families_.size(); ifam++) {
+        if(avg_families_[ifam].mean_fcn_ != nullptr) {	
+          *avg_families_[ifam].mean_fcn_ = 0.0;
+	}
+      }
+    }
+
+    // If we got here, then either this is our first time averaging
+    // or the variances have been restarted.  Either way, valid to
+    // set variances to zero.    
     if (ns_vari_ == 0) {
-      // If we got here, then either this is our first time averaging
-      // or the variances have been restarted.  Either way, valid to
-      // set variances to zero.
       for (size_t ifam = 0; ifam < avg_families_.size(); ifam++) {
         if(avg_families_[ifam].vari_fcn_ != nullptr) {	
           *avg_families_[ifam].vari_fcn_ = 0.0;
@@ -245,32 +267,21 @@ void Averaging::addSampleInternal() {
 
   // Loop through families that have been registered and compute means and variances
   for (size_t ifam = 0; ifam < avg_families_.size(); ifam++) {
-    //std::cout << "starting ifam loop... " << ifam+1 << " of " << avg_families_.size() << " " << avg_families_[ifam].name_ << endl;
     // Extract fields for use on device (when available)
     AveragingFamily &fam = avg_families_[ifam];
-    //std::cout << "okay a... " << endl;        
 
     const ParGridFunction *inst = fam.instantaneous_fcn_;
     ParGridFunction *mean = fam.mean_fcn_;
     ParGridFunction *vari = fam.vari_fcn_;
-    //std::cout << "okay b... " << endl;
-    if(fam.mean_fcn_ == nullptr) {
-      std::cout << "fam.mean_fcn_ is a nullptr " << endl; 
-    }
 
     const double *d_inst = inst->Read();
-    //std::cout << "okay b1... " << endl;    
     double *d_mean = mean->ReadWrite();    
-    //std::cout << "okay b3... " << endl;        
-    double *d_vari;
-    //std::cout << "okay b4... " << endl;        
+    double *d_vari = nullptr;
     if(vari != nullptr) { d_vari = vari->ReadWrite(); }
-    //std::cout << "okay c... " << endl;            
 
     // Extract size information for use on device
     const int dof = mean->ParFESpace()->GetNDofs();  // dofs per scalar field
     const int neq = mean->ParFESpace()->GetVDim();   // number of scalar variables in mean field
-    //std::cout << "okay d... " << endl;            
 
     int d_vari_start;
     int d_vari_components;
@@ -278,36 +289,30 @@ void Averaging::addSampleInternal() {
       d_vari_start = fam.vari_start_index_;
       d_vari_components = fam.vari_components_;      
     }
-    //std::cout << "okay e... " << endl;            
 
     // Extract sample size information for use on device
     double d_ns_mean = (double)ns_mean_;
-    double d_ns_vari;
-    if(vari != nullptr) {
+    double d_ns_vari = 0;
+    if (vari != nullptr) {
       d_ns_vari = (double)ns_vari_;      
     }
 
-    //std::cout << "okay 0... " << dof << endl;    
     // "Loop" over all dofs and update statistics
     MFEM_FORALL(n, dof, {
       // Update mean
-      //std::cout << "okay 1..." << endl;
       for (int eq = 0; eq < neq; eq++) {
         const double uinst = d_inst[n + eq * dof];
         const double umean = d_mean[n + eq * dof];
         const double N_umean = d_ns_mean * umean;
         d_mean[n + eq * dof] = (N_umean + uinst) / (d_ns_mean + 1);
       }
-      //std::cout << "okay 2..." << endl;      
 
       // Update variances (only computed if we have a place to put them)
-      //if (d_vari != nullptr) {
-      if (vari != nullptr) {	
+      if (d_vari != nullptr) {
         double val = 0.;
         double delta_i = 0.;
         double delta_j = 0.;
         int vari_index = 0;
-        //std::cout << "okay 3..." << endl;      	
 
         // Variances first (i.e., diagonal of the covariance matrix)
         for (int i = d_vari_start; i < d_vari_start + d_vari_components; i++) {
@@ -318,35 +323,26 @@ void Averaging::addSampleInternal() {
           d_vari[n + vari_index * dof] = (val * d_ns_vari + delta_i * delta_i) / (d_ns_vari + 1);
           vari_index++;
         }
-        //std::cout << "okay 4... " << d_vari_start << " " << d_vari_components << endl;
 
         // Covariances second (i.e., off-diagonal components, if any)
         for (int i = d_vari_start; i < d_vari_start + d_vari_components - 1; i++) {
           const double uinst_i = d_inst[n + i * dof];
           const double umean_i = d_mean[n + i * dof];
           delta_i = uinst_i - umean_i;
-	  //std::cout << "okay 4a... " << endl;	  
-          for (int j = d_vari_start + 1; j < d_vari_start + d_vari_components; j++) {
+
+          for (int j = i + 1; j < d_vari_start + d_vari_components; j++) {
             const double uinst_j = d_inst[n + j * dof];
             const double umean_j = d_mean[n + j * dof];
             delta_j = uinst_j - umean_j;
-  	    //std::cout << "okay 4b... " << endl;	  	    
 
             val = d_vari[n + vari_index * dof];
-  	    //std::cout << "okay 4c... " << endl;	  	    	    
-            d_vari[n + vari_index * dof] = (val * d_ns_vari + delta_i * delta_j) / (d_ns_vari + 1);
-  	    //std::cout << "okay 4d... " << endl;	  	    	    
+            d_vari[n + vari_index * dof] = (val * d_ns_vari + delta_i * delta_j) / (d_ns_vari + 1);	  	    	    
             vari_index++;
-  	    //std::cout << "okay 4e... " << endl;	  	    	    
           }
         }
-      }  // end variance
-      //std::cout << "okay 5..." << endl; 
-      
+      }  // end variance      
     });
-    //std::cout << "okay 6..." << endl;     
   }
-  //std::cout << "okay 7..." << endl;   
 }
 
 void Averaging::addSampleInternal(GasMixture *mixture) {

--- a/src/averaging.cpp
+++ b/src/averaging.cpp
@@ -347,7 +347,10 @@ void Averaging::addSampleInternal(GasMixture *mixture) {
 
     const double *d_inst = inst->Read();
     double *d_mean = mean->ReadWrite();
-    double *d_vari = vari->ReadWrite();
+    double *d_vari = nullptr;
+    if (vari != nullptr) {
+      d_vari = vari->ReadWrite();
+    }
 
     // Get mixture class pointer for use on device
     //
@@ -418,7 +421,7 @@ void Averaging::addSampleInternal(GasMixture *mixture) {
 
         // Covariances second (i.e., off-diagonal components, if any)
         for (int i = d_vari_start; i < d_vari_start + d_vari_components - 1; i++) {
-          for (int j = d_vari_start + 1; j < d_vari_start + d_vari_components; j++) {
+          for (int j = i + 1; j < d_vari_start + d_vari_components; j++) {
             val = d_vari[n + vari_index * dof];
             delta_i = (nUp[i] - mean_state[i]);
             delta_j = (nUp[j] - mean_state[j]);

--- a/src/averaging.hpp
+++ b/src/averaging.hpp
@@ -180,7 +180,7 @@ class Averaging {
   /// flag to continue mean from restart
   bool enable_mean_continuation_;
 
-  /// flag to restart variances  
+  /// flag to restart variances
   bool zero_variances_;
 
   /// mfem paraview data collection, used to write viz files
@@ -288,7 +288,10 @@ class Averaging {
   int GetSamplesMean() { return ns_mean_; }
   int GetSamplesRMS() { return ns_vari_; }
   int GetSamplesInterval() { return sample_interval_; }
+
   bool ComputeMean() { return compute_mean_; }
+  bool ContinueMean() { return enable_mean_continuation_; }
+  bool RestartRMS() { return zero_variances_; }
 
   void SetSamplesMean(int &samples) { ns_mean_ = samples; }
   void SetSamplesRMS(int &samples) { ns_vari_ = samples; }

--- a/src/averaging.hpp
+++ b/src/averaging.hpp
@@ -177,6 +177,12 @@ class Averaging {
   /// Visualization directory (i.e., paraview dumped to mean_output_name_)
   std::string mean_output_name_;
 
+  /// flag to continue mean from restart
+  bool enable_mean_continuation_;
+
+  /// flag to restart variances  
+  bool zero_variances_;
+
   /// mfem paraview data collection, used to write viz files
   ParaViewDataCollection *pvdc_ = nullptr;
 

--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -243,7 +243,7 @@ void CaloricallyPerfectThermoChem::initializeSelf() {
   }
 
   tpsP_->getInput("loMach/calperfect/numerical-integ", numerical_integ_, true);
-  
+
   //-----------------------------------------------------
   // 2) Set the initial condition
   //-----------------------------------------------------
@@ -262,21 +262,21 @@ void CaloricallyPerfectThermoChem::initializeSelf() {
   // which is read later.
 
   tpsP_->getInput("loMach/calperfect/ic", ic_string_, std::string(""));
-  
+
   // set IC if we have one at this point
   if (!ic_string_.empty()) {
     if (ic_string_ == "rt3D") {
-      if(rank0_) std::cout << "Setting rt3D IC..." << std::endl;
+      if (rank0_) std::cout << "Setting rt3D IC..." << std::endl;
       FunctionCoefficient t_excoeff(temp_rt3d);
       t_excoeff.SetTime(0.0);
-      Tn_gf_.ProjectCoefficient(t_excoeff);      
+      Tn_gf_.ProjectCoefficient(t_excoeff);
     }
   } else {
     ConstantCoefficient t_ic_coef;
     t_ic_coef.constant = T_ic_;
-    Tn_gf_.ProjectCoefficient(t_ic_coef);    
+    Tn_gf_.ProjectCoefficient(t_ic_coef);
   }
-  
+
   Tn_gf_.GetTrueDofs(Tn_);
   Tnm1_gf_.SetFromTrueDofs(Tn_);
   Tnm2_gf_.SetFromTrueDofs(Tn_);
@@ -750,19 +750,16 @@ void CaloricallyPerfectThermoChem::initializeViz(ParaViewDataCollection &pvdc) {
   pvdc.RegisterField("Qt", &Qt_gf_);
 }
 
-void CaloricallyPerfectThermoChem::initializeStats(Averaging &average, IODataOrganizer &io) {
-  
+void CaloricallyPerfectThermoChem::initializeStats(Averaging &average, IODataOrganizer &io, bool continuation) {
   if (average.ComputeMean()) {
-
     // fields for averaging
     average.registerField(std::string("temperature"), &Tn_gf_, false, 0, 1);
 
     // io init
-    io.registerIOFamily("Time-averaged temperature", "/meanTemp", average.GetMeanField(std::string("temperature")), false, true, sfec_);
+    io.registerIOFamily("Time-averaged temperature", "/meanTemp", average.GetMeanField(std::string("temperature")),
+                        false, continuation, sfec_);
     io.registerIOVar("/meanTemp", "<T>", 0, true);
-
   }
-  
 }
 
 /**
@@ -1466,17 +1463,17 @@ double temp_rt3d(const Vector &x, double t) {
   double yInt, dy, wt;
   double temp, dT;
   double Tlo = 100.0;
-  double Thi = 1500.0;  
+  double Thi = 1500.0;
 
   yInt = std::cos(twoPi * x[0]) + std::cos(twoPi * x[2]);
   yInt *= CC;
   yInt += 4.0;
-  
+
   dy = x[1] - yInt;
   dT = Thi - Tlo;
 
-  wt = 0.5 * (tanh(-dy/yWidth) + 1.0);
-  temp = Tlo + wt*dT;
+  wt = 0.5 * (tanh(-dy / yWidth) + 1.0);
+  temp = Tlo + wt * dT;
 
   return temp;
 }

--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -242,6 +242,8 @@ void CaloricallyPerfectThermoChem::initializeSelf() {
     std::cout << "exports set..." << endl;
   }
 
+  tpsP_->getInput("loMach/calperfect/numerical-integ", numerical_integ_, true);
+  
   //-----------------------------------------------------
   // 2) Set the initial condition
   //-----------------------------------------------------

--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -733,6 +733,24 @@ void CaloricallyPerfectThermoChem::initializeViz(ParaViewDataCollection &pvdc) {
   pvdc.RegisterField("Qt", &Qt_gf_);
 }
 
+void CaloricallyPerfectThermoChem::initializeStats(Averaging &average, ParaViewDataCollection &pvdc, IODataOrganizer &io) {
+  
+  if (average.ComputeMean()) {
+
+    // fields for averaging
+    average.registerField(std::string("temperature"), &Tn_gf_, false, 0, 1);
+
+    // viz init
+    pvdc.RegisterField("meanTemp", average.GetMeanField(std::string("temperature")));
+
+    // io init
+    io.registerIOFamily("Time-averaged temperature", "/meanTemp", average.GetMeanField(std::string("temperature")), false, true, sfec_);
+    io.registerIOVar("/meanTemp", "<T>", 0, true);
+
+  }
+  
+}
+
 /**
    Update boundary conditions for Temperature, useful for
    ramping a dirichlet condition over time

--- a/src/calorically_perfect.hpp
+++ b/src/calorically_perfect.hpp
@@ -71,6 +71,8 @@ class CaloricallyPerfectThermoChem : public ThermoChemModelBase {
   double dt_;
   double time_;
 
+  std::string ic_string_;
+  
   // Flags
   bool rank0_;                      /**< true if this is rank 0 */
   bool partial_assembly_ = false;   /**< Enable/disable partial assembly of forms. */
@@ -216,7 +218,7 @@ class CaloricallyPerfectThermoChem : public ThermoChemModelBase {
   void step() final;
   void initializeIO(IODataOrganizer &io) final;
   void initializeViz(ParaViewDataCollection &pvdc) final;
-  void initializeStats(Averaging &average, ParaViewDataCollection &pvdc, IODataOrganizer &io) final;
+  void initializeStats(Averaging &average, IODataOrganizer &io) final;
 
   void screenHeader(std::vector<std::string> &header) const final;
   void screenValues(std::vector<double> &values) final;

--- a/src/calorically_perfect.hpp
+++ b/src/calorically_perfect.hpp
@@ -45,6 +45,7 @@ class Tps;
 
 #include "dirichlet_bc_helper.hpp"
 #include "io.hpp"
+#include "averaging.hpp"
 #include "thermo_chem_base.hpp"
 #include "tps_mfem_wrap.hpp"
 
@@ -215,6 +216,7 @@ class CaloricallyPerfectThermoChem : public ThermoChemModelBase {
   void step() final;
   void initializeIO(IODataOrganizer &io) final;
   void initializeViz(ParaViewDataCollection &pvdc) final;
+  void initializeStats(Averaging &average, ParaViewDataCollection &pvdc, IODataOrganizer &io) final;
 
   void screenHeader(std::vector<std::string> &header) const final;
   void screenValues(std::vector<double> &values) final;

--- a/src/calorically_perfect.hpp
+++ b/src/calorically_perfect.hpp
@@ -43,9 +43,9 @@ class Tps;
 
 #include <iostream>
 
+#include "averaging.hpp"
 #include "dirichlet_bc_helper.hpp"
 #include "io.hpp"
-#include "averaging.hpp"
 #include "thermo_chem_base.hpp"
 #include "tps_mfem_wrap.hpp"
 
@@ -72,7 +72,7 @@ class CaloricallyPerfectThermoChem : public ThermoChemModelBase {
   double time_;
 
   std::string ic_string_;
-  
+
   // Flags
   bool rank0_;                      /**< true if this is rank 0 */
   bool partial_assembly_ = false;   /**< Enable/disable partial assembly of forms. */
@@ -218,7 +218,7 @@ class CaloricallyPerfectThermoChem : public ThermoChemModelBase {
   void step() final;
   void initializeIO(IODataOrganizer &io) final;
   void initializeViz(ParaViewDataCollection &pvdc) final;
-  void initializeStats(Averaging &average, IODataOrganizer &io) final;
+  void initializeStats(Averaging &average, IODataOrganizer &io, bool continuation) final;
 
   void screenHeader(std::vector<std::string> &header) const final;
   void screenValues(std::vector<double> &values) final;

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -425,11 +425,7 @@ void LoMachSolver::solveStep() {
   }
 
   // averages
-  if (avg_opts_->sample_interval_ != 0) {
-    if (iter % avg_opts_->sample_interval_ == 0 && iter != 0) {
-      average_->addSample(iter, nullptr);
-    }
-  }
+  average_->addSample(iter);
 
   // restart files
   if (iter % loMach_opts_.output_frequency_ == 0 && iter != 0) {

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -409,9 +409,11 @@ void LoMachSolver::solveStep() {
     }
   }
 
-  // averages
-  if (iter % avg_opts_->sample_interval_ == 0 && iter != 0) {
-    average_->addSample(iter, nullptr);
+  // averages 
+  if (avg_opts_->sample_interval_ != 0) {
+    if (iter % avg_opts_->sample_interval_ == 0 && iter != 0) {
+      average_->addSample(iter, nullptr);
+    }
   }
   
   // restart files

--- a/src/loMach.hpp
+++ b/src/loMach.hpp
@@ -71,6 +71,7 @@ class Tps;
 #include "thermo_chem_base.hpp"
 #include "tps_mfem_wrap.hpp"
 #include "turb_model_base.hpp"
+#include "averaging.hpp"
 
 struct temporalSchemeCoefficients {
   // Current time
@@ -127,6 +128,8 @@ class LoMachSolver : public TPS::PlasmaSolver {
   FlowBase *flow_ = nullptr;
   SpongeBase *sponge_ = nullptr;
   ExternalDataBase *extData_ = nullptr;
+  AveragingOptions *avg_opts_ = nullptr;
+  Averaging *average_ = nullptr;
 
   // Mesh and geometry related
   ParMesh *pmesh_ = nullptr;

--- a/src/loMach.hpp
+++ b/src/loMach.hpp
@@ -61,6 +61,7 @@ class Tps;
 
 #include <tps_config.h>
 
+#include "averaging.hpp"
 #include "externalData_base.hpp"
 #include "io.hpp"
 #include "loMach_options.hpp"
@@ -71,7 +72,6 @@ class Tps;
 #include "thermo_chem_base.hpp"
 #include "tps_mfem_wrap.hpp"
 #include "turb_model_base.hpp"
-#include "averaging.hpp"
 
 struct temporalSchemeCoefficients {
   // Current time

--- a/src/split_flow_base.hpp
+++ b/src/split_flow_base.hpp
@@ -91,8 +91,8 @@ class FlowBase {
 
   virtual void initializeIO(IODataOrganizer &io) const {}
   virtual void initializeViz(mfem::ParaViewDataCollection &pvdc) const {}
-  virtual void initializeStats(Averaging &average, IODataOrganizer &io) const {}
-  
+  virtual void initializeStats(Averaging &average, IODataOrganizer &io, bool continuation) const {}
+
   /**
    * @brief Header strings for screen dump
    *

--- a/src/split_flow_base.hpp
+++ b/src/split_flow_base.hpp
@@ -38,6 +38,7 @@
 #include "tps_mfem_wrap.hpp"
 
 class IODataOrganizer;
+class Averaging;
 struct thermoChemToFlow;
 struct turbModelToFlow;
 struct spongeToFlow;
@@ -90,7 +91,8 @@ class FlowBase {
 
   virtual void initializeIO(IODataOrganizer &io) const {}
   virtual void initializeViz(mfem::ParaViewDataCollection &pvdc) const {}
-
+  virtual void initializeStats(Averaging &average, mfem::ParaViewDataCollection &pvdc, IODataOrganizer &io) const {}
+  
   /**
    * @brief Header strings for screen dump
    *

--- a/src/split_flow_base.hpp
+++ b/src/split_flow_base.hpp
@@ -91,7 +91,7 @@ class FlowBase {
 
   virtual void initializeIO(IODataOrganizer &io) const {}
   virtual void initializeViz(mfem::ParaViewDataCollection &pvdc) const {}
-  virtual void initializeStats(Averaging &average, mfem::ParaViewDataCollection &pvdc, IODataOrganizer &io) const {}
+  virtual void initializeStats(Averaging &average, IODataOrganizer &io) const {}
   
   /**
    * @brief Header strings for screen dump

--- a/src/thermo_chem_base.hpp
+++ b/src/thermo_chem_base.hpp
@@ -42,6 +42,7 @@ class Tps;
 }
 
 class IODataOrganizer;
+class Averaging;
 struct flowToThermoChem;
 struct turbModelToThermoChem;
 struct spongeToThermoChem;
@@ -123,6 +124,11 @@ class ThermoChemModelBase {
    */
   virtual void initializeViz(mfem::ParaViewDataCollection &pvdc) {}
 
+  /**
+   * @brief Hook to let averaging register fields and related visualization fields with ParaViewDataCollection, and restart fields with the IODataOrganizer.
+   */  
+  virtual void initializeStats(Averaging &average, mfem::ParaViewDataCollection &pvdc, IODataOrganizer &io) {}
+  
   /**
    * @brief Header strings for screen dump
    *

--- a/src/thermo_chem_base.hpp
+++ b/src/thermo_chem_base.hpp
@@ -125,9 +125,9 @@ class ThermoChemModelBase {
   virtual void initializeViz(mfem::ParaViewDataCollection &pvdc) {}
 
   /**
-   * @brief Hook to let averaging register fields and related visualization fields with ParaViewDataCollection, and restart fields with the IODataOrganizer.
+   * @brief Hook to let averaging register fields and restart fields with the IODataOrganizer.
    */  
-  virtual void initializeStats(Averaging &average, mfem::ParaViewDataCollection &pvdc, IODataOrganizer &io) {}
+  virtual void initializeStats(Averaging &average, IODataOrganizer &io) {}
   
   /**
    * @brief Header strings for screen dump

--- a/src/thermo_chem_base.hpp
+++ b/src/thermo_chem_base.hpp
@@ -126,9 +126,9 @@ class ThermoChemModelBase {
 
   /**
    * @brief Hook to let averaging register fields and restart fields with the IODataOrganizer.
-   */  
-  virtual void initializeStats(Averaging &average, IODataOrganizer &io) {}
-  
+   */
+  virtual void initializeStats(Averaging &average, IODataOrganizer &io, bool continuation) {}
+
   /**
    * @brief Header strings for screen dump
    *

--- a/src/tomboulides.cpp
+++ b/src/tomboulides.cpp
@@ -1032,17 +1032,13 @@ void Tomboulides::initializeViz(mfem::ParaViewDataCollection &pvdc) const {
   }  
 }
 
-void Tomboulides::initializeStats(Averaging &average, mfem::ParaViewDataCollection &pvdc, IODataOrganizer &io) const {
+void Tomboulides::initializeStats(Averaging &average, IODataOrganizer &io) const {
   
   if (average.ComputeMean()) {
 
     // fields for averaging
     average.registerField(std::string("velocity"), u_curr_gf_, true, 0, nvel_);
     average.registerField(std::string("pressure"), p_gf_, false, 0, 1);  
-
-    // viz init
-    pvdc.RegisterField("meanVel", average.GetMeanField(std::string("velocity")));
-    pvdc.RegisterField("meanPres", average.GetMeanField(std::string("pressure")));    
 
     // io init
     io.registerIOFamily("Time-averaged velocity", "/meanVel", average.GetMeanField(std::string("velocity")), false, true, vfec_);
@@ -1054,7 +1050,6 @@ void Tomboulides::initializeStats(Averaging &average, mfem::ParaViewDataCollecti
     io.registerIOVar("/meanPres", "<P>", 0, true);
 
     // rms
-    /*
     io.registerIOFamily("RMS velocity fluctuation", "/rmsData",
 			average.GetVariField(std::string("velocity")), false, true,vfec_);
     if (nvel_ == 3) {
@@ -1072,7 +1067,6 @@ void Tomboulides::initializeStats(Averaging &average, mfem::ParaViewDataCollecti
       // only nvel = 2 or 3 supported
       assert(false);
     }
-    */
 		       
   }
   

--- a/src/tomboulides.cpp
+++ b/src/tomboulides.cpp
@@ -1021,7 +1021,7 @@ void Tomboulides::initializeIO(IODataOrganizer &io) const {
   if (axisym_) {
     io.registerIOFamily("Velocity azimuthal", "/swirl", utheta_gf_, true, true, pfec_);
     io.registerIOVar("/swirl", "swirl", 0);
-  }  
+  }
 }
 
 void Tomboulides::initializeViz(mfem::ParaViewDataCollection &pvdc) const {
@@ -1029,29 +1029,29 @@ void Tomboulides::initializeViz(mfem::ParaViewDataCollection &pvdc) const {
   pvdc.RegisterField("pressure", p_gf_);
   if (axisym_) {
     pvdc.RegisterField("swirl", utheta_gf_);
-  }  
+  }
 }
 
-void Tomboulides::initializeStats(Averaging &average, IODataOrganizer &io) const {
-  
+void Tomboulides::initializeStats(Averaging &average, IODataOrganizer &io, bool continuation) const {
   if (average.ComputeMean()) {
-
     // fields for averaging
     average.registerField(std::string("velocity"), u_curr_gf_, true, 0, nvel_);
-    average.registerField(std::string("pressure"), p_gf_, false, 0, 1);  
+    average.registerField(std::string("pressure"), p_gf_, false, 0, 1);
 
     // io init
-    io.registerIOFamily("Time-averaged velocity", "/meanVel", average.GetMeanField(std::string("velocity")), false, true, vfec_);
+    io.registerIOFamily("Time-averaged velocity", "/meanVel", average.GetMeanField(std::string("velocity")), false,
+                        continuation, vfec_);
     io.registerIOVar("/meanVel", "<u>", 0, true);
     if (dim_ >= 2) io.registerIOVar("/meanVel", "<v>", 1, true);
     if (dim_ == 3) io.registerIOVar("/meanVel", "<w>", 2, true);
-    
-    io.registerIOFamily("Time-averaged pressure", "/meanPres", average.GetMeanField(std::string("pressure")), false, true, pfec_);
+
+    io.registerIOFamily("Time-averaged pressure", "/meanPres", average.GetMeanField(std::string("pressure")), false,
+                        continuation, pfec_);
     io.registerIOVar("/meanPres", "<P>", 0, true);
 
     // rms
-    io.registerIOFamily("RMS velocity fluctuation", "/rmsData",
-			average.GetVariField(std::string("velocity")), false, true,vfec_);
+    io.registerIOFamily("RMS velocity fluctuation", "/rmsData", average.GetVariField(std::string("velocity")), false,
+                        continuation, vfec_);
     if (nvel_ == 3) {
       io.registerIOVar("/rmsData", "uu", 0);
       io.registerIOVar("/rmsData", "vv", 1);
@@ -1067,9 +1067,7 @@ void Tomboulides::initializeStats(Averaging &average, IODataOrganizer &io) const
       // only nvel = 2 or 3 supported
       assert(false);
     }
-		       
   }
-  
 }
 
 void Tomboulides::step() {

--- a/src/tomboulides.cpp
+++ b/src/tomboulides.cpp
@@ -1053,16 +1053,16 @@ void Tomboulides::initializeStats(Averaging &average, IODataOrganizer &io, bool 
     io.registerIOFamily("RMS velocity fluctuation", "/rmsData", average.GetVariField(std::string("velocity")), false,
                         continuation, vfec_);
     if (nvel_ == 3) {
-      io.registerIOVar("/rmsData", "uu", 0);
-      io.registerIOVar("/rmsData", "vv", 1);
-      io.registerIOVar("/rmsData", "ww", 2);
-      io.registerIOVar("/rmsData", "uv", 3);
-      io.registerIOVar("/rmsData", "uw", 4);
-      io.registerIOVar("/rmsData", "vw", 5);
+      io.registerIOVar("/rmsData", "uu", 0, true);
+      io.registerIOVar("/rmsData", "vv", 1, true);
+      io.registerIOVar("/rmsData", "ww", 2, true);
+      io.registerIOVar("/rmsData", "uv", 3, true);
+      io.registerIOVar("/rmsData", "uw", 4, true);
+      io.registerIOVar("/rmsData", "vw", 5, true);
     } else if (nvel_ == 2) {
-      io.registerIOVar("/rmsData", "uu", 0);
-      io.registerIOVar("/rmsData", "vv", 1);
-      io.registerIOVar("/rmsData", "uv", 2);
+      io.registerIOVar("/rmsData", "uu", 0, true);
+      io.registerIOVar("/rmsData", "vv", 1, true);
+      io.registerIOVar("/rmsData", "uv", 2, true);
     } else {
       // only nvel = 2 or 3 supported
       assert(false);

--- a/src/tomboulides.cpp
+++ b/src/tomboulides.cpp
@@ -1049,10 +1049,12 @@ void Tomboulides::initializeStats(Averaging &average, mfem::ParaViewDataCollecti
     io.registerIOVar("/meanVel", "<u>", 0, true);
     if (dim_ >= 2) io.registerIOVar("/meanVel", "<v>", 1, true);
     if (dim_ == 3) io.registerIOVar("/meanVel", "<w>", 2, true);
+    
     io.registerIOFamily("Time-averaged pressure", "/meanPres", average.GetMeanField(std::string("pressure")), false, true, pfec_);
     io.registerIOVar("/meanPres", "<P>", 0, true);
 
     // rms
+    /*
     io.registerIOFamily("RMS velocity fluctuation", "/rmsData",
 			average.GetVariField(std::string("velocity")), false, true,vfec_);
     if (nvel_ == 3) {
@@ -1070,6 +1072,7 @@ void Tomboulides::initializeStats(Averaging &average, mfem::ParaViewDataCollecti
       // only nvel = 2 or 3 supported
       assert(false);
     }
+    */
 		       
   }
   

--- a/src/tomboulides.hpp
+++ b/src/tomboulides.hpp
@@ -355,9 +355,9 @@ class Tomboulides final : public FlowBase {
 
   /**
    * @brief Initialize statistics outputs
-   */  
-  void initializeStats(Averaging &average, IODataOrganizer &io) const final;
-  
+   */
+  void initializeStats(Averaging &average, IODataOrganizer &io, bool continuation) const final;
+
   /// Advance
   void step() final;
 

--- a/src/tomboulides.hpp
+++ b/src/tomboulides.hpp
@@ -353,6 +353,11 @@ class Tomboulides final : public FlowBase {
    */
   void initializeViz(mfem::ParaViewDataCollection &pvdc) const final;
 
+  /**
+   * @brief Initialize statistics outputs
+   */  
+  void initializeStats(Averaging &average, mfem::ParaViewDataCollection &pvdc, IODataOrganizer &io) const final;
+  
   /// Advance
   void step() final;
 

--- a/src/tomboulides.hpp
+++ b/src/tomboulides.hpp
@@ -356,7 +356,7 @@ class Tomboulides final : public FlowBase {
   /**
    * @brief Initialize statistics outputs
    */  
-  void initializeStats(Averaging &average, mfem::ParaViewDataCollection &pvdc, IODataOrganizer &io) const final;
+  void initializeStats(Averaging &average, IODataOrganizer &io) const final;
   
   /// Advance
   void step() final;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -31,6 +31,7 @@ EXTRA_DIST  = tap-driver.sh test_tps_splitcomm.py soln_differ inputs meshes lte-
 	      ref_solns/lequere-varmu/*.h5 \
 	      ref_solns/taylor-couette/*.h5 \
 	      ref_solns/pipe/*.h5 \
+	      ref_solns/aveLoMach/*.h5 \
 		      vpath.sh die.sh count_gpus.sh sniff_mpirun.sh \
 		      cyl3d.gpu.test cyl3d.mflow.gpu.test wedge.gpu.test \
 	          averaging.gpu.test cyl3d.test cyl3d.gpu.python.test cyl3d.mflow.test cyl3d.dtconst.test \
@@ -45,7 +46,7 @@ EXTRA_DIST  = tap-driver.sh test_tps_splitcomm.py soln_differ inputs meshes lte-
 		      tabulated.test lte_mixture.test distance_fcn.test \
               sgsSmag.test sgsSigma.test heatEq.test sponge.test plate.test pipe.mix.test lte2noneq-restart.test \
               coupled-3d.interface.test plasma.axisym.test plasma.axisym.lte1d.test \
-	      lomach-flow.test lomach-lequere.test interpInlet.test sgsLoMach.test autoPeriodic.test
+	      lomach-flow.test lomach-lequere.test interpInlet.test sgsLoMach.test autoPeriodic.test aveLoMach.test
 
 TESTS = vpath.sh
 XFAIL_TESTS =
@@ -110,7 +111,8 @@ TESTS += cyl3d.test \
 	 lomach-flow.test \
 	 lomach-lequere.test \
          interpInlet.test \
-         autoPeriodic.test
+         autoPeriodic.test \
+         aveLoMach.test
 
 if PYTHON_ENABLED
 TESTS += cyl3d.python.test \

--- a/test/aveLoMach.test
+++ b/test/aveLoMach.test
@@ -1,0 +1,30 @@
+#!./bats
+# -*- mode: sh -*-
+
+TEST="aveLoMach"
+RUNFILE="inputs/input.aveLoMach.ini"
+EXE="../src/tps"
+RESTART="ref_solns/aveLoMach/restart_output.sol.h5"
+
+setup() {
+    SOLN_FILE=restart_output.sol.h5
+    REF_FILE=ref_solns/aveLoMach/restart_output.sol.h5
+}
+
+@test "[$TEST] check for input file $RUNFILE" {
+    test -s $RUNFILE
+}
+
+@test "[$TEST] run tps with input -> $RUNFILE" {
+    rm -rf output/*
+    rm -f $SOLN_FILE
+    run $EXE --runFile $RUNFILE
+    [[ ${status} -eq 0 ]]
+    test -s $SOLN_FILE
+}
+
+@test "[$TEST] verify tps output with input -> $RUNFILE" {
+    test -s $SOLN_FILE
+    test -s $REF_FILE
+    h5diff -r --delta=1e-12 $SOLN_FILE $REF_FILE meanVel
+}

--- a/test/inputs/input.aveLoMach.ini
+++ b/test/inputs/input.aveLoMach.ini
@@ -1,0 +1,83 @@
+[solver]
+type = loMach
+
+[loMach]
+flow-solver = tomboulides
+thermo-solver = calorically-perfect
+mesh = meshes/flatBox.msh
+order = 1
+maxIters = 100
+outputFreq = 100
+fluid = dry_air
+refLength = 1.0
+equation_system = navier-stokes
+enablePressureForcing = False
+enableGravity = False
+openSystem = True
+ambientPressure = 101326.
+sgsModel = none
+#sgsModel = smagorinsky
+sgsModelConstant = 0.09
+
+[loMach/calperfect]
+#viscosity-model = constant
+#density-model = constant
+#constant-visc/mu0 = 1.552e-5
+#constant-density = 1.1839
+linear-solver-rtol = 1.0e-12
+linear-solver-max-iter = 2000
+viscosity-model = sutherland
+sutherland/mu0 = 1.68e-5
+sutherland/T0 = 273.0
+sutherland/S0 = 110.4
+numerical-integ = false
+#Prandtl = 0.72
+Prandtl = 0.01
+
+[loMach/tomboulides]
+linear-solver-rtol = 1.0e-12
+linear-solver-max-iter = 2000
+numerical-integ = false
+ic = tgv2d_uniform
+
+[io]
+outdirBase = output
+#enableRestart = True                                                                                                                                                         
+#restartMode = variableP
+
+[time]
+integrator = curlcurl
+cfl = 0.5
+#dt_fixed = 1.0e-4
+dt_initial = 1.0e-4
+dtFactor = 0.01
+
+[initialConditions]
+rho = 1.1839
+rhoU = 0.
+rhoV = 0.
+rhoW = 0.
+temperature = 298.15
+pressure = 101325.0
+
+[averaging]
+enableContinuation = False
+#enableContinuation = True
+#restartRMS = True
+saveMeanHist = True
+startIter = 1
+sampleFreq = 10
+
+[boundaryConditions]
+numWalls = 0
+numInlets = 0
+numOutlets = 0
+
+[periodicity]
+enablePeriodic = True
+periodicX = True
+periodicY = True
+periodicZ = True
+#xTrans = 1.0
+#yTrans = 1.0
+#zTrans = 0.1

--- a/test/ref_solns/aveLoMach/restart_output.sol.h5
+++ b/test/ref_solns/aveLoMach/restart_output.sol.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3d84bab6ef05f42cdad7b3e28a758b3a1f32b0eaaf55ec3cdf0a7b04a47fec0
+size 382040


### PR DESCRIPTION
This PR adds support for computing averages on in low Mach simulations.  It includes both extensions to `LoMachSolver` and supporting classes (e.g., `Tomboulides`) to use the `Averaging` class, as well as bug fixes, specifically to the rms calculations within `Averaging`.

This is a replacement for PR #276.  It introduces the same averaging capabilities (and is based on commits originally introduced on the `fix-averaging` branch) but the quadrature changes from #276 are left for a separate PR.