### PR TITLE
compressible bc with face-based uvw

### DIFF
--- a/src/BCintegrator.cpp
+++ b/src/BCintegrator.cpp
@@ -38,10 +38,10 @@
 #include "wallBC.hpp"
 
 BCintegrator::BCintegrator(bool _mpiRoot, MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes,
-                           IntegrationRules *_intRules, RiemannSolver *rsolver_, double &_dt, double *_time, GasMixture *_mixture,
-                           GasMixture *d_mixture, Fluxes *_fluxClass, ParGridFunction *_Up, ParGridFunction *_gradUp,
-                           const boundaryFaceIntegrationData &boundary_face_data, const int _dim,
-                           const int _num_equation, double &_max_char_speed, RunConfiguration &_runFile,
+                           IntegrationRules *_intRules, RiemannSolver *rsolver_, double &_dt, double *_time,
+                           GasMixture *_mixture, GasMixture *d_mixture, Fluxes *_fluxClass, ParGridFunction *_Up,
+                           ParGridFunction *_gradUp, const boundaryFaceIntegrationData &boundary_face_data,
+                           const int _dim, const int _num_equation, double &_max_char_speed, RunConfiguration &_runFile,
                            Array<int> &local_attr, const int &_maxIntPoints, const int &_maxDofs,
                            ParGridFunction *distance)
     : groupsMPI(_groupsMPI),
