### PR TITLE
Add basic operator split capability in ReactingFlow

### DIFF
--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -114,6 +114,7 @@ void LoMachSolver::initialize() {
     iter = 0;
     temporal_coeff_.nStep = iter;
   }
+  temporal_coeff_.order = max_bdf_order;
 
   //-----------------------------------------------------
   // 1) Prepare the mesh

--- a/src/loMach.hpp
+++ b/src/loMach.hpp
@@ -74,6 +74,9 @@ class Tps;
 #include "turb_model_base.hpp"
 
 struct temporalSchemeCoefficients {
+  // Max order
+  int order;
+
   // Current time
   double time;
 

--- a/src/reactingFlow.cpp
+++ b/src/reactingFlow.cpp
@@ -1340,15 +1340,15 @@ void ReactingFlow::step() {
     }
 
     // set register to correct full step fields
-    Yn_next_gf_.SetFromTrueDofs(Yn_);
-    Tn_next_gf_.SetFromTrueDofs(Tn_);
-    Yn_next_gf_.GetTrueDofs(Yn_next_);
-    Tn_next_gf_.GetTrueDofs(Tn_next_);
+    Yn_next_ = Yn_;
+    Tn_next_ = Tn_;
 
-    Yn_gf_.SetFromTrueDofs(spec_buffer_);
-    Tn_gf_.SetFromTrueDofs(temp_buffer_);
-    Yn_gf_.GetTrueDofs(Yn_);
-    Tn_gf_.GetTrueDofs(Tn_);
+    YnFull_gf_.SetFromTrueDofs(Yn_next_);
+    Tn_next_gf_.SetFromTrueDofs(Tn_next_);
+
+    Yn_ = spec_buffer_;
+    Tn_ = temp_buffer_;
+    Tn_gf_.SetFromTrueDofs(Tn_);
   }
 
   /// PART III: prepare for external use

