### PR TITLE
Preliminary implementation of bte coupling for low-mach

### DIFF
--- a/src/M2ulPhyS2Boltzmann.cpp
+++ b/src/M2ulPhyS2Boltzmann.cpp
@@ -36,7 +36,6 @@
 #include "M2ulPhyS.hpp"
 #include "tps2Boltzmann.hpp"
 
-// CPU version (just for starting up)
 void M2ulPhyS::push(TPS::Tps2Boltzmann &interface) {
   assert(interface.IsInitialized());
 

--- a/src/reactingFlow.hpp
+++ b/src/reactingFlow.hpp
@@ -36,6 +36,7 @@
 // forward-declaration for Tps support class
 namespace TPS {
 class Tps;
+class Tps2Boltzmann;
 }
 
 #include <hdf5.h>
@@ -102,6 +103,8 @@ class ReactingFlow : public ThermoChemModelBase {
   PerfectMixture *mixture_ = NULL;
   ArgonMixtureTransport *transport_ = NULL;
   Chemistry *chemistry_ = NULL;
+  // External reaction rates when chemistry is implemented using the BTE option
+  std::unique_ptr<ParGridFunction> externalReactionRates_;
 
   std::vector<std::string> speciesNames_;
   std::map<std::string, int> atomMap_;
@@ -415,5 +418,8 @@ class ReactingFlow : public ThermoChemModelBase {
 
   void evalSubstepNumber();
   void readTableWrapper(std::string inputPath, TableInput &result);
+
+  void push(TPS::Tps2Boltzmann &interface);
+  void fetch(TPS::Tps2Boltzmann &interface);
 };
 #endif  // REACTINGFLOW_HPP_


### PR DESCRIPTION
Getting started with the implementation of the lowMach to BTE interface.

What I need:

1. A test case equivalent to the [coupled-3d.ini](https://github.com/pecos/tps/blob/main/test/inputs/coupled-3d.ini) testcase but for the low-mach

2. A test case equivalent to [tps-inputs/axisymmetric/argon/lowP](https://github.com/pecos/tps-inputs/tree/main/axisymmetric/argon/lowP), either single or multiple reactions.

