### PR TITLE
Support for specifying a restart directory

### DIFF
--- a/src/io.hpp
+++ b/src/io.hpp
@@ -66,8 +66,8 @@ class IOOptions {
 
   int exit_check_frequency_ = 500;
 
+  std::string restart_dir_;
   std::string restart_mode_;
-
   bool restart_variable_order_ = false;
   bool restart_serial_read_ = false;
   bool restart_serial_write_ = false;
@@ -362,5 +362,6 @@ void write_variable_data_hdf5(hid_t group, std::string varName, hid_t dataspace,
  * @todo Refactor this function to make it more generic and fit better
  * into the IODataOrganizer paradigm.
  */
-void partitioning_file_hdf5(std::string mode, MPI_Groups *groupsMPI, int nelemGlobal, mfem::Array<int> &partitioning);
+void partitioning_file_hdf5(std::string mode, MPI_Groups *groupsMPI, int nelemGlobal, mfem::Array<int> &partitioning,
+                            std::string fileName = "./");
 #endif  // IO_HPP_

--- a/src/loMachIO.cpp
+++ b/src/loMachIO.cpp
@@ -181,7 +181,8 @@ void LoMachSolver::restart_files_hdf5(string mode, string inputFileName) {
     }
     serialName = inputFileName;
   } else {
-    serialName = "restart_";
+    serialName = loMach_opts_.io_opts_.restart_dir_;
+    serialName.append("/restart_");
     serialName.append(loMach_opts_.io_opts_.output_dir_);
     serialName.append(".sol.h5");
   }

--- a/src/mesh_base.cpp
+++ b/src/mesh_base.cpp
@@ -174,13 +174,17 @@ void MeshBase::initializeMesh() {
     // nelemGlobal_ = mesh->GetNE();
     if (rank0_) grvy_printf(ginfo, "Total # of mesh elements = %i\n", nelemGlobal_);
 
+    string restartDir;
+    restartDir = loMach_opts_->io_opts_.restart_dir_;
+    restartDir += "/";
+
     if (nprocs_ > 1) {
       if (loMach_opts_->io_opts_.restart_serial_read_) {
         assert(serial_mesh_->Conforming());
         partitioning_ = Array<int>(serial_mesh_->GeneratePartitioning(nprocs_, defaultPartMethod), nelemGlobal_);
-        partitioning_file_hdf5("write", groupsMPI, nelemGlobal_, partitioning_);
+        partitioning_file_hdf5("write", groupsMPI, nelemGlobal_, partitioning_, restartDir);
       } else {
-        partitioning_file_hdf5("read", groupsMPI, nelemGlobal_, partitioning_);
+        partitioning_file_hdf5("read", groupsMPI, nelemGlobal_, partitioning_, restartDir);
       }
     }
 
@@ -203,12 +207,16 @@ void MeshBase::initializeMesh() {
       serial_mesh_->UniformRefinement();
     }
 
+    string restartDir;
+    restartDir = loMach_opts_->io_opts_.restart_dir_;
+    restartDir += "/";
+
     // generate partitioning file (we assume conforming meshes)
     nelemGlobal_ = serial_mesh_->GetNE();
     if (nprocs_ > 1) {
       assert(serial_mesh_->Conforming());
       partitioning_ = Array<int>(serial_mesh_->GeneratePartitioning(nprocs_, defaultPartMethod), nelemGlobal_);
-      if (rank0_) partitioning_file_hdf5("write", groupsMPI, nelemGlobal_, partitioning_);
+      if (rank0_) partitioning_file_hdf5("write", groupsMPI, nelemGlobal_, partitioning_, restartDir);
     }
   }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1156,6 +1156,13 @@ void Orthogonalize(Vector &v, MPI_Comm comm) {
   v -= global_sum / static_cast<double>(global_size);
 }
 
+bool copyFile(const char *SRC, const char *DEST) {
+  std::ifstream src(SRC, std::ios::binary);
+  std::ofstream dest(DEST, std::ios::binary);
+  dest << src.rdbuf();
+  return src && dest;
+}
+
 namespace mfem {
 GradientVectorGridFunctionCoefficient::GradientVectorGridFunctionCoefficient(const GridFunction *gf)
     : MatrixCoefficient((gf) ? gf->VectorDim() : 0) {

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -174,6 +174,8 @@ void scalarGrad3D(ParGridFunction &u, ParGridFunction &gu);
 void vectorGrad3DV(FiniteElementSpace *fes, Vector u, Vector *gu, Vector *gv, Vector *gw);
 void scalarGrad3DV(FiniteElementSpace *fes, FiniteElementSpace *vfes, Vector u, Vector *gu);
 
+bool copyFile(const char *SRC, const char *DEST);
+
 /// Eliminate essential BCs in an Operator and apply to RHS.
 /// rename this to something sensible "ApplyEssentialBC" or something
 void EliminateRHS(Operator &A, ConstrainedOperator &constrainedA, const Array<int> &ess_tdof_list, Vector &x, Vector &b,


### PR DESCRIPTION
Restores support for optional restart directory with input file lines:

```
[io]
restartBase = <directory relative to working dir>
```

which became lost in code refactoring.  Both restart files and partition file will be created in and read from restartBase.