--- a/src/reactingFlow.cpp
+++ b/src/reactingFlow.cpp
@@ -1256,7 +1256,7 @@ void ReactingFlow::step() {
   YnFull_gf_.SetFromTrueDofs(Yn_next_);
 
   // TODO(swh): this is a bad name
-  crossDiffusion();
+  //crossDiffusion();
 
   // advance temperature
   temperatureStep();
@@ -1296,7 +1296,8 @@ void ReactingFlow::step() {
     // update wdot quantities at full substep in Yn/Tn state
     updateMixture();
     speciesProduction();
-    heatOfFormation();    
+    heatOfFormation();
+    crossDiffusion();    
 
     // advance over substep
     for (int iSpecies = 0; iSpecies < nSpecies_ - 1; iSpecies++) {
@@ -1407,6 +1408,7 @@ void ReactingFlow::temperatureSubstep(int iSub) {
 
   // heat of formation term
   tmpR0_.Set(1.0, hw_);
+  //tmpR0_.Add(1.0, crossDiff_);
   tmpR0_ /= rn_;
   tmpR0_ *= dtSub;
 
@@ -1639,7 +1641,8 @@ void ReactingFlow::crossDiffusion() {
     tmpR1c_ += tmpR1b_;
   }
   dotVector(tmpR1a_, tmpR1c_, &tmpR1_, dim_);
-  Ms_->Mult(tmpR1_, crossDiff_);
+  Ms_->Mult(tmpR1_, crossDiff_); // if including in time-splitting comment
+  //crossDiff_.Set(1.0,tmpR1_);
 }
 
 void ReactingFlow::computeExplicitTempConvectionOP(bool extrap) {

--- a/src/reactingFlow.cpp
+++ b/src/reactingFlow.cpp
@@ -422,6 +422,16 @@ ReactingFlow::ReactingFlow(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, tem
 
   tpsP_->getInput("loMach/reactingFlow/ic", ic_string_, std::string(""));
   tpsP_->getInput("loMach/reactingFlow/sub-steps", nSub_, 1);
+
+  // Check time marching order.  Operator split (i.e., nSub_ > 1) not supported for order > 1.
+  if ((nSub_ > 1) && (time_coeff_.order > 1)) {
+    if (rank0_) {
+      std::cout << "ERROR: BDF order > 1 not supported with operator split." << std::endl;
+      std::cout << "       Either set loMach/reactingFlow/sub-steps = 1 or time/bdfOrder = 1" << std::endl;
+    }
+    assert(false);
+    exit(1);
+  }
 }
 
 ReactingFlow::~ReactingFlow() {

--- a/src/reactingFlow.cpp
+++ b/src/reactingFlow.cpp
@@ -1405,10 +1405,13 @@ void ReactingFlow::temperatureSubstep(int iSub) {
   // double dtSub = dt_ * (double)(iSub+1) / (double)nSub_;
   double dtSub = dt_ / (double)nSub_;
 
+  CpMix_gf_.GetTrueDofs(CpMix_);
+
   // heat of formation term
   tmpR0_.Set(1.0, hw_);
   // tmpR0_.Add(1.0, crossDiff_);
   tmpR0_ /= rn_;
+  tmpR0_ /= CpMix_;
   tmpR0_ *= dtSub;
 
   // tmpR0_ = 0.0;

--- a/src/reactingFlow.cpp
+++ b/src/reactingFlow.cpp
@@ -1256,7 +1256,7 @@ void ReactingFlow::step() {
   YnFull_gf_.SetFromTrueDofs(Yn_next_);
 
   // TODO(swh): this is a bad name
-  //crossDiffusion();
+  // crossDiffusion();
 
   // advance temperature
   temperatureStep();
@@ -1283,21 +1283,20 @@ void ReactingFlow::step() {
   // as containers for {n}+iSub*dtsub substates
   // 2) YnStar and TnStar contain interpolated star states at substep
   // 3) _next contains full {n+1}* state
-  //Yn_gf_.GetTrueDofs(spec_buffer_);
-  //Tn_gf_.GetTrueDofs(temp_buffer_);
-  spec_buffer_.Set(1.0,Yn_);
-  temp_buffer_.Set(1.0,Tn_);  
+  // Yn_gf_.GetTrueDofs(spec_buffer_);
+  // Tn_gf_.GetTrueDofs(temp_buffer_);
+  spec_buffer_.Set(1.0, Yn_);
+  temp_buffer_.Set(1.0, Tn_);
 
   // delta of substep for star state
   substepState();
 
   for (int iSub = 0; iSub < nSub_; iSub++) {
-    
     // update wdot quantities at full substep in Yn/Tn state
     updateMixture();
     speciesProduction();
     heatOfFormation();
-    crossDiffusion();    
+    crossDiffusion();
 
     // advance over substep
     for (int iSpecies = 0; iSpecies < nSpecies_ - 1; iSpecies++) {
@@ -1403,23 +1402,23 @@ void ReactingFlow::temperatureStep() {
 
 void ReactingFlow::temperatureSubstep(int iSub) {
   // substep dt
-  //double dtSub = dt_ * (double)(iSub+1) / (double)nSub_;
-  double dtSub = dt_  / (double)nSub_;  
+  // double dtSub = dt_ * (double)(iSub+1) / (double)nSub_;
+  double dtSub = dt_ / (double)nSub_;
 
   // heat of formation term
   tmpR0_.Set(1.0, hw_);
-  //tmpR0_.Add(1.0, crossDiff_);
+  // tmpR0_.Add(1.0, crossDiff_);
   tmpR0_ /= rn_;
   tmpR0_ *= dtSub;
 
-  //tmpR0_ = 0.0;
-  
+  // tmpR0_ = 0.0;
+
   // TnStar has star state at substep here
-  tmpR0_.Add(1.0,TnStar_);
-  tmpR0_.Add(1.0,Tn_);  
+  tmpR0_.Add(1.0, TnStar_);
+  tmpR0_.Add(1.0, Tn_);
 
   // Tn now has full state at substep
-  Tn_.Set(1.0,tmpR0_);
+  Tn_.Set(1.0, tmpR0_);
 }
 
 void ReactingFlow::speciesLastStep() {
@@ -1533,23 +1532,23 @@ void ReactingFlow::speciesStep(int iSpec) {
 // Y{n + (substep+1)} = dt * wdot(Y{n + (substep)} + Y{n + (substep+1)}*
 void ReactingFlow::speciesSubstep(int iSpec, int iSub) {
   // substep dt
-  //double dtSub = dt_ * (double)(iSub+1) / (double)nSub_;
-  double dtSub = dt_  / (double)nSub_;
+  // double dtSub = dt_ * (double)(iSub+1) / (double)nSub_;
+  double dtSub = dt_ / (double)nSub_;
 
   // production of iSpec
   setScalarFromVector(prodY_, iSpec, &tmpR0_);
   tmpR0_ /= rn_;
   tmpR0_ *= dtSub;
 
-  //tmpR0_ = 0.0;  
+  // tmpR0_ = 0.0;
 
   // YnStar has star state at substep here
   setScalarFromVector(YnStar_, iSpec, &tmpR0a_);
-  tmpR0_.Add(1.0,tmpR0a_); 
+  tmpR0_.Add(1.0, tmpR0a_);
 
   setScalarFromVector(Yn_, iSpec, &tmpR0a_);
-  tmpR0_.Add(1.0,tmpR0a_); 
-  
+  tmpR0_.Add(1.0, tmpR0a_);
+
   // Yn now has full state at substep
   setVectorFromScalar(tmpR0_, iSpec, &Yn_);
 }
@@ -1641,8 +1640,8 @@ void ReactingFlow::crossDiffusion() {
     tmpR1c_ += tmpR1b_;
   }
   dotVector(tmpR1a_, tmpR1c_, &tmpR1_, dim_);
-  Ms_->Mult(tmpR1_, crossDiff_); // if including in time-splitting comment
-  //crossDiff_.Set(1.0,tmpR1_);
+  Ms_->Mult(tmpR1_, crossDiff_);  // if including in time-splitting comment
+  // crossDiff_.Set(1.0,tmpR1_);
 }
 
 void ReactingFlow::computeExplicitTempConvectionOP(bool extrap) {
@@ -1771,9 +1770,9 @@ void ReactingFlow::extrapolateState() {
 // if time-splitting order can be improved
 void ReactingFlow::substepState() {
   /*
-  double wt0, wt1;  
+  double wt0, wt1;
   wt1 = (double)(iSub + 1) / (double)nSub_;
-  wt0 = 1.0 - wt1;  
+  wt0 = 1.0 - wt1;
 
   TnStar_.Set(wt0, temp_buffer_);
   TnStar_.Add(wt1, Tn_next_);
@@ -1786,13 +1785,12 @@ void ReactingFlow::substepState() {
 
   // delta over substep of star state
   double wt = 1.0 / (double)nSub_;
-    
-  TnStar_.Set(wt, Tn_next_);  
+
+  TnStar_.Set(wt, Tn_next_);
   TnStar_.Add(-wt, temp_buffer_);
 
-  YnStar_.Set(wt, Yn_next_);    
+  YnStar_.Set(wt, Yn_next_);
   YnStar_.Add(-wt, spec_buffer_);
-  
 }
 
 void ReactingFlow::updateMixture() {

--- a/src/reactingFlow.hpp
+++ b/src/reactingFlow.hpp
@@ -337,10 +337,10 @@ class ReactingFlow : public ThermoChemModelBase {
   void crossDiffusion();
 
   // time-splitting
-  void substepState(int iSub);
+  void substepState();
   void speciesLastSubstep();
-  void speciesSubstep(int iSpec);
-  void temperatureSubstep();
+  void speciesSubstep(int iSpec, int iSub);
+  void temperatureSubstep(int iSub);
 
   /// for creation of structs to interface with old plasma/chem stuff
   void identifySpeciesType(Array<ArgonSpcs> &speciesType);

--- a/src/reactingFlow.hpp
+++ b/src/reactingFlow.hpp
@@ -289,6 +289,11 @@ class ReactingFlow : public ThermoChemModelBase {
   Vector kappa_;
   Vector visc_;
 
+  // time-splitting
+  Vector YnStar_, spec_buffer_;
+  Vector TnStar_, temp_buffer_;
+  int nSub_;
+
   // Parameters and objects used in filter-based stabilization
   bool filter_temperature_ = false;
   int filter_cutoff_modes_ = 0;
@@ -330,6 +335,12 @@ class ReactingFlow : public ThermoChemModelBase {
   void speciesProduction();
   void heatOfFormation();
   void crossDiffusion();
+
+  // time-splitting
+  void substepState(int iSub);
+  void speciesLastSubstep();
+  void speciesSubstep(int iSpec);
+  void temperatureSubstep();
 
   /// for creation of structs to interface with old plasma/chem stuff
   void identifySpeciesType(Array<ArgonSpcs> &speciesType);

--- a/src/reactingFlow.hpp
+++ b/src/reactingFlow.hpp
@@ -282,6 +282,7 @@ class ReactingFlow : public ThermoChemModelBase {
   Vector specificHeatRatios_;
   Vector initialMassFraction_;
   Vector atomMW_;
+  Vector CpMix_;
 
   Vector Qt_;
   Vector rn_;

--- a/src/reactingFlow.hpp
+++ b/src/reactingFlow.hpp
@@ -293,6 +293,7 @@ class ReactingFlow : public ThermoChemModelBase {
   // time-splitting
   Vector YnStar_, spec_buffer_;
   Vector TnStar_, temp_buffer_;
+  bool operator_split_ = false;
   int nSub_;
 
   // Parameters and objects used in filter-based stabilization

--- a/test/inputs/input.reactStiffRx.ini
+++ b/test/inputs/input.reactStiffRx.ini
@@ -1,0 +1,137 @@
+[solver]
+#type = flow
+type = loMach
+
+[loMach]
+mesh = meshes/periodic-square.mesh
+order = 2
+maxIters = 50
+outputFreq = 1
+timingFreq = 1
+fluid = 'user_defined'
+#viscosityMultiplier = 99000.
+#equation_system = 'navier-stokes'
+enablePressureForcing = false
+pressureGrad = '0.0 0.0 0.0'
+enableGravity = false
+gravity = '0.0 0.0 0.0'
+openSystem = False
+ambientPressure = 101300. # to match input.reaction.ini
+flow-solver = tomboulides
+thermo-solver = reacting-flow
+
+[loMach/tomboulides]
+linear-solver-rtol = 1.0e-12
+linear-solver-max-iter = 2000
+
+[loMach/reactingFlow]
+sub-steps = 20
+linear-solver-rtol = 1.0e-12
+linear-solver-max-iter = 2000
+initialTemperature = 294.075;
+# ic = 'step'
+
+[io]
+outdirBase = output-stiff
+
+[time]
+integrator = curlcurl
+dt_fixed = 2.0e-4
+bdfOrder = 1
+
+[spongeMultiplier]
+uniform = true
+uniformMult = 99000.
+
+[initialConditions]
+temperature = 294.0
+
+[boundaryConditions]
+numWalls = 0
+numInlets = 0
+numOutlets = 0
+
+#[periodicity]
+#enablePeriodic = True
+#periodicX = True
+#periodicY = True
+#periodicZ = True
+
+###########################################
+#        PLASMA MODELS
+###########################################
+[plasma_models]
+ambipolar = False
+two_temperature = False
+gas_model = perfect_mixture
+transport_model = constant
+chemistry_model = 'mass_action_law'
+
+[plasma_models/transport_model/constant]
+viscosity = 0.0
+bulk_viscosity = 0.0
+thermal_conductivity = 0.0
+electron_thermal_conductivity = 0.0
+diffusivity/species1 = 0.0
+diffusivity/species2 = 0.0
+diffusivity/species3 = 0.0
+momentum_transfer_frequency/species1 = 0.0
+momentum_transfer_frequency/species2 = 0.0
+momentum_transfer_frequency/species3 = 0.0
+
+[atoms]
+numAtoms = 2
+
+[atoms/atom1]
+name = 'Ar'
+mass = 2.896439e-2
+
+[atoms/atom2]
+name = 'E'
+mass = 1e-7
+
+[species]
+numSpecies = 3
+background_index = 3
+
+[species/species1]
+name = 'Ar.+1'
+composition = '{Ar : 1, E : -1}'
+#initialMassFraction = 0.
+initialMassFraction = 1.0e-12
+formation_energy = 10000
+perfect_mixture/constant_molar_cv = 2.49996
+
+[species/species2]
+name = 'E'
+composition = '{E : 1}'
+#initialMassFraction = 0.
+initialMassFraction = 1.0e-12
+initialElectronTemperature = 300.;
+formation_energy = 0.
+perfect_mixture/constant_molar_cv = 2.49996
+
+[species/species3]
+name = 'Ar'
+composition = '{Ar : 1}'
+initialMassFraction = 1.
+formation_energy = 0.
+perfect_mixture/constant_molar_cv = 2.49996
+
+[reactions]
+number_of_reactions = 1
+
+[reactions/reaction1]
+equation = 'Ar + E <=> Ar.+1 + 2 E'
+reaction_energy = 1.0e4
+reactant_stoichiometry = '0 0 1'
+product_stoichiometry = '1 1 0'
+model = arrhenius
+arrhenius/A = 1e-7
+arrhenius/b = 4.
+arrhenius/E = 0.
+
+detailed_balance = True
+equilibrium_constant/A = 1e-10
+equilibrium_constant/b = 4.
+equilibrium_constant/E = 0.

--- a/test/reactFlow-singleRx.test
+++ b/test/reactFlow-singleRx.test
@@ -3,12 +3,16 @@
 
 TEST="singleReaction"
 RUNFILE="inputs/input.reactSingleRx.ini"
+RUNFILE_STIFF="inputs/input.reactStiffRx.ini"
 EXE="../src/tps"
 RESTART="ref_solns/reactSingleRx/restart_output.sol.h5"
 
 setup() {
     SOLN_FILE=restart_output.sol.h5
     REF_FILE=ref_solns/reactSingleRx/restart_output.sol.h5
+
+    SOLN_FILE_STIFF=restart_output-stiff.sol.h5
+    REF_FILE_STIFF=ref_solns/reactSingleRx/restart_output-stiff.sol.h5
 }
 
 @test "[$TEST] check for input file $RUNFILE" {
@@ -19,11 +23,29 @@ setup() {
     rm -rf output/*
     rm -f $SOLN_FILE
     $EXE --runFile $RUNFILE
-    test -s $SOLN_FILE    
+    test -s $SOLN_FILE
 }
 
 @test "[$TEST] verify tps output with input -> $RUNFILE" {
     test -s $SOLN_FILE
     test -s $REF_FILE
     h5diff -r --delta=1e-11 $SOLN_FILE $REF_FILE /species/speciesAll
+}
+
+@test "[$TEST] check for input file $RUNFILE_STIFF" {
+    test -s $RUNFILE
+}
+
+@test "[$TEST] run tps with input -> $RUNFILE_STIFF" {
+    rm -rf output-stiff
+    rm -f $SOLN_FILE_STIFF
+    $EXE --runFile $RUNFILE_STIFF
+    test -s $SOLN_FILE_STIFF
+}
+
+@test "[$TEST] verify tps output with input -> $RUNFILE_STIFF" {
+    test -s $SOLN_FILE_STIFF
+    test -s $REF_FILE_STIFF
+    h5diff -r --relative=1e-12 $SOLN_FILE_STIFF $REF_FILE_STIFF /species/speciesAll
+    h5diff -r --relative=1e-12 $SOLN_FILE_STIFF $REF_FILE_STIFF /temperature/temperature
 }

--- a/test/ref_solns/.gitattributes
+++ b/test/ref_solns/.gitattributes
@@ -6,3 +6,4 @@ ref_solns/heatedBox/restart_output.sol.h5 filter=lfs diff=lfs merge=lfs -text
 taylor-couette/restart_output-tc.Re100.h5 filter=lfs diff=lfs merge=lfs -text
 pipe/restart_output-pipe-lam.sol.h5 filter=lfs diff=lfs merge=lfs -text
 pipe/restart_output-pipe-arans.sol.h5 filter=lfs diff=lfs merge=lfs -text
+reactSingleRx/restart_output-stiff.sol.h5 filter=lfs diff=lfs merge=lfs -text

--- a/test/ref_solns/reactSingleRx/restart_output-stiff.sol.h5
+++ b/test/ref_solns/reactSingleRx/restart_output-stiff.sol.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc10a16abb8c1e2cf0725948c85f083022bc3d09e24c48139735c2a2be0d58cd
+size 7896


### PR DESCRIPTION
This PR adds an operator splitting implementation intended to support stiff reactions.  Specifically, we use Lie splitting within `ReactingFlow`.  The 'spatial' terms, specifically advection-diffusion, are discretized with backward Euler.  The 'reaction' terms, including the source term in the temperature equation due to chemical reactions, are discretized with forward Euler at a user-specified subdivision of the advection-diffusion time step.  This allows the time step seen by the chemistry to be set arbitrarily small, enabling stable integration of stiff reactions, without affecting the time step of the advection-diffusion component of the system.