### PR TITLE
Filter of subgrid eddy viscosity

### DIFF
--- a/src/algebraicSubgridModels.hpp
+++ b/src/algebraicSubgridModels.hpp
@@ -111,6 +111,10 @@ class AlgebraicSubgridModels : public TurbModelBase {
   /// Velocity \f$(H^1)^d\f$ finite element space.
   ParFiniteElementSpace *vfes_ = nullptr;
 
+  /// spaces for filtered eddy viscosity
+  FiniteElementCollection *sfec_filter_ = nullptr;
+  ParFiniteElementSpace *sfes_filter_ = nullptr;
+
   ParGridFunction *gradU_gf_ = nullptr;
   ParGridFunction *gradV_gf_ = nullptr;
   ParGridFunction *gradW_gf_ = nullptr;
@@ -127,18 +131,15 @@ class AlgebraicSubgridModels : public TurbModelBase {
   ParGridFunction subgridVisc_gf_;
   Vector subgridVisc_;
 
-  // for plotting
-  // ParGridFunction resolution_gf_;
-  // Vector gridScale_;
+  // filter related
+  ParGridFunction muT_NM1_gf_;
+  ParGridFunction muT_filtered_gf_;
 
   // grid information
   ParGridFunction *gridScale_ = nullptr;
-  // ParGridFunction *bufferGridScale_ = nullptr;
-  // ParGridFunction *bufferGridScaleX = nullptr;
-  // ParGridFunction *bufferGridScaleY = nullptr;
-  // ParGridFunction *bufferGridScaleZ = nullptr;
 
   double sgs_model_const_;
+  int sgs_model_nFilter_;
 
  public:
   AlgebraicSubgridModels(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, TPS::Tps *tps, ParGridFunction *gridScale,
@@ -154,9 +155,6 @@ class AlgebraicSubgridModels : public TurbModelBase {
 
   /// Return a pointer to the current temperature ParGridFunction.
   ParGridFunction *getCurrentEddyViscosity() { return &subgridVisc_gf_; }
-
-  /// Return a pointer to the scalar grid size measure ParGridFunction.
-  // ParGridFunction *getGridScale() { return &resolution_gf_; }
 
   // subgrid scale models => move to turb model class
   void sgsSmag(const DenseMatrix &gradUp, double delta, double &nu_sgs);

--- a/src/algebraicSubgridModels.hpp
+++ b/src/algebraicSubgridModels.hpp
@@ -130,6 +130,10 @@ class AlgebraicSubgridModels : public TurbModelBase {
 
   ParGridFunction subgridVisc_gf_;
   Vector subgridVisc_;
+  Vector muT_NM0_;
+  Vector muT_NM1_;
+  Vector muT_NM2_;
+  Vector muT_NM3_;
 
   // filter related
   ParGridFunction muT_NM1_gf_;
@@ -140,6 +144,8 @@ class AlgebraicSubgridModels : public TurbModelBase {
 
   double sgs_model_const_;
   int sgs_model_nFilter_;
+  bool sgs_model_smooth_;
+  int aveSteps_;
 
  public:
   AlgebraicSubgridModels(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, TPS::Tps *tps, ParGridFunction *gridScale,

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -173,6 +173,7 @@ void vectorGrad3D(ParGridFunction &u, ParGridFunction &gu, ParGridFunction &gv, 
 void scalarGrad3D(ParGridFunction &u, ParGridFunction &gu);
 void vectorGrad3DV(FiniteElementSpace *fes, Vector u, Vector *gu, Vector *gv, Vector *gw);
 void scalarGrad3DV(FiniteElementSpace *fes, FiniteElementSpace *vfes, Vector u, Vector *gu);
+void makeContinuous(ParGridFunction &u);
 
 bool copyFile(const char *SRC, const char *DEST);
 


### PR DESCRIPTION
Adds option to apply p-filter to subgrid mu_T with 

```
[loMach]
sgsFilterModes = <number of polynomial orders to discard>
```

If the requested number of filter modes is greater than the shape function order-1, a warning is printed and no filtering is performed.  Additionally, add option to apply 4-step time smoothing with

```
[loMach]
sgsSmooth = true
```

Rather crude, but may be built on in the future.