### PR TITLE
Switch from cuda-memcheck to compute-sanitizer

### DIFF
--- a/test/cuda-memcheck.test
+++ b/test/cuda-memcheck.test
@@ -6,14 +6,13 @@ RUNFILE="inputs/input.dtconst.2iters.cyl.ini"
 
 @test "[$TEST] verify cuda-memcheck detects known error" {
     test -e ./badcuda
-    run /usr/local/cuda/bin/cuda-memcheck --error-exitcode 1 ./badcuda
+    run /usr/local/cuda/bin/compute-sanitizer --error-exitcode 1 ./badcuda
     [[ "${status}" -eq 1 ]]
 }
 
 @test "[$TEST] run tps with input -> $RUNFILE under cuda-memcheck" {
     test -s $RUNFILE
 
-    /usr/local/cuda/bin/cuda-memcheck --error-exitcode 1 ../src/tps $OPTS --runFile $RUNFILE
-
+    ../libtool --mode=execute /usr/local/cuda/bin/compute-sanitizer --error-exitcode 1 ../src/tps --runFile $RUNFILE
 }
 


### PR DESCRIPTION
After OS upgrade on CI system, cuda-memcheck fails to detect the known errors in badcuda.cpp, which are based on examples from the nvidia docs:

https://docs.nvidia.com/cuda/archive/11.4.1/cuda-memcheck/index.html#example-use-of-memcheck

It isn't clear why this is the case, but since cuda-memcheck is deprecated in favor of compute-sanitizer in later versions anyway, I am switching to compute-sanitizer.  It successfully detects errors in badcuda.