### PR TITLE
local element size for time-stepping

### DIFF
--- a/src/algebraicSubgridModels.cpp
+++ b/src/algebraicSubgridModels.cpp
@@ -114,7 +114,7 @@ void AlgebraicSubgridModels::initializeSelf() {
   // gridScaleZ_.SetSize(sfes_truevsize);
   // resolution_gf_.SetSpace(sfes_);
 
-  if (verbose) grvy_printf(ginfo, "AlgebraicSubgridModels vectors and gf initialized...\n");
+  if (rank0_) grvy_printf(ginfo, "AlgebraicSubgridModels vectors and gf initialized...\n");
 
   // exports
   toFlow_interface_.eddy_viscosity = &subgridVisc_gf_;

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -351,7 +351,11 @@ void LoMachSolver::solveBegin() {
     std::cout << std::endl;
     std::cout << std::setw(11) << "#     Step ";
     std::cout << std::setw(13) << "Time ";
-    std::cout << std::setw(13) << "dt ";
+    if (loMach_opts_.ts_opts_.constant_dt_ < 0.0) {
+      std::cout << std::setw(13) << "CFL ";
+    } else {
+      std::cout << std::setw(13) << "dt ";
+    }
     std::cout << std::setw(13) << "Wtime/Step ";
     for (size_t i = 0; i < thermo_header.size(); i++) {
       std::cout << std::setw(12) << thermo_header[i] << " ";
@@ -365,7 +369,12 @@ void LoMachSolver::solveBegin() {
 
     std::cout << std::setw(10) << iter << " ";
     std::cout << std::setw(10) << std::scientific << temporal_coeff_.time << " ";
-    std::cout << std::setw(10) << std::scientific << temporal_coeff_.dt << " ";
+    if (loMach_opts_.ts_opts_.constant_dt_ < 0.0) {
+      double max_cfl = computeCFL();
+      std::cout << std::setw(10) << std::scientific << max_cfl << " ";      
+    } else {
+      std::cout << std::setw(10) << std::scientific << temporal_coeff_.dt << " ";
+    }
     std::cout << std::setw(10) << std::scientific << 0.0 << " ";
     for (size_t i = 0; i < thermo_screen_values.size(); i++) {
       std::cout << std::setw(10) << std::scientific << thermo_screen_values[i] << " ";
@@ -421,7 +430,12 @@ void LoMachSolver::solveStep() {
     if (rank0_) {
       // TODO(trevilo): Add state summary
       std::cout << std::setw(10) << iter << " ";
-      std::cout << std::setw(10) << std::scientific << temporal_coeff_.time << " ";
+      if (loMach_opts_.ts_opts_.constant_dt_ < 0.0) {
+        double max_cfl = computeCFL();
+        std::cout << std::setw(10) << std::scientific << max_cfl << " ";      
+      } else {      
+        std::cout << std::setw(10) << std::scientific << temporal_coeff_.time << " ";
+      }
       std::cout << std::setw(10) << std::scientific << temporal_coeff_.dt << " ";
       std::cout << std::setw(10) << std::scientific << max_time_per_step << " ";
       for (size_t i = 0; i < thermo_screen_values.size(); i++) {

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -689,8 +689,8 @@ void LoMachSolver::setTimestep() {
       Umag = std::sqrt(Umag);
       Umax_lcl = std::max(Umag, Umax_lcl);
 
+      // local hmin comes in devided by order
       double hmin = dataD[n];
-      hmin /= (double)order;
       convT_lcl = hmin / Umax_lcl; 
       
     }

--- a/src/loMach.hpp
+++ b/src/loMach.hpp
@@ -180,7 +180,7 @@ class LoMachSolver : public TPS::PlasmaSolver {
   // Time marching related parameters
   int iter;
   int iter_start_;
-  double CFL;
+  double CFL_;
 
   int max_bdf_order;  // input option now
   temporalSchemeCoefficients temporal_coeff_;


### PR DESCRIPTION
FIx to dynamic time-stepping to use local minimum element size as opposed to global.  Also, switched screen dump for constant dt to print max CFL instead of the same time-step repeatedly.