@@ -68,7 +68,7 @@ BCintegrator::BCintegrator(bool _mpiRoot, MPI_Groups *_groupsMPI, ParMesh *_mesh
   mpiRoot = _mpiRoot;
   time = *_time;
   pTime = _time;
-  
+
   // Init inlet BCs
   for (size_t in = 0; in < config.GetInletPatchType()->size(); in++) {
     std::pair<int, InletType> patchANDtype = (*config.GetInletPatchType())[in];

--- a/src/BCintegrator.hpp
+++ b/src/BCintegrator.hpp
@@ -89,17 +89,18 @@ class BCintegrator : public NonlinearFormIntegrator {
   bool mpiRoot;
   double time;
   double *pTime;
-  
+
   // void calcMeanState();
   void computeBdrFlux(const int attr, Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
                       double delta, double time, double distance, Vector &bdrFlux);
 
  public:
-  BCintegrator(bool _mpiRoot, MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules,
-               RiemannSolver *rsolver_, double &_dt, double *_time, GasMixture *mixture, GasMixture *d_mixture, Fluxes *_fluxClass,
-               ParGridFunction *_Up, ParGridFunction *_gradUp, const boundaryFaceIntegrationData &boundary_face_data,
-               const int _dim, const int _num_equation, double &_max_char_speed, RunConfiguration &_runFile,
-               Array<int> &local_bdr_attr, const int &_maxIntPoints, const int &_maxDofs, ParGridFunction *distance_);
+  BCintegrator(bool _mpiRoot, MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes,
+               IntegrationRules *_intRules, RiemannSolver *rsolver_, double &_dt, double *_time, GasMixture *mixture,
+               GasMixture *d_mixture, Fluxes *_fluxClass, ParGridFunction *_Up, ParGridFunction *_gradUp,
+               const boundaryFaceIntegrationData &boundary_face_data, const int _dim, const int _num_equation,
+               double &_max_char_speed, RunConfiguration &_runFile, Array<int> &local_bdr_attr,
+               const int &_maxIntPoints, const int &_maxDofs, ParGridFunction *distance_);
   ~BCintegrator();
 
   virtual void AssembleFaceVector(const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &Tr,

--- a/src/BCintegrator.hpp
+++ b/src/BCintegrator.hpp
@@ -86,13 +86,17 @@ class BCintegrator : public NonlinearFormIntegrator {
   std::unordered_map<int, BoundaryCondition *> outletBCmap;
   std::unordered_map<int, BoundaryCondition *> wallBCmap;
 
+  bool mpiRoot;
+  double time;
+  double *pTime;
+  
   // void calcMeanState();
   void computeBdrFlux(const int attr, Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip,
-                      double delta, double distance, Vector &bdrFlux);
+                      double delta, double time, double distance, Vector &bdrFlux);
 
  public:
-  BCintegrator(MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules,
-               RiemannSolver *rsolver_, double &_dt, GasMixture *mixture, GasMixture *d_mixture, Fluxes *_fluxClass,
+  BCintegrator(bool _mpiRoot, MPI_Groups *_groupsMPI, ParMesh *_mesh, ParFiniteElementSpace *_vfes, IntegrationRules *_intRules,
+               RiemannSolver *rsolver_, double &_dt, double *_time, GasMixture *mixture, GasMixture *d_mixture, Fluxes *_fluxClass,
                ParGridFunction *_Up, ParGridFunction *_gradUp, const boundaryFaceIntegrationData &boundary_face_data,
                const int _dim, const int _num_equation, double &_max_char_speed, RunConfiguration &_runFile,
                Array<int> &local_bdr_attr, const int &_maxIntPoints, const int &_maxDofs, ParGridFunction *distance_);

--- a/src/BoundaryCondition.hpp
+++ b/src/BoundaryCondition.hpp
@@ -74,7 +74,7 @@ class BoundaryCondition {
   virtual ~BoundaryCondition();
 
   virtual void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
-                              double distance, Vector &bdrFlux) = 0;
+                              double time, double distance, Vector &bdrFlux) = 0;
 
   /** \brief Set the boundary state used in the gradient evaluation
    *

--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -685,9 +685,12 @@ void M2ulPhyS::initVariables() {
   Array<int> local_attr;
   getAttributesInPartition(local_attr);
 
+  double *pTime;
+  pTime = &time;
+  
   bcIntegrator = NULL;
   if (local_attr.Size() > 0) {
-    bcIntegrator = new BCintegrator(groupsMPI, mesh, vfes, intRules, rsolver, dt, mixture, d_mixture, d_fluxClass, Up,
+    bcIntegrator = new BCintegrator(rank0_, groupsMPI, mesh, vfes, intRules, rsolver, dt, pTime, mixture, d_mixture, d_fluxClass, Up,
                                     gradUp, gpu_precomputed_data_.boundary_face_data, dim, num_equation, max_char_speed,
                                     config, local_attr, maxIntPoints, maxDofs, distance_);
   }
@@ -3563,6 +3566,7 @@ void M2ulPhyS::parseBCInputs() {
   // Inlet Bcs
   std::map<std::string, InletType> inletMapping;
   inletMapping["subsonic"] = SUB_DENS_VEL;
+  inletMapping["subsonicFaceBased"] = SUB_DENS_VEL_FACE;  
   inletMapping["nonreflecting"] = SUB_DENS_VEL_NR;
   inletMapping["nonreflectingConstEntropy"] = SUB_VEL_CONST_ENT;
 

--- a/src/M2ulPhyS2Boltzmann.cpp
+++ b/src/M2ulPhyS2Boltzmann.cpp
@@ -90,12 +90,12 @@ void M2ulPhyS::fetch(TPS::Tps2Boltzmann &interface) {
   mfem::ParFiniteElementSpace *reaction_rates_fes(&(interface.NativeFes(TPS::Tps2Boltzmann::Index::ReactionRates)));
   externalReactionRates.reset(new mfem::ParGridFunction(reaction_rates_fes));
   interface.interpolateToNativeFES(*externalReactionRates, TPS::Tps2Boltzmann::Index::ReactionRates);
-  #if defined(_CUDA_) || defined(_HIP_)
-    const double * data(externalReactionRates->Read() );
-    int size(externalReactionRates->FESpace()->GetNDofs() );
-    assert(externalReactionRates->FESpace()->GetOrdering() == mfem::Ordering::byNODES);
-    gpu::deviceSetChemistryReactionData<<<1, 1>>>(data, size, chemistry_);
-  #else
-    chemistry_->setGridFunctionRates(*externalReactionRates);
-  #endif
+#if defined(_CUDA_) || defined(_HIP_)
+  const double *data(externalReactionRates->Read());
+  int size(externalReactionRates->FESpace()->GetNDofs());
+  assert(externalReactionRates->FESpace()->GetOrdering() == mfem::Ordering::byNODES);
+  gpu::deviceSetChemistryReactionData<<<1, 1>>>(data, size, chemistry_);
+#else
+  chemistry_->setGridFunctionRates(*externalReactionRates);
+#endif
 }

--- a/src/chemistry.cpp
+++ b/src/chemistry.cpp
@@ -109,7 +109,7 @@ MFEM_HOST_DEVICE Chemistry::~Chemistry() {
   }
 }
 
-MFEM_HOST_DEVICE void Chemistry::setRates(const double * data, int size) {
+MFEM_HOST_DEVICE void Chemistry::setRates(const double *data, int size) {
   for (int r = 0; r < numReactions_; r++) {
     if (reactions_[r]->reactionModel == GRIDFUNCTION_RXN) {
       GridFunctionReaction *rx = (GridFunctionReaction *)(reactions_[r]);

--- a/src/chemistry.hpp
+++ b/src/chemistry.hpp
@@ -97,7 +97,7 @@ class Chemistry {
 
   // Set the grid function rates for GRIDFUNCTION_RXN reaction types
   void setGridFunctionRates(mfem::GridFunction &f);
-  MFEM_HOST_DEVICE void setRates(const double * data, int size);
+  MFEM_HOST_DEVICE void setRates(const double *data, int size);
 
   // return Vector of reaction rate coefficients, with the size of numReaction_.
   // WARNING(marc) I have removed "virtual" qualifier here assuming these functions will not

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -131,6 +131,7 @@ enum InletType {
   UNI_DENS_VEL,      // uniform inlet with density and vel specified
   INTERPOLATE,       // from an external data file
   SUB_DENS_VEL,      // Subsonic inlet specified by the density and velocity components
+  SUB_DENS_VEL_FACE,      // Subsonic inlet specified by the density and velocity component relative to the inlet face with u = normal, v & w tangent components  
   SUB_DENS_VEL_NR,   // Non-reflecting subsonic inlet specified by the density and velocity components
   SUB_VEL_CONST_ENT  // Subsonic non-reflecting. Specified vel, keeps entropy constant
 };

--- a/src/dataStructures.hpp
+++ b/src/dataStructures.hpp
@@ -128,12 +128,17 @@ enum SpeciesPrimitiveType { MASS_FRACTION, MOLE_FRACTION, NUMBER_DENSITY, NUM_SP
 enum boundaryCategory { INLET, OUTLET, WALL, NUM_BC_CATEGORIES };
 
 enum InletType {
-  UNI_DENS_VEL,      // uniform inlet with density and vel specified
-  INTERPOLATE,       // from an external data file
-  SUB_DENS_VEL,      // Subsonic inlet specified by the density and velocity components
-  SUB_DENS_VEL_FACE,      // Subsonic inlet specified by the density and velocity component relative to the inlet face with u = normal, v & w tangent components  
-  SUB_DENS_VEL_NR,   // Non-reflecting subsonic inlet specified by the density and velocity components
-  SUB_VEL_CONST_ENT  // Subsonic non-reflecting. Specified vel, keeps entropy constant
+  UNI_DENS_VEL,         // uniform inlet with density and vel specified
+  INTERPOLATE,          // from an external data file
+  SUB_DENS_VEL,         // Subsonic inlet specified by the density and velocity components
+  SUB_DENS_VEL_FACE_X,  // Subsonic inlet specified by the density and velocity component relative to the inlet face
+                        // with u = normal, w = global x
+  SUB_DENS_VEL_FACE_Y,  // Subsonic inlet specified by the density and velocity component relative to the inlet face
+                        // with u = normal, w = global y
+  SUB_DENS_VEL_FACE_Z,  // Subsonic inlet specified by the density and velocity component relative to the inlet face
+                        // with u = normal, w = global z
+  SUB_DENS_VEL_NR,      // Non-reflecting subsonic inlet specified by the density and velocity components
+  SUB_VEL_CONST_ENT     // Subsonic non-reflecting. Specified vel, keeps entropy constant
 };
 
 enum OutletType {

--- a/src/gpu_constructor.cpp
+++ b/src/gpu_constructor.cpp
@@ -124,11 +124,11 @@ __global__ void freeDeviceRadiation(Radiation *radiation) {
 //---------------------------------------------------
 // And finally device setters
 //---------------------------------------------------
-__global__ void deviceSetGridFunctionReactionData(const double * data, int size, GridFunctionReaction * reaction) {
+__global__ void deviceSetGridFunctionReactionData(const double *data, int size, GridFunctionReaction *reaction) {
   reaction->setData(data, size);
 }
 
-__global__ void deviceSetChemistryReactionData(const double * data, int size, Chemistry * chem) {
+__global__ void deviceSetChemistryReactionData(const double *data, int size, Chemistry *chem) {
   chem->setRates(data, size);
 }
 

--- a/src/gpu_constructor.hpp
+++ b/src/gpu_constructor.hpp
@@ -161,8 +161,8 @@ __global__ void freeDeviceChemistry(Chemistry *chem);
 __global__ void freeDeviceRadiation(Radiation *radiation);
 
 //! Set the data to a GridFunctionReaction
-__global__ void deviceSetGridFunctionReactionData(const double * data, int size, GridFunctionReaction * reaction);
-__global__ void deviceSetChemistryReactionData(const double * data, int size, Chemistry * chem);
+__global__ void deviceSetGridFunctionReactionData(const double *data, int size, GridFunctionReaction *reaction);
+__global__ void deviceSetChemistryReactionData(const double *data, int size, Chemistry *chem);
 
 #endif  // cuda or hip
 }  // namespace gpu

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -143,7 +143,7 @@ InletBC::InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rs
   boundaryUp.UseDevice(true);
   boundaryUp.SetSize(bdrN * num_equation_);
   boundaryUp = 0.;
-  
+
   Vector iState, iUp;
   iState.UseDevice(false);
   iUp.UseDevice(false);
@@ -215,7 +215,7 @@ InletBC::InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rs
 
   meanUp.Read();
   boundaryU.Read();
-  boundaryUp.Read();  
+  boundaryUp.Read();
   tangent1.Read();
   tangent2.Read();
 }
@@ -439,17 +439,29 @@ void InletBC::initBoundaryU(ParGridFunction *Up) {
   }
 
   boundaryU.Read();
-  boundaryUp.Read();  
+  boundaryUp.Read();
 }
 
-void InletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta, double time, double distance, Vector &bdrFlux) {
+void InletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                             double time, double distance, Vector &bdrFlux) {
+  Vector tangentW(dim_);
+  for (int d = 0; d < dim_; d++) tangentW[d] = 0.0;
   switch (inletType_) {
     case SUB_DENS_VEL:
       subsonicReflectingDensityVelocity(normal, stateIn, bdrFlux);
       break;
-    case SUB_DENS_VEL_FACE:
-      subsonicReflectingDensityVelocityFace(normal, stateIn, transip, time, bdrFlux);
-      break;      
+    case SUB_DENS_VEL_FACE_X:
+      tangentW[0] = 1.0;
+      subsonicReflectingDensityVelocityFace(normal, tangentW, stateIn, transip, time, bdrFlux);
+      break;
+    case SUB_DENS_VEL_FACE_Y:
+      tangentW[1] = 1.0;
+      subsonicReflectingDensityVelocityFace(normal, tangentW, stateIn, transip, time, bdrFlux);
+      break;
+    case SUB_DENS_VEL_FACE_Z:
+      tangentW[2] = 1.0;
+      subsonicReflectingDensityVelocityFace(normal, tangentW, stateIn, transip, time, bdrFlux);
+      break;
     case SUB_DENS_VEL_NR:
       subsonicNonReflectingDensityVelocity(normal, stateIn, gradState, bdrFlux);
       break;
@@ -743,9 +755,10 @@ void InletBC::subsonicReflectingDensityVelocity(Vector &normal, Vector &stateIn,
   rsolver->Eval(stateIn, state2, normal, bdrFlux, true);
 }
 
-/// Specifying subsonic vel and rho wher v is relative to the FACE-coordinate system specifyied by the face normal and y-axis
-void InletBC::subsonicReflectingDensityVelocityFace(Vector &normal, Vector &stateIn, Vector transip, double time, Vector &bdrFlux) {
-
+/// Specifying subsonic vel and rho wher v is relative to the FACE-coordinate system specifyied by the face normal and
+/// tangentW
+void InletBC::subsonicReflectingDensityVelocityFace(Vector &normal, Vector tangentW, Vector &stateIn, Vector transip,
+                                                    double time, Vector &bdrFlux) {
   const double p = mixture->ComputePressure(stateIn);
 
   Vector state2(num_equation_);
@@ -758,6 +771,7 @@ void InletBC::subsonicReflectingDensityVelocityFace(Vector &normal, Vector &stat
   tRamp = 0.1;  // make this readable
   wt = time / tRamp;
   wt = min(wt, 1.0);
+  wt = 1.0;
 
   // injectsion relative to face
   double pi = 3.14159265359;
@@ -770,10 +784,20 @@ void InletBC::subsonicReflectingDensityVelocityFace(Vector &normal, Vector &stat
   for (int d = 0; d < dim_; d++) mod += normal[d] * normal[d];
   unitNorm *= -1.0 / sqrt(mod);  // inward-facing normal
 
-  // t2 aligned with +y-axis
-  tangent2[0] = 0.0;
-  tangent2[1] = 1.0;
-  tangent2[2] = 0.0;
+  // t2 aligned with tangent-w
+  for (int d = 0; d < dim_; d++) tangent2[d] = tangentW[d];
+
+  // ensure normal is orthogonal to tangent-w
+  {
+    Vector projt2(dim_);
+    double tmag, tn;
+    tmag = 0.0;
+    tn = 0.0;
+    for (int d = 0; d < dim_; d++) tmag += tangent2[d] * tangent2[d];
+    for (int d = 0; d < dim_; d++) tn += tangent2[d] * unitNorm[d];
+    for (int d = 0; d < dim_; d++) projt2[d] = (tn / tmag) * tangent2[d];
+    for (int d = 0; d < dim_; d++) unitNorm[d] -= projt2[d];
+  }
 
   // t1 is then orthogonal to both normal and y-axis (clockwise, looking down +)
   tangent1[0] = +(unitNorm[1] * tangent2[2] - unitNorm[2] * tangent2[1]);
@@ -836,7 +860,7 @@ void InletBC::subsonicReflectingDensityVelocityFace(Vector &normal, Vector &stat
   for (int eq = 0; eq < num_equation_; eq++) {
     boundaryUp[eq + bdrN * num_equation_] = iUp[eq];
   }
-  bdrN++;  
+  bdrN++;
 }
 
 void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -764,7 +764,8 @@ void InletBC::subsonicReflectingDensityVelocityFace(Vector &normal, Vector tange
   Vector state2(num_equation_);
   state2 = stateIn;
 
-  double Rgas = mixture->GetGasConstant();
+  // double Rgas = mixture->GetGasConstant();
+  // double pi = 3.14159265359;
   Vector unitNorm;
 
   double tRamp, wt;
@@ -774,7 +775,6 @@ void InletBC::subsonicReflectingDensityVelocityFace(Vector &normal, Vector tange
   wt = 1.0;
 
   // injectsion relative to face
-  double pi = 3.14159265359;
   double Un = wt * inputState[1];
   double Ut = wt * inputState[2];
 
@@ -1012,6 +1012,21 @@ void InletBC::interpInlet_gpu(const mfem::Vector &x, const elementIndexingData &
       // compute mirror state
       switch (type) {
         case InletType::SUB_DENS_VEL:
+          p = d_mix->ComputePressure(u1);
+          pluginInputState(d_inputState, u2, nvel, numActiveSpecies);
+          d_mix->modifyEnergyForPressure(u2, u2, p, true);
+          break;
+        case InletType::SUB_DENS_VEL_FACE_X:
+          p = d_mix->ComputePressure(u1);
+          pluginInputState(d_inputState, u2, nvel, numActiveSpecies);
+          d_mix->modifyEnergyForPressure(u2, u2, p, true);
+          break;
+        case InletType::SUB_DENS_VEL_FACE_Y:
+          p = d_mix->ComputePressure(u1);
+          pluginInputState(d_inputState, u2, nvel, numActiveSpecies);
+          d_mix->modifyEnergyForPressure(u2, u2, p, true);
+          break;
+        case InletType::SUB_DENS_VEL_FACE_Z:
           p = d_mix->ComputePressure(u1);
           pluginInputState(d_inputState, u2, nvel, numActiveSpecies);
           d_mix->modifyEnergyForPressure(u2, u2, p, true);

--- a/src/inletBC.cpp
+++ b/src/inletBC.cpp
@@ -139,6 +139,11 @@ InletBC::InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rs
   boundaryU.UseDevice(true);
   boundaryU.SetSize(bdrN * num_equation_);
   boundaryU = 0.;
+
+  boundaryUp.UseDevice(true);
+  boundaryUp.SetSize(bdrN * num_equation_);
+  boundaryUp = 0.;
+  
   Vector iState, iUp;
   iState.UseDevice(false);
   iUp.UseDevice(false);
@@ -210,6 +215,7 @@ InletBC::InletBC(MPI_Groups *_groupsMPI, Equations _eqSystem, RiemannSolver *_rs
 
   meanUp.Read();
   boundaryU.Read();
+  boundaryUp.Read();  
   tangent1.Read();
   tangent2.Read();
 }
@@ -433,14 +439,17 @@ void InletBC::initBoundaryU(ParGridFunction *Up) {
   }
 
   boundaryU.Read();
+  boundaryUp.Read();  
 }
 
-void InletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
-                             double distance, Vector &bdrFlux) {
+void InletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta, double time, double distance, Vector &bdrFlux) {
   switch (inletType_) {
     case SUB_DENS_VEL:
       subsonicReflectingDensityVelocity(normal, stateIn, bdrFlux);
       break;
+    case SUB_DENS_VEL_FACE:
+      subsonicReflectingDensityVelocityFace(normal, stateIn, transip, time, bdrFlux);
+      break;      
     case SUB_DENS_VEL_NR:
       subsonicNonReflectingDensityVelocity(normal, stateIn, gradState, bdrFlux);
       break;
@@ -732,6 +741,102 @@ void InletBC::subsonicReflectingDensityVelocity(Vector &normal, Vector &stateIn,
   mixture->modifyEnergyForPressure(state2, state2, p, true);
 
   rsolver->Eval(stateIn, state2, normal, bdrFlux, true);
+}
+
+/// Specifying subsonic vel and rho wher v is relative to the FACE-coordinate system specifyied by the face normal and y-axis
+void InletBC::subsonicReflectingDensityVelocityFace(Vector &normal, Vector &stateIn, Vector transip, double time, Vector &bdrFlux) {
+
+  const double p = mixture->ComputePressure(stateIn);
+
+  Vector state2(num_equation_);
+  state2 = stateIn;
+
+  double Rgas = mixture->GetGasConstant();
+  Vector unitNorm;
+
+  double tRamp, wt;
+  tRamp = 0.1;  // make this readable
+  wt = time / tRamp;
+  wt = min(wt, 1.0);
+
+  // injectsion relative to face
+  double pi = 3.14159265359;
+  double Un = wt * inputState[1];
+  double Ut = wt * inputState[2];
+
+  // unit normals pointing INTO of domain
+  unitNorm = normal;
+  double mod = 0.;
+  for (int d = 0; d < dim_; d++) mod += normal[d] * normal[d];
+  unitNorm *= -1.0 / sqrt(mod);  // inward-facing normal
+
+  // t2 aligned with +y-axis
+  tangent2[0] = 0.0;
+  tangent2[1] = 1.0;
+  tangent2[2] = 0.0;
+
+  // t1 is then orthogonal to both normal and y-axis (clockwise, looking down +)
+  tangent1[0] = +(unitNorm[1] * tangent2[2] - unitNorm[2] * tangent2[1]);
+  tangent1[1] = -(unitNorm[0] * tangent2[2] - unitNorm[2] * tangent2[0]);
+  tangent1[2] = +(unitNorm[0] * tangent2[1] - unitNorm[1] * tangent2[0]);
+
+  // aligned with face coords
+  state2[0] = inputState[0];
+  // if using temp as the input input, then... p / (Rgas * inputState[0]);
+  state2[1] = state2[0] * Un;
+  state2[2] = state2[0] * Ut;
+  if (nvel_ == 3) state2[3] = state2[0] * 0.0;
+
+  if (eqSystem == NS_PASSIVE) {
+    state2[num_equation_ - 1] = 0.;
+  } else if (numActiveSpecies_ > 0) {
+    for (int sp = 0; sp < numActiveSpecies_; sp++) {
+      // NOTE: inlet BC does not specify total energy. therefore skips one index.
+      // NOTE: regardless of dim_ension, inletBC save the first 4 elements for density and velocity.
+      state2[nvel_ + 2 + sp] = inputState[4 + sp];
+    }
+  }
+
+  // transform from face coords to global
+  {
+    DenseMatrix M(dim_, dim_);
+    for (int d = 0; d < dim_; d++) {
+      M(0, d) = unitNorm[d];
+      M(1, d) = tangent1[d];
+      if (dim_ == 3) M(2, d) = tangent2[d];
+    }
+    DenseMatrix invM(dim_, dim_);
+    mfem::CalcInverse(M, invM);
+    Vector momN(dim_), momX(dim_);
+    for (int d = 0; d < dim_; d++) momN[d] = state2[1 + d];
+    invM.Mult(momN, momX);
+    for (int d = 0; d < dim_; d++) state2[1 + d] = momX[d];
+  }
+
+  if (eqSystem == NS_PASSIVE) {
+    state2[num_equation_ - 1] = 0.;
+  } else if (numActiveSpecies_ > 0) {
+    for (int sp = 0; sp < numActiveSpecies_; sp++) {
+      // NOTE: inlet BC does not specify total energy. therefore skips one index.
+      // NOTE: regardless of dim_ension, inletBC save the first 4 elements for density and velocity.
+      state2[nvel_ + 2 + sp] = inputState[4 + sp];
+    }
+  }
+
+  // NOTE: If two-temperature, BC for electron temperature is T_e = T_h, where the total pressure is p.
+  Vector tmpU(num_equation_);
+  tmpU = state2;
+  for (int eq = 1; eq <= dim_; eq++) tmpU[eq] = 2.0 * state2[eq] - stateIn[eq];
+  mixture->modifyEnergyForPressure(tmpU, tmpU, p, true);
+  rsolver->Eval(stateIn, tmpU, normal, bdrFlux, true);
+
+  // store primitive in boundaryU for gradient calcs
+  Vector iUp(num_equation_);
+  mixture->GetPrimitivesFromConservatives(tmpU, iUp);
+  for (int eq = 0; eq < num_equation_; eq++) {
+    boundaryUp[eq + bdrN * num_equation_] = iUp[eq];
+  }
+  bdrN++;  
 }
 
 void InletBC::integrateInlets_gpu(Vector &y, const Vector &x, const elementIndexingData &elem_index_data,

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -59,6 +59,7 @@ class InletBC : public BoundaryCondition {
   Vector meanUp;
 
   Vector boundaryU;
+  Vector boundaryUp;  
   int bdrN;
   bool bdrUInit;
 
@@ -85,6 +86,8 @@ class InletBC : public BoundaryCondition {
 
   void subsonicReflectingDensityVelocity(Vector &normal, Vector &stateIn, Vector &bdrFlux);
 
+  void subsonicReflectingDensityVelocityFace(Vector &normal, Vector &stateIn, Vector transip, double time, Vector &bdrFlux);  
+
   void subsonicNonReflectingDensityVelocity(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector &bdrFlux);
 
   virtual void updateMean(IntegrationRules *intRules, ParGridFunction *Up);
@@ -96,7 +99,7 @@ class InletBC : public BoundaryCondition {
           const Array<double> &_inputData, const int &_maxIntPoints, const int &maxDofs, bool axisym);
   ~InletBC();
 
-  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta, double time, 
                       double distance, Vector &bdrFlux);
 
   virtual void initBCs();

--- a/src/inletBC.hpp
+++ b/src/inletBC.hpp
@@ -59,7 +59,7 @@ class InletBC : public BoundaryCondition {
   Vector meanUp;
 
   Vector boundaryU;
-  Vector boundaryUp;  
+  Vector boundaryUp;
   int bdrN;
   bool bdrUInit;
 
@@ -86,7 +86,8 @@ class InletBC : public BoundaryCondition {
 
   void subsonicReflectingDensityVelocity(Vector &normal, Vector &stateIn, Vector &bdrFlux);
 
-  void subsonicReflectingDensityVelocityFace(Vector &normal, Vector &stateIn, Vector transip, double time, Vector &bdrFlux);  
+  void subsonicReflectingDensityVelocityFace(Vector &normal, Vector tangentW, Vector &stateIn, Vector transip,
+                                             double time, Vector &bdrFlux);
 
   void subsonicNonReflectingDensityVelocity(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector &bdrFlux);
 
@@ -99,8 +100,8 @@ class InletBC : public BoundaryCondition {
           const Array<double> &_inputData, const int &_maxIntPoints, const int &maxDofs, bool axisym);
   ~InletBC();
 
-  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta, double time, 
-                      double distance, Vector &bdrFlux);
+  void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
+                      double time, double distance, Vector &bdrFlux);
 
   virtual void initBCs();
 

--- a/src/outletBC.cpp
+++ b/src/outletBC.cpp
@@ -305,7 +305,7 @@ void OutletBC::initBCs() {
 }
 
 void OutletBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
-                              double distance, Vector &bdrFlux) {
+                              double time, double distance, Vector &bdrFlux) {
   switch (outletType_) {
     case SUB_P:
       subsonicReflectingPressure(normal, stateIn, bdrFlux);

--- a/src/outletBC.hpp
+++ b/src/outletBC.hpp
@@ -104,7 +104,7 @@ class OutletBC : public BoundaryCondition {
   ~OutletBC();
 
   void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
-                      double distance, Vector &bdrFlux);
+                      double time, double distance, Vector &bdrFlux);
 
   virtual void initBCs();
 

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -84,12 +84,12 @@ MFEM_HOST_DEVICE GridFunctionReaction::GridFunctionReaction(int comp)
 
 MFEM_HOST_DEVICE GridFunctionReaction::~GridFunctionReaction() {}
 
-MFEM_HOST_DEVICE void GridFunctionReaction::setData(const double * data, int size) {
+MFEM_HOST_DEVICE void GridFunctionReaction::setData(const double *data, int size) {
   data_ = data + comp_ * size_;
   size_ = size;
 }
 
-void GridFunctionReaction::setGridFunction(const mfem::GridFunction & f) {
+void GridFunctionReaction::setGridFunction(const mfem::GridFunction &f) {
   size_ = f.FESpace()->GetNDofs();
   assert(comp_ < f.FESpace()->GetVDim());
   assert(f.FESpace()->GetOrdering() == mfem::Ordering::byNODES);

--- a/src/reaction.hpp
+++ b/src/reaction.hpp
@@ -129,9 +129,9 @@ class GridFunctionReaction : public Reaction {
 
   MFEM_HOST_DEVICE virtual ~GridFunctionReaction();
 
-  void setGridFunction(const mfem::GridFunction & f);
+  void setGridFunction(const mfem::GridFunction &f);
 
-  MFEM_HOST_DEVICE void setData(const double * data, int size);
+  MFEM_HOST_DEVICE void setData(const double *data, int size);
 
   MFEM_HOST_DEVICE virtual double computeRateCoefficient([[maybe_unused]] const double &T_h,
                                                          [[maybe_unused]] const double &T_e, const int &dofindex,

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -140,8 +140,7 @@ void Tps::parseCommandLineArgs(int argc, char *argv[]) {
   args.AddOption(&visualMode, "-visual", "--visualization", "", "--no-visualization",
                  "Launch post-process visualization.");
   gpu_aware_mpi_ = false;
-  args.AddOption(&gpu_aware_mpi_, "-ga", "--gpu-aware-mpi", "", "--no-gpu-aware-mpi",
-                 "Set GPU-aware MPI.");
+  args.AddOption(&gpu_aware_mpi_, "-ga", "--gpu-aware-mpi", "", "--no-gpu-aware-mpi", "Set GPU-aware MPI.");
   args.Parse();
 
   if (!args.Good()) {

--- a/src/tps2Boltzmann.cpp
+++ b/src/tps2Boltzmann.cpp
@@ -94,11 +94,9 @@ Tps2Boltzmann::Tps2Boltzmann(Tps *tps)
 
   save_to_paraview_dc = tps->getInput("boltzmannInterface/save_to_paraview", false);
 
-
   offsets.SetSize(NIndexes + 1);
   ncomps.SetSize(NIndexes + 1);
 }
-
 
 int Tps2Boltzmann::_countBTEReactions() {
   int total_reactions(0);

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -203,7 +203,7 @@ void WallBC::buildWallElemsArray() {
 }
 
 void WallBC::computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
-                            double distance, Vector &bdrFlux) {
+                            double time, double distance, Vector &bdrFlux) {
   switch (wallType_) {
       /*
       case INV:

--- a/src/wallBC.hpp
+++ b/src/wallBC.hpp
@@ -87,7 +87,7 @@ class WallBC : public BoundaryCondition {
   WallType getType() { return wallType_; }
 
   void computeBdrFlux(Vector &normal, Vector &stateIn, DenseMatrix &gradState, Vector transip, double delta,
-                      double distance, Vector &bdrFlux) override;
+                      double time, double distance, Vector &bdrFlux) override;
   void computeBdrPrimitiveStateForGradient(const Vector &primIn, Vector &primBC) const override;
 
   void initBCs() override;

--- a/test/inputs/input.plate.ini
+++ b/test/inputs/input.plate.ini
@@ -27,8 +27,8 @@ enableConstantTimestep = True
 
 [viscosityMultiplierFunction]
 isEnabled = True
-norm = '1.0 0.0 0.0'
-p0 = '0.0 0.0 0.0'
+normal = '1.0 0.0 0.0'
+point = '0.0 0.0 0.0'
 pInit = '0.0 0.0 0.0'
 width = 0.5
 viscosityRatio = 10.

--- a/test/inputs/plasma.lte1d.ini
+++ b/test/inputs/plasma.lte1d.ini
@@ -56,8 +56,8 @@ enableConstantTimestep = True
 
 [viscosityMultiplierFunction]
 isEnabled = True
-norm = '0 1 0'
-p0 = '0 0.46 0'
+normal = '0 1 0'
+point = '0 0.46 0'
 pInit = '0 0.46 0' # @ 4970
 width = 0.02
 viscosityRatio = 20.

--- a/test/inputs/plasma.lte2d.ini
+++ b/test/inputs/plasma.lte2d.ini
@@ -53,8 +53,8 @@ integrator = forwardEuler
 
 [viscosityMultiplierFunction]
 isEnabled = True
-norm = '0 1 0'
-p0 = '0 0.46 0'
+normal = '0 1 0'
+point = '0 0.46 0'
 pInit = '0 0.46 0' # @ 4970
 width = 0.02
 viscosityRatio = 20.


### PR DESCRIPTION
Adds three bc types for the compressible path:
+ subsonicFaceBasedX
+ subsonicFaceBasedY
+ subsonicFaceBasedZ

where uvw will specify the local (u_n, u_t1, u_t2) velocity vector. The normal is defined by the patch normal and t2 is the direction specified by the N-global direction corresponding to the N in subsonicFaceBasedN.