### PR TITLE
Add support for SUPG for scalar transport equations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,3 +28,5 @@ test/meshes/spongeBox.msh filter=lfs diff=lfs merge=lfs -text
 test/ref_solns/sgsLoMach/restart_output.sol.h5 filter=lfs diff=lfs merge=lfs -text
 test/ref_solns/aveLoMach/restart_output.sol.h5 filter=lfs diff=lfs merge=lfs -text
 test/ref_solns/reactNitrogen/restart_output.sol.h5 filter=lfs diff=lfs merge=lfs -text
+test/ref_solns/supg/restart_output_wstab1T.sol.h5 filter=lfs diff=lfs merge=lfs -text
+test/ref_solns/supg/restart_output_lte_supg.sol.h5 filter=lfs diff=lfs merge=lfs -text

--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -58,7 +58,8 @@ MFEM_HOST_DEVICE double Sutherland(const double T, const double mu_star, const d
 }
 
 CaloricallyPerfectThermoChem::CaloricallyPerfectThermoChem(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts,
-                                                           temporalSchemeCoefficients &time_coeff, ParGridFunction *gridScale, TPS::Tps *tps)
+                                                           temporalSchemeCoefficients &time_coeff,
+                                                           ParGridFunction *gridScale, TPS::Tps *tps)
     : tpsP_(tps), pmesh_(pmesh), time_coeff_(time_coeff) {
   rank0_ = (pmesh_->GetMyRank() == 0);
   order_ = loMach_opts->order;
@@ -178,7 +179,7 @@ CaloricallyPerfectThermoChem::~CaloricallyPerfectThermoChem() {
   delete csupg_coeff_;
   delete uw1_coeff_;
   delete uw2_coeff_;
-  delete upwind_coeff_; 
+  delete upwind_coeff_;
   delete swdiff_coeff_;
   delete supg_coeff_;
 
@@ -467,7 +468,7 @@ void CaloricallyPerfectThermoChem::initializeOperators() {
   rhou_coeff_ = new ScalarVectorProductCoefficient(*rhon_next_coeff_, *un_next_coeff_);
 
   // artifical diffusion coefficients
-  if(sw_stab_) {
+  if (sw_stab_) {
     umag_coeff_ = new VectorMagnitudeCoefficient(*un_next_coeff_);
     gscale_coeff_ = new GridFunctionCoefficient(gridScale_gf_);
     visc_coeff_ = new GridFunctionCoefficient(&visc_gf_);
@@ -491,7 +492,6 @@ void CaloricallyPerfectThermoChem::initializeOperators() {
 
     supg_coeff_ = new ScalarMatrixProductCoefficient(*upwind_coeff_, *swdiff_coeff_);
   }
-  
 
   At_form_ = new ParBilinearForm(sfes_);
   auto *at_blfi = new ConvectionIntegrator(*rhou_coeff_);
@@ -629,7 +629,7 @@ void CaloricallyPerfectThermoChem::initializeOperators() {
     lqd_blfi->SetIntRule(&ir_di);
   }
   LQ_form_->AddDomainIntegrator(lqd_blfi);
-  
+
   // DiffusionIntegrator *slqd_blfi;
   if (sw_stab_) {
     // slqd_blfi = new DiffusionIntegrator(*supg_coeff_);

--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -537,13 +537,12 @@ void CaloricallyPerfectThermoChem::initializeOperators() {
     hmt_blfi->SetIntRule(&ir_di);
     hdt_blfi->SetIntRule(&ir_di);
   }
-  // SUPG
+  // SUPG diffusion
   if (sw_stab_) {
     auto *sdt_blfi = new DiffusionIntegrator(*supg_coeff_);
-    // SUPG diffusion
-    // if (numerical_integ_) {
-    //   sdt_blfi->SetIntRule(&ir_di);
-    // }
+    if (numerical_integ_) {
+      sdt_blfi->SetIntRule(&ir_di);
+    }
     Ht_form_->AddDomainIntegrator(sdt_blfi);
   }
   Ht_form_->AddDomainIntegrator(hmt_blfi);
@@ -630,14 +629,12 @@ void CaloricallyPerfectThermoChem::initializeOperators() {
   }
   LQ_form_->AddDomainIntegrator(lqd_blfi);
 
-  // DiffusionIntegrator *slqd_blfi;
+  // SUPG diffusion
   if (sw_stab_) {
-    // slqd_blfi = new DiffusionIntegrator(*supg_coeff_);
     auto *slqd_blfi = new DiffusionIntegrator(*supg_coeff_);
-    // SUPG diffusion
-    // if (numerical_integ_) {
-    //   slqd_blfi->SetIntRule(&ir_di);
-    // }
+    if (numerical_integ_) {
+      slqd_blfi->SetIntRule(&ir_di);
+    }
     LQ_form_->AddDomainIntegrator(slqd_blfi);
   }
 

--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -471,7 +471,7 @@ void CaloricallyPerfectThermoChem::initializeOperators() {
     umag_coeff_ = new VectorMagnitudeCoefficient(*un_next_coeff_);
     gscale_coeff_ = new GridFunctionCoefficient(gridScale_gf_);
     visc_coeff_ = new GridFunctionCoefficient(&visc_gf_);
-    visc_inv_coeff_ = new PowerCoefficient(*visc_coeff_, -1);
+    visc_inv_coeff_ = new PowerCoefficient(*visc_coeff_, -1.0);
 
     // compute Reh
     reh1_coeff_ = new ProductCoefficient(*rho_coeff_, *visc_inv_coeff_);
@@ -538,13 +538,14 @@ void CaloricallyPerfectThermoChem::initializeOperators() {
     hdt_blfi->SetIntRule(&ir_di);
   }
   // SUPG
-  auto *sdt_blfi = new DiffusionIntegrator(*supg_coeff_);
-  if (sw_stab_)
+  if (sw_stab_) {
+    auto *sdt_blfi = new DiffusionIntegrator(*supg_coeff_);
     // SUPG diffusion
     // if (numerical_integ_) {
     //   sdt_blfi->SetIntRule(&ir_di);
     // }
     Ht_form_->AddDomainIntegrator(sdt_blfi);
+  }
   Ht_form_->AddDomainIntegrator(hmt_blfi);
   Ht_form_->AddDomainIntegrator(hdt_blfi);
   Ht_form_->Assemble();
@@ -628,6 +629,15 @@ void CaloricallyPerfectThermoChem::initializeOperators() {
     lqd_blfi->SetIntRule(&ir_di);
   }
   LQ_form_->AddDomainIntegrator(lqd_blfi);
+  
+  // auto *slqd_blfi = new DiffusionIntegrator(*supg_coeff_);
+  // if (sw_stab_)
+  //   // SUPG diffusion
+  //   // if (numerical_integ_) {
+  //   //   slqd_blfi->SetIntRule(&ir_di);
+  //   // }
+  //   LQ_form_->AddDomainIntegrator(slqd_blfi);
+
   if (partial_assembly_) {
     LQ_form_->SetAssemblyLevel(AssemblyLevel::PARTIAL);
   }

--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -630,13 +630,15 @@ void CaloricallyPerfectThermoChem::initializeOperators() {
   }
   LQ_form_->AddDomainIntegrator(lqd_blfi);
   
-  // auto *slqd_blfi = new DiffusionIntegrator(*supg_coeff_);
-  // if (sw_stab_)
-  //   // SUPG diffusion
-  //   // if (numerical_integ_) {
-  //   //   slqd_blfi->SetIntRule(&ir_di);
-  //   // }
-  //   LQ_form_->AddDomainIntegrator(slqd_blfi);
+  DiffusionIntegrator *slqd_blfi;
+  if (sw_stab_)
+    slqd_blfi = new DiffusionIntegrator(*supg_coeff_);
+    // SUPG diffusion
+    // if (numerical_integ_) {
+    //   slqd_blfi->SetIntRule(&ir_di);
+    // }
+    LQ_form_->AddDomainIntegrator(slqd_blfi);
+
 
   if (partial_assembly_) {
     LQ_form_->SetAssemblyLevel(AssemblyLevel::PARTIAL);

--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -630,15 +630,16 @@ void CaloricallyPerfectThermoChem::initializeOperators() {
   }
   LQ_form_->AddDomainIntegrator(lqd_blfi);
   
-  DiffusionIntegrator *slqd_blfi;
-  if (sw_stab_)
-    slqd_blfi = new DiffusionIntegrator(*supg_coeff_);
+  // DiffusionIntegrator *slqd_blfi;
+  if (sw_stab_) {
+    // slqd_blfi = new DiffusionIntegrator(*supg_coeff_);
+    auto *slqd_blfi = new DiffusionIntegrator(*supg_coeff_);
     // SUPG diffusion
     // if (numerical_integ_) {
     //   slqd_blfi->SetIntRule(&ir_di);
     // }
     LQ_form_->AddDomainIntegrator(slqd_blfi);
-
+  }
 
   if (partial_assembly_) {
     LQ_form_->SetAssemblyLevel(AssemblyLevel::PARTIAL);

--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -477,7 +477,7 @@ void CaloricallyPerfectThermoChem::initializeOperators() {
     // compute Reh
     reh1_coeff_ = new ProductCoefficient(*rho_coeff_, *visc_inv_coeff_);
     reh2_coeff_ = new ProductCoefficient(*reh1_coeff_, *gscale_coeff_);
-    Reh_coeff_ = new ProductCoefficient(*reh1_coeff_, *umag_coeff_);
+    Reh_coeff_ = new ProductCoefficient(*reh2_coeff_, *umag_coeff_);
 
     // Csupg
     csupg_coeff_ = new TransformedCoefficient(Reh_coeff_, csupgFactor);

--- a/src/calorically_perfect.cpp
+++ b/src/calorically_perfect.cpp
@@ -168,19 +168,19 @@ CaloricallyPerfectThermoChem::~CaloricallyPerfectThermoChem() {
   delete rho_over_dt_coeff_;
   delete rho_coeff_;
 
-  delete umag_coeff_
-  delete gscale_coeff_ 
-  delete visc_coeff_
-  delete visc_inv_coeff_
-  delete reh1_coeff_ 
-  delete reh2_coeff_ 
-  delete Reh_coeff_ 
-  delete csupg_coeff_
-  delete uw1_coeff_ 
-  delete uw2_coeff_
-  delete upwind_coeff_ 
-  delete swdiff_coeff_ 
-  delete supg_coeff_
+  delete umag_coeff_;
+  delete gscale_coeff_;
+  delete visc_coeff_;
+  delete visc_inv_coeff_;
+  delete reh1_coeff_;
+  delete reh2_coeff_;
+  delete Reh_coeff_;
+  delete csupg_coeff_;
+  delete uw1_coeff_;
+  delete uw2_coeff_;
+  delete upwind_coeff_; 
+  delete swdiff_coeff_;
+  delete supg_coeff_;
 
   // allocated in initializeSelf
   delete sfes_;
@@ -468,28 +468,28 @@ void CaloricallyPerfectThermoChem::initializeOperators() {
 
   // artifical diffusion coefficients
   if(sw_stab_) {
-    umag_coeff_ = new VectorMagnitudeCoefficient(un_next_coeff_)
-    gscale_coeff_ = new GridFunctionCoefficient(gridScale)
-    visc_coeff_ = new GridFunctionCoefficient(visc_gf_)
-    visc_inv_coeff_ = new PowerCoefficient(visc_coeff_, -1)
+    umag_coeff_ = new VectorMagnitudeCoefficient(*un_next_coeff_);
+    gscale_coeff_ = new GridFunctionCoefficient(gridScale_gf_);
+    visc_coeff_ = new GridFunctionCoefficient(&visc_gf_);
+    visc_inv_coeff_ = new PowerCoefficient(*visc_coeff_, -1);
 
     // compute Reh
-    reh1_coeff_ = new ProductCoefficient(rho_coeff_, visc_inv_coeff_)
-    reh2_coeff_ = new ProductCoefficient(reh1_coeff_, gscale_coeff_)
-    Reh_coeff_ = new ProductCoefficient(reh1_coeff_, umag_coeff_)
+    reh1_coeff_ = new ProductCoefficient(*rho_coeff_, *visc_inv_coeff_);
+    reh2_coeff_ = new ProductCoefficient(*reh1_coeff_, *gscale_coeff_);
+    Reh_coeff_ = new ProductCoefficient(*reh1_coeff_, *umag_coeff_);
 
     // Csupg
-    csupg_coeff_ = new TransformCoefficient(Reh_coeff_, csupgFactor);
+    csupg_coeff_ = new TransformedCoefficient(Reh_coeff_, csupgFactor);
 
     // compute upwind magnitude
-    uw1_coeff_ = new ProductCoefficient(rho_coeff_, csupg_coeff_)
-    uw2_coeff_ = new ProductCoefficient(uw1_coeff_, gscale_coeff_)
-    upwind_coeff_ = new ProductCoefficient(uw2_coeff_, umag_coeff_)
+    uw1_coeff_ = new ProductCoefficient(*rho_coeff_, *csupg_coeff_);
+    uw2_coeff_ = new ProductCoefficient(*uw1_coeff_, *gscale_coeff_);
+    upwind_coeff_ = new ProductCoefficient(*uw2_coeff_, *umag_coeff_);
 
     // streamwise diffusion direction
-    swdiff_coeff_ = new TransformedMatrixVectorCoefficient(un_next_coeff_, streamwiseTensor);
+    swdiff_coeff_ = new TransformedMatrixVectorCoefficient(un_next_coeff_, &streamwiseTensor);
 
-    supg_coeff_ = new ScalarMatrixProductCoefficient(*upwind_coeff_, *swdiff_coeff)
+    supg_coeff_ = new ScalarMatrixProductCoefficient(*upwind_coeff_, *swdiff_coeff_);
   }
   
 
@@ -538,13 +538,13 @@ void CaloricallyPerfectThermoChem::initializeOperators() {
     hdt_blfi->SetIntRule(&ir_di);
   }
   // SUPG
+  auto *sdt_blfi = new DiffusionIntegrator(*supg_coeff_);
   if (sw_stab_)
     // SUPG diffusion
-    auto *Sdt_blfi = new DiffusionIntegrator(*supg_coeff_);
-    if (numerical_integ_) {
-      Sdt_blfi->SetIntRule(&ir_di);
-    }
-    Ht_form_->AddDomainIntegrator(Sdt_blfi);
+    // if (numerical_integ_) {
+    //   sdt_blfi->SetIntRule(&ir_di);
+    // }
+    Ht_form_->AddDomainIntegrator(sdt_blfi);
   Ht_form_->AddDomainIntegrator(hmt_blfi);
   Ht_form_->AddDomainIntegrator(hdt_blfi);
   Ht_form_->Assemble();

--- a/src/calorically_perfect.hpp
+++ b/src/calorically_perfect.hpp
@@ -155,6 +155,8 @@ class CaloricallyPerfectThermoChem : public ThermoChemModelBase {
   ParGridFunction R0PM0_gf_;
   ParGridFunction Qt_gf_;
 
+  ParGridFunction *gridScale_gf_ = nullptr;
+
   // ParGridFunction *buffer_tInlet_ = nullptr;
   GridFunctionCoefficient *temperature_bc_field_ = nullptr;
 
@@ -170,6 +172,20 @@ class CaloricallyPerfectThermoChem : public ThermoChemModelBase {
   ScalarVectorProductCoefficient *kap_gradT_coeff_ = nullptr;
   GridFunctionCoefficient *rho_over_dt_coeff_ = nullptr;
   GridFunctionCoefficient *rho_coeff_ = nullptr;
+
+  VectorMagnitudeCoefficient *umag_coeff_ = nullptr;
+  GridFunctionCoefficient *gscale_coeff_ = nullptr;
+  GridFunctionCoefficient *visc_coeff_ = nullptr;
+  PowerCoefficient *visc_inv_coeff_ = nullptr;
+  ProductCoefficient *reh1_coeff_  = nullptr;
+  ProductCoefficient *reh2_coeff_  = nullptr;
+  ProductCoefficient *Reh_coeff_  = nullptr;
+  TransformCoefficient *csupg_coeff_ = nullptr;
+  ProductCoefficient *uw1_coeff_  = nullptr;
+  ProductCoefficient *uw2_coeff_ = nullptr;
+  ProductCoefficient *upwind_coeff_  = nullptr;
+  TransformedMatrixVectorCoefficient *swdiff_coeff_  = nullptr;
+  ScalarMatrixProductCoefficient *supg_coeff_ = nullptr;
 
   // operators and solvers
   ParBilinearForm *At_form_ = nullptr;
@@ -233,7 +249,7 @@ class CaloricallyPerfectThermoChem : public ThermoChemModelBase {
 
  public:
   CaloricallyPerfectThermoChem(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &timeCoeff,
-                               TPS::Tps *tps);
+                               ParGridFunction *gridScale, TPS::Tps *tps);
   virtual ~CaloricallyPerfectThermoChem();
 
   // Functions overriden from base class

--- a/src/calorically_perfect.hpp
+++ b/src/calorically_perfect.hpp
@@ -48,6 +48,7 @@ class Tps;
 #include "io.hpp"
 #include "thermo_chem_base.hpp"
 #include "tps_mfem_wrap.hpp"
+#include "utils.hpp"
 
 using VecFuncT = void(const Vector &x, double t, Vector &u);
 using ScalarFuncT = double(const Vector &x, double t);
@@ -136,6 +137,9 @@ class CaloricallyPerfectThermoChem : public ThermoChemModelBase {
   // Initial temperature value (if constant IC)
   double T_ic_;
 
+  // streamwise-stabilization
+  bool sw_stab_;
+
   // FEM related fields and objects
 
   // Scalar \f$H^1\f$ finite element collection.
@@ -180,7 +184,7 @@ class CaloricallyPerfectThermoChem : public ThermoChemModelBase {
   ProductCoefficient *reh1_coeff_  = nullptr;
   ProductCoefficient *reh2_coeff_  = nullptr;
   ProductCoefficient *Reh_coeff_  = nullptr;
-  TransformCoefficient *csupg_coeff_ = nullptr;
+  TransformedCoefficient *csupg_coeff_ = nullptr;
   ProductCoefficient *uw1_coeff_  = nullptr;
   ProductCoefficient *uw2_coeff_ = nullptr;
   ProductCoefficient *upwind_coeff_  = nullptr;

--- a/src/calorically_perfect.hpp
+++ b/src/calorically_perfect.hpp
@@ -181,14 +181,14 @@ class CaloricallyPerfectThermoChem : public ThermoChemModelBase {
   GridFunctionCoefficient *gscale_coeff_ = nullptr;
   GridFunctionCoefficient *visc_coeff_ = nullptr;
   PowerCoefficient *visc_inv_coeff_ = nullptr;
-  ProductCoefficient *reh1_coeff_  = nullptr;
-  ProductCoefficient *reh2_coeff_  = nullptr;
-  ProductCoefficient *Reh_coeff_  = nullptr;
+  ProductCoefficient *reh1_coeff_ = nullptr;
+  ProductCoefficient *reh2_coeff_ = nullptr;
+  ProductCoefficient *Reh_coeff_ = nullptr;
   TransformedCoefficient *csupg_coeff_ = nullptr;
-  ProductCoefficient *uw1_coeff_  = nullptr;
+  ProductCoefficient *uw1_coeff_ = nullptr;
   ProductCoefficient *uw2_coeff_ = nullptr;
-  ProductCoefficient *upwind_coeff_  = nullptr;
-  TransformedMatrixVectorCoefficient *swdiff_coeff_  = nullptr;
+  ProductCoefficient *upwind_coeff_ = nullptr;
+  TransformedMatrixVectorCoefficient *swdiff_coeff_ = nullptr;
   ScalarMatrixProductCoefficient *supg_coeff_ = nullptr;
 
   // operators and solvers

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -166,7 +166,7 @@ void LoMachSolver::initialize() {
   if (loMach_opts_.thermo_solver == "constant-property") {
     thermo_ = new ConstantPropertyThermoChem(pmesh_, loMach_opts_.order, tpsP_);
   } else if (loMach_opts_.thermo_solver == "calorically-perfect") {
-    thermo_ = new CaloricallyPerfectThermoChem(pmesh_, &loMach_opts_, temporal_coeff_, tpsP_);
+    thermo_ = new CaloricallyPerfectThermoChem(pmesh_, &loMach_opts_, temporal_coeff_, (meshData_->getGridScale()), tpsP_);
   } else if (loMach_opts_.thermo_solver == "lte-thermo-chem") {
     thermo_ = new LteThermoChem(pmesh_, &loMach_opts_, temporal_coeff_, tpsP_);
   } else if (loMach_opts_.thermo_solver == "reacting-flow") {

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -169,7 +169,7 @@ void LoMachSolver::initialize() {
     thermo_ =
         new CaloricallyPerfectThermoChem(pmesh_, &loMach_opts_, temporal_coeff_, (meshData_->getGridScale()), tpsP_);
   } else if (loMach_opts_.thermo_solver == "lte-thermo-chem") {
-    thermo_ = new LteThermoChem(pmesh_, &loMach_opts_, temporal_coeff_, tpsP_);
+    thermo_ = new LteThermoChem(pmesh_, &loMach_opts_, temporal_coeff_, meshData_->getGridScale(), tpsP_);
   } else if (loMach_opts_.thermo_solver == "reacting-flow") {
     thermo_ = new ReactingFlow(pmesh_, &loMach_opts_, temporal_coeff_, (meshData_->getGridScale()), tpsP_);
   } else {

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -182,7 +182,7 @@ void LoMachSolver::initialize() {
   // Instantiate flow solver
   if (loMach_opts_.flow_solver == "zero-flow") {
     // No flow---set u = 0.  Primarily useful for testing thermochem models in isolation
-    flow_ = new ZeroFlow(pmesh_, 1);
+    flow_ = new ZeroFlow(pmesh_, 1, tpsP_);
   } else if (loMach_opts_.flow_solver == "tomboulides") {
     // Tomboulides flow solver
     flow_ = new Tomboulides(pmesh_, loMach_opts_.order, loMach_opts_.order, temporal_coeff_, tpsP_);

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -170,7 +170,7 @@ void LoMachSolver::initialize() {
   } else if (loMach_opts_.thermo_solver == "lte-thermo-chem") {
     thermo_ = new LteThermoChem(pmesh_, &loMach_opts_, temporal_coeff_, tpsP_);
   } else if (loMach_opts_.thermo_solver == "reacting-flow") {
-    thermo_ = new ReactingFlow(pmesh_, &loMach_opts_, temporal_coeff_, tpsP_);
+    thermo_ = new ReactingFlow(pmesh_, &loMach_opts_, temporal_coeff_, (meshData_->getGridScale()), tpsP_);
   } else {
     // Unknown choice... die
     if (rank0_) {

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -166,7 +166,8 @@ void LoMachSolver::initialize() {
   if (loMach_opts_.thermo_solver == "constant-property") {
     thermo_ = new ConstantPropertyThermoChem(pmesh_, loMach_opts_.order, tpsP_);
   } else if (loMach_opts_.thermo_solver == "calorically-perfect") {
-    thermo_ = new CaloricallyPerfectThermoChem(pmesh_, &loMach_opts_, temporal_coeff_, (meshData_->getGridScale()), tpsP_);
+    thermo_ =
+        new CaloricallyPerfectThermoChem(pmesh_, &loMach_opts_, temporal_coeff_, (meshData_->getGridScale()), tpsP_);
   } else if (loMach_opts_.thermo_solver == "lte-thermo-chem") {
     thermo_ = new LteThermoChem(pmesh_, &loMach_opts_, temporal_coeff_, tpsP_);
   } else if (loMach_opts_.thermo_solver == "reacting-flow") {

--- a/src/lte_thermo_chem.cpp
+++ b/src/lte_thermo_chem.cpp
@@ -68,8 +68,8 @@ static double sigmaTorchStartUp(const Vector &pos) {
 static FunctionCoefficient sigma_start_up(sigmaTorchStartUp);
 
 LteThermoChem::LteThermoChem(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &time_coeff,
-                             TPS::Tps *tps)
-    : tpsP_(tps), pmesh_(pmesh), time_coeff_(time_coeff) {
+                ParGridFunction *gridScale, TPS::Tps *tps)
+    : tpsP_(tps), pmesh_(pmesh), time_coeff_(time_coeff), gridScale_gf_(gridScale)  {
   rank0_ = (pmesh_->GetMyRank() == 0);
   order_ = loMach_opts->order;
 
@@ -166,6 +166,8 @@ LteThermoChem::LteThermoChem(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, t
   tps->getInput("loMach/ltethermo/linear-solver-rtol", rtol_, 1e-12);
   tps->getInput("loMach/ltethermo/linear-solver-max-iter", max_iter_, 1000);
   tps->getInput("loMach/ltethermo/linear-solver-verbosity", pl_solve_, 0);
+
+  tpsP_->getInput("loMach/ltethermo/streamwise-stabilization", sw_stab_, false);
 }
 
 LteThermoChem::~LteThermoChem() {
@@ -204,6 +206,20 @@ LteThermoChem::~LteThermoChem() {
   delete rho_Cp_over_dt_coeff_;
   delete rho_Cp_coeff_;
   delete rho_coeff_;
+
+  delete umag_coeff_;
+  delete gscale_coeff_;
+  delete visc_coeff_;
+  delete visc_inv_coeff_;
+  delete reh1_coeff_;
+  delete reh2_coeff_;
+  delete Reh_coeff_;
+  delete csupg_coeff_;
+  delete uw1_coeff_;
+  delete uw2_coeff_;
+  delete upwind_coeff_;
+  delete swdiff_coeff_;
+  delete supg_coeff_;
 
   // allocated in initializeSelf
   delete sfes_;
@@ -555,6 +571,37 @@ void LteThermoChem::initializeOperators() {
     rad_kap_gradT_coeff_ = new ScalarVectorProductCoefficient(radius_coeff, *kap_gradT_coeff_);
   }
 
+  // artifical diffusion coefficients
+  if (sw_stab_) {
+    umag_coeff_ = new VectorMagnitudeCoefficient(*un_next_coeff_);
+    gscale_coeff_ = new GridFunctionCoefficient(gridScale_gf_);
+    visc_coeff_ = new GridFunctionCoefficient(&mu_gf_);
+    visc_inv_coeff_ = new PowerCoefficient(*visc_coeff_, -1.0);
+
+    // compute Reh
+    reh1_coeff_ = new ProductCoefficient(*rho_coeff_, *visc_inv_coeff_);
+    reh2_coeff_ = new ProductCoefficient(*reh1_coeff_, *gscale_coeff_);
+    Reh_coeff_ = new ProductCoefficient(*reh2_coeff_, *umag_coeff_);
+
+    // Csupg
+    csupg_coeff_ = new TransformedCoefficient(Reh_coeff_, csupgFactor);
+
+    // compute upwind magnitude
+    if (axisym_) {
+      uw1_coeff_ = new ProductCoefficient(*rad_rho_Cp_coeff_, *csupg_coeff_);
+    } else {
+      uw1_coeff_ = new ProductCoefficient(*rho_Cp_coeff_, *csupg_coeff_);
+    }
+    uw2_coeff_ = new ProductCoefficient(*uw1_coeff_, *gscale_coeff_);
+    upwind_coeff_ = new ProductCoefficient(*uw2_coeff_, *umag_coeff_);
+
+    // streamwise diffusion direction
+    swdiff_coeff_ = new TransformedMatrixVectorCoefficient(un_next_coeff_, &streamwiseTensor);
+
+    supg_coeff_ = new ScalarMatrixProductCoefficient(*upwind_coeff_, *swdiff_coeff_);
+  }
+
+
   // Convection: Atemperature(i,j) = \int_{\Omega} \phi_i \rho Cp u \cdot \nabla \phi_j
   At_form_ = new ParBilinearForm(sfes_);
   ConvectionIntegrator *at_blfi;
@@ -645,6 +692,14 @@ void LteThermoChem::initializeOperators() {
   }
   Ht_form_->AddDomainIntegrator(hmt_blfi);
   Ht_form_->AddDomainIntegrator(hdt_blfi);
+
+  if (sw_stab_) {
+    auto *sdt_blfi = new DiffusionIntegrator(*supg_coeff_);
+    if (numerical_integ_) {
+      sdt_blfi->SetIntRule(&ir_di);
+    }
+    Ht_form_->AddDomainIntegrator(sdt_blfi);
+  }
   if (partial_assembly_) {
     Ht_form_->SetAssemblyLevel(AssemblyLevel::PARTIAL);
   }
@@ -784,6 +839,14 @@ void LteThermoChem::initializeOperators() {
     lqd_blfi->SetIntRule(&ir_di);
   }
   LQ_form_->AddDomainIntegrator(lqd_blfi);
+
+  if (sw_stab_) {
+    auto *slqd_blfi = new DiffusionIntegrator(*supg_coeff_);
+    if (numerical_integ_) {
+      slqd_blfi->SetIntRule(&ir_di);
+    }
+    LQ_form_->AddDomainIntegrator(slqd_blfi);
+  }
   if (partial_assembly_) {
     LQ_form_->SetAssemblyLevel(AssemblyLevel::PARTIAL);
   }

--- a/src/lte_thermo_chem.hpp
+++ b/src/lte_thermo_chem.hpp
@@ -49,6 +49,7 @@ class Tps;
 #include "table.hpp"
 #include "thermo_chem_base.hpp"
 #include "tps_mfem_wrap.hpp"
+#include "utils.hpp"
 
 using VecFuncT = void(const Vector &x, double t, Vector &u);
 using ScalarFuncT = double(const Vector &x, double t);
@@ -89,6 +90,7 @@ class LteThermoChem final : public ThermoChemModelBase {
   bool numerical_integ_ = false;  /**< Enable/disable numerical integration rules of forms. */
   bool domain_is_open_ = false;   /**< true if domain is open */
   bool axisym_ = false;
+  bool sw_stab_ = false;          /**< Enable/disable supg stabilization. */
 
   // Linear-solver-related options
   int pl_solve_ = 0;    /**< Verbosity level passed to mfem solvers */
@@ -148,6 +150,8 @@ class LteThermoChem final : public ThermoChemModelBase {
   ParGridFunction R0PM0_gf_;
   ParGridFunction Qt_gf_;
 
+  ParGridFunction *gridScale_gf_ = nullptr;
+
   // ParGridFunction *buffer_tInlet_ = nullptr;
   GridFunctionCoefficient *temperature_bc_field_ = nullptr;
 
@@ -179,6 +183,20 @@ class LteThermoChem final : public ThermoChemModelBase {
   ProductCoefficient *rad_jh_coeff_ = nullptr;
   ProductCoefficient *rad_radiation_sink_coeff_ = nullptr;
   ScalarVectorProductCoefficient *rad_kap_gradT_coeff_ = nullptr;
+
+  VectorMagnitudeCoefficient *umag_coeff_ = nullptr;
+  GridFunctionCoefficient *gscale_coeff_ = nullptr;
+  GridFunctionCoefficient *visc_coeff_ = nullptr;
+  PowerCoefficient *visc_inv_coeff_ = nullptr;
+  ProductCoefficient *reh1_coeff_ = nullptr;
+  ProductCoefficient *reh2_coeff_ = nullptr;
+  ProductCoefficient *Reh_coeff_ = nullptr;
+  TransformedCoefficient *csupg_coeff_ = nullptr;
+  ProductCoefficient *uw1_coeff_ = nullptr;
+  ProductCoefficient *uw2_coeff_ = nullptr;
+  ProductCoefficient *upwind_coeff_ = nullptr;
+  TransformedMatrixVectorCoefficient *swdiff_coeff_ = nullptr;
+  ScalarMatrixProductCoefficient *supg_coeff_ = nullptr;
 
   // operators and solvers
   ParBilinearForm *At_form_ = nullptr;
@@ -241,7 +259,8 @@ class LteThermoChem final : public ThermoChemModelBase {
   ParGridFunction Tn_filtered_gf_;
 
  public:
-  LteThermoChem(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &timeCoeff, TPS::Tps *tps);
+  LteThermoChem(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &timeCoeff,
+                ParGridFunction *gridScale, TPS::Tps *tps);
   virtual ~LteThermoChem();
 
   // Functions overriden from base class

--- a/src/reactingFlow.cpp
+++ b/src/reactingFlow.cpp
@@ -1114,7 +1114,7 @@ void ReactingFlow::initializeSelf() {
         }
         AddTempDirichletBC(temperature_value, inlet_attr);
 
-        // AddSpecDirichletBC(0.0, inlet_attr);
+        AddSpecDirichletBC(0.0, inlet_attr);
 
       } else if (type == "interpolate") {
         Array<int> inlet_attr(pmesh_->bdr_attributes.Max());
@@ -1198,7 +1198,7 @@ void ReactingFlow::initializeSelf() {
         Qt_bc_coeff->constant = 0.0;
         AddQtDirichletBC(Qt_bc_coeff, attr_wall);
 
-        // AddSpecDirichletBC(0.0, attr_wall);
+        AddSpecDirichletBC(0.0, attr_wall);
       }
     }
     if (rank0_) std::cout << "Temp wall bc completed: " << numWalls << endl;

--- a/src/reactingFlow.cpp
+++ b/src/reactingFlow.cpp
@@ -1672,13 +1672,13 @@ void ReactingFlow::initializeOperators() {
   LQ_form_->AddDomainIntegrator(lqd_blfi);
 
   DiffusionIntegrator *slqd_blfi;
-  if (sw_stab_) slqd_blfi = new DiffusionIntegrator(*supg_coeff_);
-  // SUPG diffusion
-  // if (numerical_integ_) {
-  //   slqd_blfi->SetIntRule(&ir_di);
-  // }
-  LQ_form_->AddDomainIntegrator(slqd_blfi);
-
+  if (sw_stab_) {
+    slqd_blfi = new DiffusionIntegrator(*supg_coeff_);
+    // if (numerical_integ_) {
+    //   slqd_blfi->SetIntRule(&ir_di);
+    // }
+    LQ_form_->AddDomainIntegrator(slqd_blfi);
+  }
   if (partial_assembly_) {
     LQ_form_->SetAssemblyLevel(AssemblyLevel::PARTIAL);
   }

--- a/src/reactingFlow.cpp
+++ b/src/reactingFlow.cpp
@@ -702,7 +702,7 @@ ReactingFlow::ReactingFlow(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, tem
   tpsP_->getInput("loMach/reactingFlow/streamwise-stabilization", sw_stab_, false);
   
   // NOTE: clipping Qt for debugging
-  tpsP_->getInput("loMach/reactingFlow/clip-qt", clip_qt_, false);
+  // tpsP_->getInput("loMach/reactingFlow/clip-qt", clip_qt_, false);
   
 
 }  // NOLINT
@@ -1009,20 +1009,20 @@ void ReactingFlow::initializeSelf() {
   Rmix_gf_.SetSpace(sfes_);
 
   // qt rhs visualization
-  rhsqt_bd_.SetSpace(sfes_);
-  rhsqt_fo_.SetSpace(sfes_);
-  rhsqt_jh_.SetSpace(sfes_);
-  rhsqt_hf_.SetSpace(sfes_);
-  rhsqt_sd_.SetSpace(sfes_);
-  rhsqt_total_.SetSpace(sfes_);
-  Xqt_gf_.SetSpace(sfes_);
-  rhsqt_bd_ = 0.0;
-  rhsqt_fo_ = 0.0;
-  rhsqt_jh_ = 0.0;
-  rhsqt_hf_ = 0.0;
-  rhsqt_sd_ = 0.0;
-  rhsqt_total_ = 0.0;
-  Xqt_gf_ = 0.0;
+  // rhsqt_bd_.SetSpace(sfes_);
+  // rhsqt_fo_.SetSpace(sfes_);
+  // rhsqt_jh_.SetSpace(sfes_);
+  // rhsqt_hf_.SetSpace(sfes_);
+  // rhsqt_sd_.SetSpace(sfes_);
+  // rhsqt_total_.SetSpace(sfes_);
+  // Xqt_gf_.SetSpace(sfes_);
+  // rhsqt_bd_ = 0.0;
+  // rhsqt_fo_ = 0.0;
+  // rhsqt_jh_ = 0.0;
+  // rhsqt_hf_ = 0.0;
+  // rhsqt_sd_ = 0.0;
+  // rhsqt_total_ = 0.0;
+  // Xqt_gf_ = 0.0;
 
   // exports
   toFlow_interface_.density = &rn_gf_;
@@ -2642,13 +2642,13 @@ void ReactingFlow::initializeViz(ParaViewDataCollection &pvdc) {
   pvdc.RegisterField("emission", &emission_gf_);
   
   // diagnose Qt issues, rhs contributions
-  pvdc.RegisterField("rhsqt_bd", &rhsqt_bd_); //boundary terms
-  pvdc.RegisterField("rhsqt_fo", &rhsqt_fo_); //bilinear form
-  pvdc.RegisterField("rhsqt_jh", &rhsqt_jh_); //joule heating
-  pvdc.RegisterField("rhsqt_hf", &rhsqt_hf_); //heat of formation
-  pvdc.RegisterField("rhsqt_sd", &rhsqt_sd_); ///species-temp diff
-  pvdc.RegisterField("rhsqt_total", &rhsqt_total_);
-  pvdc.RegisterField("Xqt", &Xqt_gf_);
+  // pvdc.RegisterField("rhsqt_bd", &rhsqt_bd_); //boundary terms
+  // pvdc.RegisterField("rhsqt_fo", &rhsqt_fo_); //bilinear form
+  // pvdc.RegisterField("rhsqt_jh", &rhsqt_jh_); //joule heating
+  // pvdc.RegisterField("rhsqt_hf", &rhsqt_hf_); //heat of formation
+  // pvdc.RegisterField("rhsqt_sd", &rhsqt_sd_); ///species-temp diff
+  // pvdc.RegisterField("rhsqt_total", &rhsqt_total_);
+  // pvdc.RegisterField("Xqt", &Xqt_gf_);
   
   vizSpecFields_.clear();
   vizSpecNames_.clear();
@@ -3125,29 +3125,29 @@ void ReactingFlow::AddQtDirichletBC(ScalarFuncT *f, Array<int> &attr) {
 
 void ReactingFlow::computeQtTO() {
   tmpR0_ = 0.0;
-  rhsqt_bd_ = 0.0;
-  rhsqt_fo_ = 0.0;
-  rhsqt_jh_ = 0.0;
-  rhsqt_hf_ = 0.0;
-  rhsqt_sd_ = 0.0;
-  rhsqt_total_ = 0.0;
-  Xqt_gf_ = 0.0;
+  // rhsqt_bd_ = 0.0;
+  // rhsqt_fo_ = 0.0;
+  // rhsqt_jh_ = 0.0;
+  // rhsqt_hf_ = 0.0;
+  // rhsqt_sd_ = 0.0;
+  // rhsqt_total_ = 0.0;
+  // Xqt_gf_ = 0.0;
   LQ_bdry_->Update();
   LQ_bdry_->Assemble();
-  // LQ_bdry_->ParallelAssemble(tmpR0_);
-  // tmpR0_.Neg();
-  LQ_bdry_->ParallelAssemble(rhsqt_bd_);
-  rhsqt_bd_.Neg();
-  tmpR0_ += rhsqt_bd_;
+  LQ_bdry_->ParallelAssemble(tmpR0_);
+  tmpR0_.Neg();
+  // LQ_bdry_->ParallelAssemble(rhsqt_bd_);
+  // rhsqt_bd_.Neg();
+  // tmpR0_ += rhsqt_bd_;
   // printf("%f\n", tmpR0_.Norml2());
 
   Array<int> empty;
   LQ_form_->Update();
   LQ_form_->Assemble();
   LQ_form_->FormSystemMatrix(empty, LQ_);
-  // LQ_->AddMult(Tn_next_, tmpR0_);  // tmpR0_ += LQ{Tn_next}
-  LQ_->Mult(Tn_next_, rhsqt_fo_);  // tmpR0_ += LQ{Tn_next}
-  tmpR0_ += rhsqt_fo_;
+  LQ_->AddMult(Tn_next_, tmpR0_);  // tmpR0_ += LQ{Tn_next}
+  // LQ_->Mult(Tn_next_, rhsqt_fo_);  // tmpR0_ += LQ{Tn_next}
+  // tmpR0_ += rhsqt_fo_;
   // printf("%f\n", tmpR0_.Norml2());
 
   // Joule heating (and radiation sink)
@@ -3155,54 +3155,50 @@ void ReactingFlow::computeQtTO() {
   jh_form_->Assemble();
   jh_form_->ParallelAssemble(jh_);
   tmpR0_ -= jh_;
-  rhsqt_jh_.SetFromTrueDofs(jh_);
-  rhsqt_jh_.Neg();
+  // rhsqt_jh_.SetFromTrueDofs(jh_);
+  // rhsqt_jh_.Neg();
   // printf("%f\n", tmpR0_.Norml2());
   
   // heat of formation
-  // Ms_->AddMult(hw_, tmpR0_, -1.0);
-  Ms_->Mult(hw_, rhsqt_hf_);
-  rhsqt_hf_.Neg();
-  tmpR0_ += rhsqt_hf_;
+  Ms_->AddMult(hw_, tmpR0_, -1.0);
+  // Ms_->Mult(hw_, rhsqt_hf_);
+  // rhsqt_hf_.Neg();
+  // tmpR0_ += rhsqt_hf_;
   // printf("%f\n", tmpR0_.Norml2());
 
   // species-temp diffusion term, already in int-weak form
   tmpR0_.Add(-1.0, crossDiff_);
-  rhsqt_sd_.SetFromTrueDofs(crossDiff_);
-  rhsqt_sd_.Neg();
+  // rhsqt_sd_.SetFromTrueDofs(crossDiff_);
+  // rhsqt_sd_.Neg();
   // printf("%f\n", tmpR0_.Norml2());
 
   sfes_->GetRestrictionMatrix()->MultTranspose(tmpR0_, resT_gf_);
-  rhsqt_total_.SetFromTrueDofs(resT_gf_);
+  // rhsqt_total_.SetFromTrueDofs(resT_gf_);
 
   Qt_ = 0.0;
   Qt_gf_.SetFromTrueDofs(Qt_);
 
   Vector Xqt, Bqt;
   Mq_form_->FormLinearSystem(Qt_ess_tdof_, Qt_gf_, resT_gf_, Mq_, Xqt, Bqt, 1);
-  // std::ofstream myfile("mq_mat");
-  // Mq_->PrintMatlab(myfile);
   MqInv_->Mult(Bqt, Xqt);
-  // std::ofstream myfile("mqi_mat");
-  // MqInv_->PrintMatlab(myfile);
   Mq_form_->RecoverFEMSolution(Xqt, resT_gf_, Qt_gf_);
-  Xqt_gf_.SetFromTrueDofs(Xqt);
+  // Xqt_gf_.SetFromTrueDofs(Xqt);
 
   Qt_gf_ *= Rmix_gf_;
   Qt_gf_ /= CpMix_gf_;
   Qt_gf_ /= thermo_pressure_;
 
   // NOTE: clipping for diagnosis, goes both directions for now
-  double clip_val;
-  if (clip_qt_) {
-    tpsP_->getInput("loMach/reactingFlow/clip-qt-value", clip_val, 50000.);
+  // double clip_val;
+  // if (clip_qt_) {
+  //   tpsP_->getInput("loMach/reactingFlow/clip-qt-value", clip_val, 50000.);
 
-    for (int n = 0; n < sfes_->GetNDofs(); n++) {
-      // Qt_gf_[n] = std::clamp(Qt_gf_[n], -clip_val, clip_val)
-      Qt_gf_[n] = std::min(clip_val, std::max(-clip_val, Qt_gf_[n]));
-    }
+  //   for (int n = 0; n < sfes_->GetNDofs(); n++) {
+  //     // Qt_gf_[n] = std::clamp(Qt_gf_[n], -clip_val, clip_val)
+  //     Qt_gf_[n] = std::min(clip_val, std::max(-clip_val, Qt_gf_[n]));
+  //   }
 
-  }
+  // }
 
   Qt_gf_.Neg();
 }

--- a/src/reactingFlow.cpp
+++ b/src/reactingFlow.cpp
@@ -700,6 +700,11 @@ ReactingFlow::ReactingFlow(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, tem
 
   // artificial diffusion (SUPG)
   tpsP_->getInput("loMach/reactingFlow/streamwise-stabilization", sw_stab_, false);
+  
+  // NOTE: clipping Qt for debugging
+  tpsP_->getInput("loMach/reactingFlow/clip-qt", clip_qt_, false);
+  
+
 }  // NOLINT
 
 ReactingFlow::~ReactingFlow() {
@@ -793,6 +798,7 @@ ReactingFlow::~ReactingFlow() {
   delete upwind_coeff_; 
   delete swdiff_coeff_;
   delete supg_coeff_;
+  delete supg_cp_coeff_;
 
   // allocated in initializeSelf
   delete vfes_;
@@ -1001,6 +1007,22 @@ void ReactingFlow::initializeSelf() {
 
   Mmix_gf_.SetSpace(sfes_);
   Rmix_gf_.SetSpace(sfes_);
+
+  // qt rhs visualization
+  rhsqt_bd_.SetSpace(sfes_);
+  rhsqt_fo_.SetSpace(sfes_);
+  rhsqt_jh_.SetSpace(sfes_);
+  rhsqt_hf_.SetSpace(sfes_);
+  rhsqt_sd_.SetSpace(sfes_);
+  rhsqt_total_.SetSpace(sfes_);
+  Xqt_gf_.SetSpace(sfes_);
+  rhsqt_bd_ = 0.0;
+  rhsqt_fo_ = 0.0;
+  rhsqt_jh_ = 0.0;
+  rhsqt_hf_ = 0.0;
+  rhsqt_sd_ = 0.0;
+  rhsqt_total_ = 0.0;
+  Xqt_gf_ = 0.0;
 
   // exports
   toFlow_interface_.density = &rn_gf_;
@@ -1325,6 +1347,7 @@ void ReactingFlow::initializeOperators() {
       swdiff_coeff_ = new TransformedMatrixVectorCoefficient(un_next_coeff_, &streamwiseTensor);
 
       supg_coeff_ = new ScalarMatrixProductCoefficient(*upwind_coeff_, *swdiff_coeff_);
+      supg_cp_coeff_ = new ScalarMatrixProductCoefficient(*cpMix_coeff_, *supg_coeff_);
     }
     else {
       // compute upwind magnitude
@@ -1336,6 +1359,7 @@ void ReactingFlow::initializeOperators() {
       swdiff_coeff_ = new TransformedMatrixVectorCoefficient(un_next_coeff_, &streamwiseTensor);
 
       supg_coeff_ = new ScalarMatrixProductCoefficient(*upwind_coeff_, *swdiff_coeff_);
+      supg_cp_coeff_ = new ScalarMatrixProductCoefficient(*cpMix_coeff_, *supg_coeff_);
     }
   }
 
@@ -1449,7 +1473,7 @@ void ReactingFlow::initializeOperators() {
   DiffusionIntegrator *sdt_blfi; 
   if (sw_stab_) {
     // auto *sdt_blfi = new DiffusionIntegrator(*supg_coeff_);
-    sdt_blfi = new DiffusionIntegrator(*supg_coeff_);
+    sdt_blfi = new DiffusionIntegrator(*supg_cp_coeff_);
     // SUPG diffusion
     // if (numerical_integ_) {
     //   sdt_blfi->SetIntRule(&ir_di);
@@ -2616,7 +2640,16 @@ void ReactingFlow::initializeViz(ParaViewDataCollection &pvdc) {
   pvdc.RegisterField("epsilon_rad", &radiation_sink_gf_);
   pvdc.RegisterField("weff", &weff_gf_);
   pvdc.RegisterField("emission", &emission_gf_);
-
+  
+  // diagnose Qt issues, rhs contributions
+  pvdc.RegisterField("rhsqt_bd", &rhsqt_bd_); //boundary terms
+  pvdc.RegisterField("rhsqt_fo", &rhsqt_fo_); //bilinear form
+  pvdc.RegisterField("rhsqt_jh", &rhsqt_jh_); //joule heating
+  pvdc.RegisterField("rhsqt_hf", &rhsqt_hf_); //heat of formation
+  pvdc.RegisterField("rhsqt_sd", &rhsqt_sd_); ///species-temp diff
+  pvdc.RegisterField("rhsqt_total", &rhsqt_total_);
+  pvdc.RegisterField("Xqt", &Xqt_gf_);
+  
   vizSpecFields_.clear();
   vizSpecNames_.clear();
   for (int sp = 0; sp < nSpecies_; sp++) {
@@ -3092,43 +3125,85 @@ void ReactingFlow::AddQtDirichletBC(ScalarFuncT *f, Array<int> &attr) {
 
 void ReactingFlow::computeQtTO() {
   tmpR0_ = 0.0;
+  rhsqt_bd_ = 0.0;
+  rhsqt_fo_ = 0.0;
+  rhsqt_jh_ = 0.0;
+  rhsqt_hf_ = 0.0;
+  rhsqt_sd_ = 0.0;
+  rhsqt_total_ = 0.0;
+  Xqt_gf_ = 0.0;
   LQ_bdry_->Update();
   LQ_bdry_->Assemble();
-  LQ_bdry_->ParallelAssemble(tmpR0_);
-  tmpR0_.Neg();
+  // LQ_bdry_->ParallelAssemble(tmpR0_);
+  // tmpR0_.Neg();
+  LQ_bdry_->ParallelAssemble(rhsqt_bd_);
+  rhsqt_bd_.Neg();
+  tmpR0_ += rhsqt_bd_;
+  // printf("%f\n", tmpR0_.Norml2());
 
   Array<int> empty;
   LQ_form_->Update();
   LQ_form_->Assemble();
   LQ_form_->FormSystemMatrix(empty, LQ_);
-  LQ_->AddMult(Tn_next_, tmpR0_);  // tmpR0_ += LQ{Tn_next}
+  // LQ_->AddMult(Tn_next_, tmpR0_);  // tmpR0_ += LQ{Tn_next}
+  LQ_->Mult(Tn_next_, rhsqt_fo_);  // tmpR0_ += LQ{Tn_next}
+  tmpR0_ += rhsqt_fo_;
+  // printf("%f\n", tmpR0_.Norml2());
 
   // Joule heating (and radiation sink)
   jh_form_->Update();
   jh_form_->Assemble();
   jh_form_->ParallelAssemble(jh_);
   tmpR0_ -= jh_;
-
+  rhsqt_jh_.SetFromTrueDofs(jh_);
+  rhsqt_jh_.Neg();
+  // printf("%f\n", tmpR0_.Norml2());
+  
   // heat of formation
-  Ms_->AddMult(hw_, tmpR0_, -1.0);
+  // Ms_->AddMult(hw_, tmpR0_, -1.0);
+  Ms_->Mult(hw_, rhsqt_hf_);
+  rhsqt_hf_.Neg();
+  tmpR0_ += rhsqt_hf_;
+  // printf("%f\n", tmpR0_.Norml2());
 
   // species-temp diffusion term, already in int-weak form
   tmpR0_.Add(-1.0, crossDiff_);
+  rhsqt_sd_.SetFromTrueDofs(crossDiff_);
+  rhsqt_sd_.Neg();
+  // printf("%f\n", tmpR0_.Norml2());
 
   sfes_->GetRestrictionMatrix()->MultTranspose(tmpR0_, resT_gf_);
+  rhsqt_total_.SetFromTrueDofs(resT_gf_);
 
   Qt_ = 0.0;
   Qt_gf_.SetFromTrueDofs(Qt_);
 
   Vector Xqt, Bqt;
   Mq_form_->FormLinearSystem(Qt_ess_tdof_, Qt_gf_, resT_gf_, Mq_, Xqt, Bqt, 1);
-
+  // std::ofstream myfile("mq_mat");
+  // Mq_->PrintMatlab(myfile);
   MqInv_->Mult(Bqt, Xqt);
+  // std::ofstream myfile("mqi_mat");
+  // MqInv_->PrintMatlab(myfile);
   Mq_form_->RecoverFEMSolution(Xqt, resT_gf_, Qt_gf_);
+  Xqt_gf_.SetFromTrueDofs(Xqt);
 
   Qt_gf_ *= Rmix_gf_;
   Qt_gf_ /= CpMix_gf_;
   Qt_gf_ /= thermo_pressure_;
+
+  // NOTE: clipping for diagnosis, goes both directions for now
+  double clip_val;
+  if (clip_qt_) {
+    tpsP_->getInput("loMach/reactingFlow/clip-qt-value", clip_val, 50000.);
+
+    for (int n = 0; n < sfes_->GetNDofs(); n++) {
+      // Qt_gf_[n] = std::clamp(Qt_gf_[n], -clip_val, clip_val)
+      Qt_gf_[n] = std::min(clip_val, std::max(-clip_val, Qt_gf_[n]));
+    }
+
+  }
+
   Qt_gf_.Neg();
 }
 

--- a/src/reactingFlow.cpp
+++ b/src/reactingFlow.cpp
@@ -1316,29 +1316,20 @@ void ReactingFlow::initializeOperators() {
     // Csupg
     csupg_coeff_ = new TransformedCoefficient(Reh_coeff_, csupgFactor);
 
+    // compute upwind magnitude
     if (axisym_) {
-      // compute upwind magnitude
       uw1_coeff_ = new ProductCoefficient(*rad_rho_coeff_, *csupg_coeff_);
-      uw2_coeff_ = new ProductCoefficient(*uw1_coeff_, *gscale_coeff_);
-      upwind_coeff_ = new ProductCoefficient(*uw2_coeff_, *umag_coeff_);
-
-      // streamwise diffusion direction
-      swdiff_coeff_ = new TransformedMatrixVectorCoefficient(un_next_coeff_, &streamwiseTensor);
-
-      supg_coeff_ = new ScalarMatrixProductCoefficient(*upwind_coeff_, *swdiff_coeff_);
-      supg_cp_coeff_ = new ScalarMatrixProductCoefficient(*cpMix_coeff_, *supg_coeff_);
     } else {
-      // compute upwind magnitude
       uw1_coeff_ = new ProductCoefficient(*rhon_next_coeff_, *csupg_coeff_);
-      uw2_coeff_ = new ProductCoefficient(*uw1_coeff_, *gscale_coeff_);
-      upwind_coeff_ = new ProductCoefficient(*uw2_coeff_, *umag_coeff_);
-
-      // streamwise diffusion direction
-      swdiff_coeff_ = new TransformedMatrixVectorCoefficient(un_next_coeff_, &streamwiseTensor);
-
-      supg_coeff_ = new ScalarMatrixProductCoefficient(*upwind_coeff_, *swdiff_coeff_);
-      supg_cp_coeff_ = new ScalarMatrixProductCoefficient(*cpMix_coeff_, *supg_coeff_);
     }
+    uw2_coeff_ = new ProductCoefficient(*uw1_coeff_, *gscale_coeff_);
+    upwind_coeff_ = new ProductCoefficient(*uw2_coeff_, *umag_coeff_);
+
+    // streamwise diffusion direction
+    swdiff_coeff_ = new TransformedMatrixVectorCoefficient(un_next_coeff_, &streamwiseTensor);
+
+    supg_coeff_ = new ScalarMatrixProductCoefficient(*upwind_coeff_, *swdiff_coeff_);
+    supg_cp_coeff_ = new ScalarMatrixProductCoefficient(*cpMix_coeff_, *supg_coeff_);
   }
 
   At_form_ = new ParBilinearForm(sfes_);
@@ -1448,9 +1439,8 @@ void ReactingFlow::initializeOperators() {
     hdt_blfi->SetIntRule(&ir_di);
   }
   // SUPG
-  DiffusionIntegrator *sdt_blfi;
   if (sw_stab_) {
-    sdt_blfi = new DiffusionIntegrator(*supg_cp_coeff_);
+    auto sdt_blfi = new DiffusionIntegrator(*supg_cp_coeff_);
     if (numerical_integ_) {
       sdt_blfi->SetIntRule(&ir_di);
     }
@@ -1483,11 +1473,10 @@ void ReactingFlow::initializeOperators() {
     hdy_blfi->SetIntRule(&ir_di);
   }
   // SUPG
-  DiffusionIntegrator *syt_blfi;
   if (sw_stab_) {
-    syt_blfi = new DiffusionIntegrator(*supg_coeff_);
+    auto syt_blfi = new DiffusionIntegrator(*supg_coeff_);
     if (numerical_integ_) {
-      sdt_blfi->SetIntRule(&ir_di);
+      syt_blfi->SetIntRule(&ir_di);
     }
     Hy_form_->AddDomainIntegrator(syt_blfi);
   }

--- a/src/reactingFlow.cpp
+++ b/src/reactingFlow.cpp
@@ -1651,13 +1651,14 @@ void ReactingFlow::initializeOperators() {
   }
   LQ_form_->AddDomainIntegrator(lqd_blfi);
 
-  // auto *slqd_blfi = new DiffusionIntegrator(*supg_coeff_);
-  // if (sw_stab_)
-  //   // SUPG diffusion
-  //   // if (numerical_integ_) {
-  //   //   slqd_blfi->SetIntRule(&ir_di);
-  //   // }
-  //   LQ_form_->AddDomainIntegrator(slqd_blfi);
+  DiffusionIntegrator *slqd_blfi;
+  if (sw_stab_)
+    slqd_blfi = new DiffusionIntegrator(*supg_coeff_);
+    // SUPG diffusion
+    // if (numerical_integ_) {
+    //   slqd_blfi->SetIntRule(&ir_di);
+    // }
+    LQ_form_->AddDomainIntegrator(slqd_blfi);
 
   if (partial_assembly_) {
     LQ_form_->SetAssemblyLevel(AssemblyLevel::PARTIAL);

--- a/src/reactingFlow.hpp
+++ b/src/reactingFlow.hpp
@@ -156,7 +156,7 @@ class ReactingFlow : public ThermoChemModelBase {
 
   // streamwise-stabilization
   bool sw_stab_;
-  
+
   // clip qt for diagnosis
   // bool clip_qt_;
 
@@ -268,14 +268,14 @@ class ReactingFlow : public ThermoChemModelBase {
   GridFunctionCoefficient *gscale_coeff_ = nullptr;
   GridFunctionCoefficient *visc_coeff_ = nullptr;
   PowerCoefficient *visc_inv_coeff_ = nullptr;
-  ProductCoefficient *reh1_coeff_  = nullptr;
-  ProductCoefficient *reh2_coeff_  = nullptr;
-  ProductCoefficient *Reh_coeff_  = nullptr;
+  ProductCoefficient *reh1_coeff_ = nullptr;
+  ProductCoefficient *reh2_coeff_ = nullptr;
+  ProductCoefficient *Reh_coeff_ = nullptr;
   TransformedCoefficient *csupg_coeff_ = nullptr;
-  ProductCoefficient *uw1_coeff_  = nullptr;
+  ProductCoefficient *uw1_coeff_ = nullptr;
   ProductCoefficient *uw2_coeff_ = nullptr;
-  ProductCoefficient *upwind_coeff_  = nullptr;
-  TransformedMatrixVectorCoefficient *swdiff_coeff_  = nullptr;
+  ProductCoefficient *upwind_coeff_ = nullptr;
+  TransformedMatrixVectorCoefficient *swdiff_coeff_ = nullptr;
   ScalarMatrixProductCoefficient *supg_coeff_ = nullptr;
   ScalarMatrixProductCoefficient *supg_cp_coeff_ = nullptr;
 
@@ -391,7 +391,7 @@ class ReactingFlow : public ThermoChemModelBase {
   std::vector<std::string> vizSpecNames_;
 
  public:
-  ReactingFlow(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &timeCoeff, 
+  ReactingFlow(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &timeCoeff,
                ParGridFunction *gridScale, TPS::Tps *tps);
   virtual ~ReactingFlow();
 

--- a/src/reactingFlow.hpp
+++ b/src/reactingFlow.hpp
@@ -156,6 +156,9 @@ class ReactingFlow : public ThermoChemModelBase {
 
   // streamwise-stabilization
   bool sw_stab_;
+  
+  // clip qt for diagnosis
+  bool clip_qt_;
 
   // FEM related fields and objects
 
@@ -208,6 +211,15 @@ class ReactingFlow : public ThermoChemModelBase {
   // Interface with EM
   ParGridFunction sigma_gf_;
   ParGridFunction jh_gf_;
+
+  // viz for qt rhs
+  ParGridFunction rhsqt_bd_;
+  ParGridFunction rhsqt_fo_;
+  ParGridFunction rhsqt_jh_;
+  ParGridFunction rhsqt_hf_;
+  ParGridFunction rhsqt_sd_;
+  ParGridFunction rhsqt_total_;
+  ParGridFunction Xqt_gf_;
 
   // ParGridFunction *buffer_tInlet_ = nullptr;
   GridFunctionCoefficient *temperature_bc_field_ = nullptr;
@@ -265,6 +277,7 @@ class ReactingFlow : public ThermoChemModelBase {
   ProductCoefficient *upwind_coeff_  = nullptr;
   TransformedMatrixVectorCoefficient *swdiff_coeff_  = nullptr;
   ScalarMatrixProductCoefficient *supg_coeff_ = nullptr;
+  ScalarMatrixProductCoefficient *supg_cp_coeff_ = nullptr;
 
   // operators and solvers
   ParBilinearForm *At_form_ = nullptr;

--- a/src/reactingFlow.hpp
+++ b/src/reactingFlow.hpp
@@ -154,6 +154,9 @@ class ReactingFlow : public ThermoChemModelBase {
   // Initial temperature value (if constant IC)
   double T_ic_;
 
+  // streamwise-stabilization
+  bool sw_stab_;
+
   // FEM related fields and objects
 
   // Scalar \f$H^1\f$ finite element collection.
@@ -173,6 +176,8 @@ class ReactingFlow : public ThermoChemModelBase {
 
   // Vector \f$H^1\f$ finite element space.
   ParFiniteElementSpace *vfes_ = nullptr;
+
+  ParGridFunction *gridScale_gf_ = nullptr;
 
   // Fields
   ParGridFunction Tnm1_gf_, Tnm2_gf_;
@@ -246,6 +251,20 @@ class ReactingFlow : public ThermoChemModelBase {
   ProductCoefficient *rad_jh_coeff_ = nullptr;
   ProductCoefficient *rad_radiation_sink_coeff_ = nullptr;
   ScalarVectorProductCoefficient *rad_kap_gradT_coeff_ = nullptr;
+
+  VectorMagnitudeCoefficient *umag_coeff_ = nullptr;
+  GridFunctionCoefficient *gscale_coeff_ = nullptr;
+  GridFunctionCoefficient *visc_coeff_ = nullptr;
+  PowerCoefficient *visc_inv_coeff_ = nullptr;
+  ProductCoefficient *reh1_coeff_  = nullptr;
+  ProductCoefficient *reh2_coeff_  = nullptr;
+  ProductCoefficient *Reh_coeff_  = nullptr;
+  TransformedCoefficient *csupg_coeff_ = nullptr;
+  ProductCoefficient *uw1_coeff_  = nullptr;
+  ProductCoefficient *uw2_coeff_ = nullptr;
+  ProductCoefficient *upwind_coeff_  = nullptr;
+  TransformedMatrixVectorCoefficient *swdiff_coeff_  = nullptr;
+  ScalarMatrixProductCoefficient *supg_coeff_ = nullptr;
 
   // operators and solvers
   ParBilinearForm *At_form_ = nullptr;
@@ -359,7 +378,8 @@ class ReactingFlow : public ThermoChemModelBase {
   std::vector<std::string> vizSpecNames_;
 
  public:
-  ReactingFlow(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &timeCoeff, TPS::Tps *tps);
+  ReactingFlow(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &timeCoeff, 
+               ParGridFunction *gridScale, TPS::Tps *tps);
   virtual ~ReactingFlow();
 
   // Functions overriden from base class

--- a/src/reactingFlow.hpp
+++ b/src/reactingFlow.hpp
@@ -158,7 +158,7 @@ class ReactingFlow : public ThermoChemModelBase {
   bool sw_stab_;
   
   // clip qt for diagnosis
-  bool clip_qt_;
+  // bool clip_qt_;
 
   // FEM related fields and objects
 
@@ -213,13 +213,13 @@ class ReactingFlow : public ThermoChemModelBase {
   ParGridFunction jh_gf_;
 
   // viz for qt rhs
-  ParGridFunction rhsqt_bd_;
-  ParGridFunction rhsqt_fo_;
-  ParGridFunction rhsqt_jh_;
-  ParGridFunction rhsqt_hf_;
-  ParGridFunction rhsqt_sd_;
-  ParGridFunction rhsqt_total_;
-  ParGridFunction Xqt_gf_;
+  // ParGridFunction rhsqt_bd_;
+  // ParGridFunction rhsqt_fo_;
+  // ParGridFunction rhsqt_jh_;
+  // ParGridFunction rhsqt_hf_;
+  // ParGridFunction rhsqt_sd_;
+  // ParGridFunction rhsqt_total_;
+  // ParGridFunction Xqt_gf_;
 
   // ParGridFunction *buffer_tInlet_ = nullptr;
   GridFunctionCoefficient *temperature_bc_field_ = nullptr;

--- a/src/reactingFlow.hpp
+++ b/src/reactingFlow.hpp
@@ -157,9 +157,6 @@ class ReactingFlow : public ThermoChemModelBase {
   // streamwise-stabilization
   bool sw_stab_;
 
-  // clip qt for diagnosis
-  // bool clip_qt_;
-
   // FEM related fields and objects
 
   // Scalar \f$H^1\f$ finite element collection.
@@ -211,15 +208,6 @@ class ReactingFlow : public ThermoChemModelBase {
   // Interface with EM
   ParGridFunction sigma_gf_;
   ParGridFunction jh_gf_;
-
-  // viz for qt rhs
-  // ParGridFunction rhsqt_bd_;
-  // ParGridFunction rhsqt_fo_;
-  // ParGridFunction rhsqt_jh_;
-  // ParGridFunction rhsqt_hf_;
-  // ParGridFunction rhsqt_sd_;
-  // ParGridFunction rhsqt_total_;
-  // ParGridFunction Xqt_gf_;
 
   // ParGridFunction *buffer_tInlet_ = nullptr;
   GridFunctionCoefficient *temperature_bc_field_ = nullptr;

--- a/src/split_flow_base.cpp
+++ b/src/split_flow_base.cpp
@@ -37,7 +37,7 @@
 using namespace mfem;
 
 ZeroFlow::ZeroFlow(mfem::ParMesh *pmesh, int vorder, TPS::Tps *tps)
-    : pmesh_(pmesh), vorder_(vorder), tpsP_(tps), dim_(pmesh->Dimension()) {
+    : pmesh_(pmesh), vorder_(vorder), dim_(pmesh->Dimension()), tpsP_(tps) {
   // nonzero flow option
   tpsP_->getInput("loMach/zeroflow/nonzero-flow", nonzero_flow_, false);
 }

--- a/src/split_flow_base.cpp
+++ b/src/split_flow_base.cpp
@@ -37,7 +37,7 @@
 using namespace mfem;
 
 ZeroFlow::ZeroFlow(mfem::ParMesh *pmesh, int vorder, TPS::Tps *tps)
-    : pmesh_(pmesh), vorder_(vorder), dim_(pmesh->Dimension()), tpsP_(tps) {
+    : pmesh_(pmesh), vorder_(vorder), tpsP_(tps), dim_(pmesh->Dimension()) {
   // nonzero flow option
   tpsP_->getInput("loMach/zeroflow/nonzero-flow", nonzero_flow_, false);
 }

--- a/src/split_flow_base.cpp
+++ b/src/split_flow_base.cpp
@@ -31,16 +31,15 @@
 // -----------------------------------------------------------------------------------el-
 
 #include "split_flow_base.hpp"
+
 #include "tps.hpp"
 
 using namespace mfem;
 
-ZeroFlow::ZeroFlow(mfem::ParMesh *pmesh, int vorder, TPS::Tps *tps) 
+ZeroFlow::ZeroFlow(mfem::ParMesh *pmesh, int vorder, TPS::Tps *tps)
     : pmesh_(pmesh), vorder_(vorder), dim_(pmesh->Dimension()), tpsP_(tps) {
-
   // nonzero flow option
   tpsP_->getInput("loMach/zeroflow/nonzero-flow", nonzero_flow_, false);
-
 }
 
 ZeroFlow::~ZeroFlow() {

--- a/src/split_flow_base.cpp
+++ b/src/split_flow_base.cpp
@@ -31,13 +31,21 @@
 // -----------------------------------------------------------------------------------el-
 
 #include "split_flow_base.hpp"
+#include "tps.hpp"
 
 using namespace mfem;
 
-ZeroFlow::ZeroFlow(mfem::ParMesh *pmesh, int vorder) : pmesh_(pmesh), vorder_(vorder), dim_(pmesh->Dimension()) {}
+ZeroFlow::ZeroFlow(mfem::ParMesh *pmesh, int vorder, TPS::Tps *tps) 
+    : pmesh_(pmesh), vorder_(vorder), dim_(pmesh->Dimension()), tpsP_(tps) {
+
+  // nonzero flow option
+  tpsP_->getInput("loMach/zero-flow/nonzero-flow", nonzero_flow_, false);
+
+}
 
 ZeroFlow::~ZeroFlow() {
   delete velocity_;
+  delete zero_;
   delete fes_;
   delete fec_;
 }
@@ -46,13 +54,25 @@ void ZeroFlow::initializeSelf() {
   fec_ = new H1_FECollection(vorder_, dim_);
   fes_ = new ParFiniteElementSpace(pmesh_, fec_, dim_);
   velocity_ = new ParGridFunction(fes_);
+  zero_ = new ParGridFunction(fes_);
   *velocity_ = 0.0;
+  *zero_ = 0.0;
+
+  // set background velocity if nonzero
+  if (nonzero_flow_) {
+    Vector zero(dim_);
+    Vector velocity_value(dim_);
+    zero = 0.0;
+    tpsP_->getVec("loMach/zero-flow/nonzero-vel", velocity_value, dim_, zero);
+    VectorConstantCoefficient ub_coeff(velocity_value);
+    velocity_->ProjectCoefficient(ub_coeff);
+  }
 
   toThermoChem_interface_.velocity = velocity_;
   toThermoChem_interface_.swirl_supported = false;
 
-  // no need to create additional zero vectors
-  toTurbModel_interface_.gradU = velocity_;
-  toTurbModel_interface_.gradV = velocity_;
-  toTurbModel_interface_.gradW = velocity_;
+  // need to create additional zero vectors, in case of nonzero vel
+  toTurbModel_interface_.gradU = zero_;
+  toTurbModel_interface_.gradV = zero_;
+  toTurbModel_interface_.gradW = zero_;
 }

--- a/src/split_flow_base.cpp
+++ b/src/split_flow_base.cpp
@@ -39,7 +39,7 @@ ZeroFlow::ZeroFlow(mfem::ParMesh *pmesh, int vorder, TPS::Tps *tps)
     : pmesh_(pmesh), vorder_(vorder), dim_(pmesh->Dimension()), tpsP_(tps) {
 
   // nonzero flow option
-  tpsP_->getInput("loMach/zero-flow/nonzero-flow", nonzero_flow_, false);
+  tpsP_->getInput("loMach/zeroflow/nonzero-flow", nonzero_flow_, false);
 
 }
 
@@ -57,13 +57,12 @@ void ZeroFlow::initializeSelf() {
   zero_ = new ParGridFunction(fes_);
   *velocity_ = 0.0;
   *zero_ = 0.0;
-
   // set background velocity if nonzero
   if (nonzero_flow_) {
     Vector zero(dim_);
     Vector velocity_value(dim_);
     zero = 0.0;
-    tpsP_->getVec("loMach/zero-flow/nonzero-vel", velocity_value, dim_, zero);
+    tpsP_->getVec("loMach/zeroflow/nonzero-vel", velocity_value, dim_, zero);
     VectorConstantCoefficient ub_coeff(velocity_value);
     velocity_->ProjectCoefficient(ub_coeff);
   }

--- a/src/split_flow_base.hpp
+++ b/src/split_flow_base.hpp
@@ -35,6 +35,11 @@
  * @brief Contains base class and simplest possible variant of flow model
  */
 
+// forward-declaration for Tps support class (tps.hpp)
+namespace TPS {
+class Tps;
+}
+
 #include "tps_mfem_wrap.hpp"
 
 class IODataOrganizer;
@@ -143,6 +148,13 @@ class FlowBase {
 
 class ZeroFlow final : public FlowBase {
  protected:
+
+  // Options-related structures
+  TPS::Tps *tpsP_ = nullptr;
+
+  // Options
+  bool nonzero_flow_ = false;
+
   mfem::ParMesh *pmesh_;
   const int vorder_;
   const int dim_;
@@ -150,10 +162,11 @@ class ZeroFlow final : public FlowBase {
   mfem::FiniteElementCollection *fec_ = nullptr;
   mfem::ParFiniteElementSpace *fes_ = nullptr;
   mfem::ParGridFunction *velocity_ = nullptr;
+  mfem::ParGridFunction *zero_ = nullptr;
 
  public:
   /// Constructor
-  ZeroFlow(mfem::ParMesh *pmesh, int vorder);
+  ZeroFlow(mfem::ParMesh *pmesh, int vorder, TPS::Tps *tps = nullptr);
 
   /// Destructor
   ~ZeroFlow() final;

--- a/src/split_flow_base.hpp
+++ b/src/split_flow_base.hpp
@@ -148,7 +148,6 @@ class FlowBase {
 
 class ZeroFlow final : public FlowBase {
  protected:
-
   // Options-related structures
   TPS::Tps *tpsP_ = nullptr;
 

--- a/src/split_flow_base.hpp
+++ b/src/split_flow_base.hpp
@@ -148,15 +148,15 @@ class FlowBase {
 
 class ZeroFlow final : public FlowBase {
  protected:
-  // Options-related structures
-  TPS::Tps *tpsP_ = nullptr;
-
   // Options
   bool nonzero_flow_;
 
   mfem::ParMesh *pmesh_;
   const int vorder_;
   const int dim_;
+
+  // Options-related structures
+  TPS::Tps *tpsP_ = nullptr;
 
   mfem::FiniteElementCollection *fec_ = nullptr;
   mfem::ParFiniteElementSpace *fes_ = nullptr;

--- a/src/split_flow_base.hpp
+++ b/src/split_flow_base.hpp
@@ -153,7 +153,7 @@ class ZeroFlow final : public FlowBase {
   TPS::Tps *tpsP_ = nullptr;
 
   // Options
-  bool nonzero_flow_ = false;
+  bool nonzero_flow_;
 
   mfem::ParMesh *pmesh_;
   const int vorder_;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1427,7 +1427,7 @@ void GradientVectorGridFunctionCoefficient::Eval(DenseMatrix &G, ElementTransfor
 
 
 VectorMagnitudeCoefficient::VectorMagnitudeCoefficient(VectorCoefficient &A)
-   : a(&A), va(A.GetVDim()) { }
+   : a(&A), va(A.GetVDim()) {}
 
 void VectorMagnitudeCoefficient::SetTime(double t)
 {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1156,9 +1156,7 @@ void streamwiseTensor(const Vector &vel, DenseMatrix &swMgbl) {
 }
 
 double csupgFactor(double Reh) {
-  // return  0.5 * (tanh(re_factor * Re - re_offset) + 1.0);
-  // printf("%f\n", Reh);
-  // printf("%f\n", 0.5 * (tanh(Reh) + 1.0));
+  // TODO(trevilo): This implementation has lost the re_factor and re_offset options.  Bring them back.
   return 0.5 * (tanh(Reh) + 1.0);
 }
 
@@ -1346,12 +1344,7 @@ void VectorMagnitudeCoefficient::SetTime(double t) {
 
 double VectorMagnitudeCoefficient::Eval(ElementTransformation &T, const IntegrationPoint &ip) {
   a->Eval(va, T, ip);
-  // double res = 0;
-  // for (int i = 0; i < va.size(); i++) { res += va[i] * va[i]}
-  // res = std::sqrt(res)
-  // return res;
-  double mod = std::max(std::sqrt(va * va), 1.0e-18);
-  return mod;
+  return std::max(std::sqrt(va * va), 1.0e-18);
 }
 
 void TransformedMatrixVectorCoefficient::SetTime(double t) {
@@ -1364,15 +1357,6 @@ void TransformedMatrixVectorCoefficient::Eval(DenseMatrix &G, ElementTransformat
   buf.SetSize(Q1->GetVDim());
   Q1->Eval(buf, T, ip);
   Function(buf, G);
-
-  // int dim = Q1->GetVDim();
-  // std::cout << " " << endl;
-  // for (int i = 0; i < dim; i++) {
-  //   for (int j = 0; j < dim; j++) {
-  //     std::cout << G(i,j) << " " ;
-  //   }
-  //   std::cout << endl;
-  // }
 }
 
 }  // namespace mfem

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1133,10 +1133,7 @@ void scalarGrad3DV(FiniteElementSpace *fes, FiniteElementSpace *vfes, Vector u, 
   R1_gf.GetTrueDofs(*gu);
 }
 
-
-
 void streamwiseTensor(const Vector &vel, DenseMatrix &swMgbl) {
-
   int dim = vel.Size();
 
   // streamwise coordinate system
@@ -1154,7 +1151,7 @@ void streamwiseTensor(const Vector &vel, DenseMatrix &swMgbl) {
   mod = std::max(mod, 1.0e-18);
   double Umag = std::sqrt(mod);
   unitNorm /= Umag;
- 
+
   // std::cout << Umag << " " << endl ;
 
   // for zero-flow
@@ -1183,7 +1180,7 @@ void streamwiseTensor(const Vector &vel, DenseMatrix &swMgbl) {
 
   unitT1[minusInd] = -unitNorm[maxInd];
   unitT1[maxInd] = unitNorm[minusInd];
-  if (dim == 3) { // DOUBLE CHECK THIS WHEN TESTING 3D
+  if (dim == 3) {  // DOUBLE CHECK THIS WHEN TESTING 3D
     unitT1[plusInd] = 0.0;
   }
   mod = 0.0;
@@ -1211,7 +1208,6 @@ void streamwiseTensor(const Vector &vel, DenseMatrix &swMgbl) {
   swM = 0.0;
   swM(0, 0) = 1.0;
 
-  
   // std::cout << " " << endl;
   // for (int i = 0; i < dim; i++) {
   //   for (int j = 0; j < dim; j++) {
@@ -1219,7 +1215,6 @@ void streamwiseTensor(const Vector &vel, DenseMatrix &swMgbl) {
   //   }
   //   std::cout << endl;
   // }
-  
 
   // M_{im} swM_{mn} M_{jn} or M*"mu"*M^T (with n,t1,t2 in columns of M)
   // DenseMatrix swMgbl(dim, dim);
@@ -1241,7 +1236,6 @@ void streamwiseTensor(const Vector &vel, DenseMatrix &swMgbl) {
   //   }
   //   std::cout << endl;
   // }
-  
 }
 
 double csupgFactor(double Reh) {
@@ -1250,7 +1244,6 @@ double csupgFactor(double Reh) {
   // printf("%f\n", 0.5 * (tanh(Reh) + 1.0));
   return 0.5 * (tanh(Reh) + 1.0);
 }
-
 
 void EliminateRHS(Operator &A, ConstrainedOperator &constrainedA, const Array<int> &ess_tdof_list, Vector &x, Vector &b,
                   Vector &X, Vector &B, int copy_interior) {
@@ -1425,19 +1418,16 @@ void GradientVectorGridFunctionCoefficient::Eval(DenseMatrix &G, ElementTransfor
   }
 }
 
+VectorMagnitudeCoefficient::VectorMagnitudeCoefficient(VectorCoefficient &A) : a(&A), va(A.GetVDim()) {}
 
-VectorMagnitudeCoefficient::VectorMagnitudeCoefficient(VectorCoefficient &A)
-   : a(&A), va(A.GetVDim()) {}
-
-void VectorMagnitudeCoefficient::SetTime(double t)
-{
-  if (a) { a->SetTime(t); }
+void VectorMagnitudeCoefficient::SetTime(double t) {
+  if (a) {
+    a->SetTime(t);
+  }
   this->Coefficient::SetTime(t);
 }
 
-double VectorMagnitudeCoefficient::Eval(ElementTransformation &T,
-                                     const IntegrationPoint &ip)
-{
+double VectorMagnitudeCoefficient::Eval(ElementTransformation &T, const IntegrationPoint &ip) {
   a->Eval(va, T, ip);
   // double res = 0;
   // for (int i = 0; i < va.size(); i++) { res += va[i] * va[i]}
@@ -1447,14 +1437,12 @@ double VectorMagnitudeCoefficient::Eval(ElementTransformation &T,
   return mod;
 }
 
-void TransformedMatrixVectorCoefficient::SetTime(double t)
-{
+void TransformedMatrixVectorCoefficient::SetTime(double t) {
   Q1->SetTime(t);
   this->MatrixCoefficient::SetTime(t);
 }
 
 void TransformedMatrixVectorCoefficient::Eval(DenseMatrix &G, ElementTransformation &T, const IntegrationPoint &ip) {
-  
   Vector buf;
   buf.SetSize(Q1->GetVDim());
   Q1->Eval(buf, T, ip);

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -188,9 +188,10 @@ void makeContinuous(ParGridFunction &u);
 
 bool copyFile(const char *SRC, const char *DEST);
 
-/// upwind diffusion
-// double upwindDiffMag(Vector *state, double gridspace);
+/// upwind diffusion support: evaluate u * u^T / ||u||^2
 void streamwiseTensor(const Vector &vel, DenseMatrix &swMgbl);
+
+/// upwind diffusion support: evaluate supg constant
 double csupgFactor(double Reh);
 
 /// Eliminate essential BCs in an Operator and apply to RHS.

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -231,40 +231,37 @@ class GradientVectorGridFunctionCoefficient : public MatrixCoefficient {
 };
 
 /// Scalar coefficient defined as the magnitude of a vector coefficient
-class VectorMagnitudeCoefficient : public Coefficient
-{
-private:
-   VectorCoefficient * a;
+class VectorMagnitudeCoefficient : public Coefficient {
+ private:
+  VectorCoefficient *a;
 
-   mutable Vector va;
-public:
-   /// Construct with the vector coefficient.  Result is \sqrt{(\f$ A \cdot a \f$}.
-   VectorMagnitudeCoefficient(VectorCoefficient &A);
+  mutable Vector va;
 
-   /// Set the time for internally stored coefficients
-   void SetTime(double t);
+ public:
+  /// Construct with the vector coefficient.  Result is \sqrt{(\f$ A \cdot a \f$}.
+  VectorMagnitudeCoefficient(VectorCoefficient &A);
 
-   /// Reset the vector
-   void SetACoef(VectorCoefficient &A) { a = &A; }
-   /// Return the vector coefficient
-   VectorCoefficient * GetACoef() const { return a; }
+  /// Set the time for internally stored coefficients
+  void SetTime(double t);
 
-   /// Evaluate the coefficient at @a ip.
-   virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+  /// Reset the vector
+  void SetACoef(VectorCoefficient &A) { a = &A; }
+  /// Return the vector coefficient
+  VectorCoefficient *GetACoef() const { return a; }
+
+  /// Evaluate the coefficient at @a ip.
+  virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
 };
 
-/// Matrix coefficient computed from a function F(v(x)) of a dim-sized vector coefficient, v(x) 
+/// Matrix coefficient computed from a function F(v(x)) of a dim-sized vector coefficient, v(x)
 class TransformedMatrixVectorCoefficient : public MatrixCoefficient {
  protected:
   VectorCoefficient *Q1;
   std::function<void(const Vector &, DenseMatrix &)> Function;
 
  public:
-  TransformedMatrixVectorCoefficient(VectorCoefficient *vc, 
-    std::function<void(const Vector &, DenseMatrix &)> F) : 
-    MatrixCoefficient(vc->GetVDim() ),
-    Q1(vc), Function(std::move(F)) { }
+  TransformedMatrixVectorCoefficient(VectorCoefficient *vc, std::function<void(const Vector &, DenseMatrix &)> F)
+      : MatrixCoefficient(vc->GetVDim()), Q1(vc), Function(std::move(F)) {}
 
   /// Set the time for internally stored coefficients
   void SetTime(double t);

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -188,6 +188,11 @@ void makeContinuous(ParGridFunction &u);
 
 bool copyFile(const char *SRC, const char *DEST);
 
+/// upwind diffusion
+// double upwindDiffMag(Vector *state, double gridspace);
+void streamwiseTensor(DenseMatrix swMgbl, Vector vel);
+double csupgFactor(double Reh);
+
 /// Eliminate essential BCs in an Operator and apply to RHS.
 /// rename this to something sensible "ApplyEssentialBC" or something
 void EliminateRHS(Operator &A, ConstrainedOperator &constrainedA, const Array<int> &ess_tdof_list, Vector &x, Vector &b,
@@ -223,6 +228,53 @@ class GradientVectorGridFunctionCoefficient : public MatrixCoefficient {
   virtual void Eval(DenseMatrix &G, ElementTransformation &T, const IntegrationPoint &ip);
 
   virtual ~GradientVectorGridFunctionCoefficient() {}
+};
+
+/// Scalar coefficient defined as the magnitude of a vector coefficient
+class VectorMagnitudeCoefficient : public Coefficient
+{
+private:
+   VectorCoefficient * a;
+
+   mutable Vector va;
+public:
+   /// Construct with the vector coefficient.  Result is \sqrt{(\f$ A \cdot a \f$}.
+   VectorMagnitudeCoefficient(VectorCoefficient &A);
+
+   /// Set the time for internally stored coefficients
+   void SetTime(double t);
+
+   /// Reset the vector
+   void SetACoef(VectorCoefficient &A) { a = &A; }
+   /// Return the vector coefficient
+   VectorCoefficient * GetACoef() const { return a; }
+
+   /// Evaluate the coefficient at @a ip.
+   virtual double Eval(ElementTransformation &T,
+                       const IntegrationPoint &ip);
+};
+
+/// Matrix coefficient computed from a function F(v(x)) of a dim-sized vector coefficient, v(x) 
+class TransformedMatrixVectorCoefficient : public MatrixCoefficient {
+ private:
+  Coefficient * Q1;
+  std::function<void(const Vector &, DenseMatrix &)> Function;
+
+ public:
+  /** @brief Construct the coefficient with a scalar grid function @a gf. The
+      grid function is not owned by the coefficient. */
+  TransformedMatrixVectorCoefficient(const VectorCoefficient *vc, 
+    std::function<void(const Vector &, DenseMatrix &)> F)
+    : Q1(vc), Function(std::move(F)) { }
+
+  /// Set the time for internally stored coefficients
+  void SetTime(double t);
+
+  /// Evaluate the gradient vector coefficient at @a ip.
+  using MatrixCoefficient::Eval;
+  virtual void Eval(DenseMatrix &G, ElementTransformation &T, const IntegrationPoint &ip);
+
+  virtual ~TransformedMatrixVectorCoefficient() {}
 };
 }  // namespace mfem
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -190,7 +190,7 @@ bool copyFile(const char *SRC, const char *DEST);
 
 /// upwind diffusion
 // double upwindDiffMag(Vector *state, double gridspace);
-void streamwiseTensor(DenseMatrix swMgbl, Vector vel);
+void streamwiseTensor(const Vector &vel, DenseMatrix &swMgbl);
 double csupgFactor(double Reh);
 
 /// Eliminate essential BCs in an Operator and apply to RHS.
@@ -256,22 +256,20 @@ public:
 
 /// Matrix coefficient computed from a function F(v(x)) of a dim-sized vector coefficient, v(x) 
 class TransformedMatrixVectorCoefficient : public MatrixCoefficient {
- private:
-  Coefficient * Q1;
+ protected:
+  VectorCoefficient *Q1;
   std::function<void(const Vector &, DenseMatrix &)> Function;
 
  public:
-  /** @brief Construct the coefficient with a scalar grid function @a gf. The
-      grid function is not owned by the coefficient. */
-  TransformedMatrixVectorCoefficient(const VectorCoefficient *vc, 
-    std::function<void(const Vector &, DenseMatrix &)> F)
-    : Q1(vc), Function(std::move(F)) { }
+  TransformedMatrixVectorCoefficient(VectorCoefficient *vc, 
+    std::function<void(const Vector &, DenseMatrix &)> F) : 
+    MatrixCoefficient(vc->GetVDim() ),
+    Q1(vc), Function(std::move(F)) { }
 
   /// Set the time for internally stored coefficients
   void SetTime(double t);
 
-  /// Evaluate the gradient vector coefficient at @a ip.
-  using MatrixCoefficient::Eval;
+  // using MatrixCoefficient::Eval;
   virtual void Eval(DenseMatrix &G, ElementTransformation &T, const IntegrationPoint &ip);
 
   virtual ~TransformedMatrixVectorCoefficient() {}

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -38,6 +38,7 @@ EXTRA_DIST  = tap-driver.sh test_tps_splitcomm.py soln_differ inputs meshes lte-
               ref_solns/reactTable/*.h5 \
               ref_solns/radDecay/*.h5 \
               ref_solns/reactNitrogen/*.h5 \
+              ref_solns/supg/*.h5 \
 		      vpath.sh die.sh count_gpus.sh sniff_mpirun.sh \
 		      cyl3d.gpu.test cyl3d.mflow.gpu.test wedge.gpu.test \
 	          averaging.gpu.test cyl3d.test cyl3d.gpu.python.test cyl3d.mflow.test cyl3d.dtconst.test \
@@ -54,7 +55,7 @@ EXTRA_DIST  = tap-driver.sh test_tps_splitcomm.py soln_differ inputs meshes lte-
               coupled-3d.interface.test plasma.axisym.test plasma.axisym.lte1d.test \
 	      lomach-flow.test lomach-lequere.test interpInlet.test sgsLoMach.test autoPeriodic.test aveLoMach.test \
               reactFlow-binDiff.test reactFlow-singleRx.test reactFlow-table.test radiativeDecay.test \
-              reactFlow-nitrogen.test argon_minimal.test argon_minimal.binary.test
+              reactFlow-nitrogen.test argon_minimal.test argon_minimal.binary.test supg-scalars.test
 
 TESTS = vpath.sh
 XFAIL_TESTS =
@@ -128,7 +129,8 @@ TESTS += cyl3d.test \
          reactFlow-singleRx.test \
          reactFlow-table.test \
          radiativeDecay.test \
-         reactFlow-nitrogen.test
+         reactFlow-nitrogen.test \
+	 supg-scalars.test
 
 if PYTHON_ENABLED
 TESTS += cyl3d.python.test \

--- a/test/inputs/input.supgBox.ini
+++ b/test/inputs/input.supgBox.ini
@@ -6,8 +6,8 @@ mesh = meshes/boxStab.msh
 order = 1
 nFilter = 0
 filterWeight = 1.0
-maxIters = 1000
-outputFreq = 1000
+maxIters = 10000
+outputFreq = 500
 fluid = dry_air
 refLength = 1.0
 equation_system = navier-stokes
@@ -35,7 +35,7 @@ Prandtl = 0.72
 #msolve-rtol = 1.0e-10
 #hsolve-maxIters = 2000
 #msolve-maxIters = 2000
-streamwise-stabilization = false
+streamwise-stabilization = true
 #Reh_offset = 1.0
 #Reh_factor = 0.01
 
@@ -44,7 +44,7 @@ nonzero-flow = true
 nonzero-vel = '1.0 0.0 0.0'
 
 [io]
-outdirBase = output_nostab1L
+outdirBase = output_wstab1T
 #enableRestart = True
 #restartMode = variableP
 

--- a/test/inputs/input.supgBox.ini
+++ b/test/inputs/input.supgBox.ini
@@ -1,0 +1,109 @@
+[solver]
+type = loMach
+
+[loMach]
+mesh = meshes/boxStab.msh
+order = 1
+nFilter = 0
+filterWeight = 1.0
+maxIters = 100
+outputFreq = 100
+fluid = dry_air
+refLength = 1.0
+equation_system = navier-stokes
+enablePressureForcing = True
+# pressureGrad = '0.00005372 0.0 0.0'
+enableGravity = False
+gravity = '0.0 0.0 0.0'
+openSystem = False
+sgsModel = none
+# flow-solver = tomboulides
+flow-solver = zero-flow
+thermo-solver = calorically-perfect
+
+[loMach/calperfect]
+viscosity-model = sutherland
+sutherland/mu0 = 1.68e-5
+sutherland/T0 = 273.0
+sutherland/S0 = 110.4
+numerical-integ = false
+Prandtl = 0.72
+#ic = channel
+#hsolve-atol = 1.0e-12
+#msolve-atol = 1.0e-12
+#hsolve-rtol = 1.0e-10
+#msolve-rtol = 1.0e-10
+#hsolve-maxIters = 2000
+#msolve-maxIters = 2000
+#streamwise-stabilization = true
+#Reh_offset = 1.0
+#Reh_factor = 0.01
+
+[loMach/zeroflow]
+nonzero-flow = True
+nonzero-vel = '1.0 0.0 0.0'
+
+[io]
+outdirBase = output
+#enableRestart = True
+#restartMode = variableP
+
+[time]
+enableConstantTimestep = True
+integrator = curlcurl
+#cfl = 0.4
+dt_initial = 1.0e-4
+#dtFactor = 0.01
+dt_fixed = 1.0e-4
+bdfOrder = 1
+
+[spongeMultiplier]
+uniform = true
+uniformMult = 1.0
+
+[initialConditions]
+rho = 1.0
+rhoU = 1.0
+rhoV = 0.0
+rhoW = 0.0
+temperature = 300.0
+pressure = 101325.0
+
+[boundaryConditions]
+numWalls = 0
+numInlets = 2
+numOutlets = 0
+
+#[boundaryConditions/wall1]
+#patch = 1
+#type = viscous_isothermal
+#temperature = 300
+#velocity = '0.0 0.0 0.0'
+#
+#[boundaryConditions/wall2]
+#patch = 3
+#type = viscous_isothermal
+#temperature = 300
+#velocity = '0.0 0.0 0.0'
+
+[boundaryConditions/inlet1]
+patch = 4
+type = uniform
+#swirl = 40.0
+#velocity = '1.0 0.0 0.0'
+temperature = 300.0
+
+[boundaryConditions/inlet2]
+patch = 2
+type = uniform
+temperature = 270
+
+[periodicity]
+enablePeriodic = True
+#periodicX = True
+periodicY = True
+
+# background velocity set by new ZeroFlow option
+
+# how to set up the specific BCs in config? inlets walls and outlets are hard coded
+# mainly need neumann walls, or is that periodicity?

--- a/test/inputs/input.supgBox.ini
+++ b/test/inputs/input.supgBox.ini
@@ -35,7 +35,7 @@ Prandtl = 0.72
 #msolve-rtol = 1.0e-10
 #hsolve-maxIters = 2000
 #msolve-maxIters = 2000
-#streamwise-stabilization = true
+streamwise-stabilization = true
 #Reh_offset = 1.0
 #Reh_factor = 0.01
 

--- a/test/inputs/input.supgBox.ini
+++ b/test/inputs/input.supgBox.ini
@@ -6,8 +6,8 @@ mesh = meshes/boxStab.msh
 order = 1
 nFilter = 0
 filterWeight = 1.0
-maxIters = 100
-outputFreq = 100
+maxIters = 1000
+outputFreq = 1000
 fluid = dry_air
 refLength = 1.0
 equation_system = navier-stokes
@@ -35,16 +35,16 @@ Prandtl = 0.72
 #msolve-rtol = 1.0e-10
 #hsolve-maxIters = 2000
 #msolve-maxIters = 2000
-streamwise-stabilization = true
+streamwise-stabilization = false
 #Reh_offset = 1.0
 #Reh_factor = 0.01
 
 [loMach/zeroflow]
-nonzero-flow = True
+nonzero-flow = true
 nonzero-vel = '1.0 0.0 0.0'
 
 [io]
-outdirBase = output
+outdirBase = output_nostab1L
 #enableRestart = True
 #restartMode = variableP
 

--- a/test/inputs/input.supgLte.ini
+++ b/test/inputs/input.supgLte.ini
@@ -1,0 +1,53 @@
+[solver]
+type = loMach
+
+[loMach]
+mesh = meshes/boxStab.msh
+order = 3
+maxIters = 1000
+outputFreq = 50
+timingFreq = 50
+enableGravity = False
+openSystem = False
+sgsModel = none
+flow-solver = zero-flow
+thermo-solver = lte-thermo-chem
+
+[loMach/ltethermo]
+table-file = lte-data/air_sutherland_lomach.h5
+streamwise-stabilization = true
+
+[loMach/zeroflow]
+nonzero-flow = true
+nonzero-vel = '1.0 0.0 0.0'
+
+[initialConditions]
+temperature = 300.0
+
+[io]
+outdirBase = output_lte_supg
+
+[time]
+enableConstantTimestep = True
+integrator = curlcurl
+dt_fixed = 1.0e-3
+bdfOrder = 1
+
+[boundaryConditions]
+numWalls = 0
+numInlets = 2
+numOutlets = 0
+
+[boundaryConditions/inlet1]
+patch = 4
+type = uniform
+temperature = 300.0
+
+[boundaryConditions/inlet2]
+patch = 2
+type = uniform
+temperature = 270
+
+[periodicity]
+enablePeriodic = True
+periodicY = True

--- a/test/meshes/boxStab.msh
+++ b/test/meshes/boxStab.msh
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf889720de9350d00f33208efc95855b676a2a69d82ed0be121ee69454d53a26
+size 5004

--- a/test/ref_solns/supg/restart_output_lte_supg.sol.h5
+++ b/test/ref_solns/supg/restart_output_lte_supg.sol.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:089e64d85dafb6b8bd90ad65c2aec0403d7ef734fbf0583289f742cbbb400c57
+size 7768

--- a/test/ref_solns/supg/restart_output_wstab1T.sol.h5
+++ b/test/ref_solns/supg/restart_output_wstab1T.sol.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1e1ab788060fbcd86fe6d74fb3c8abde9ddde0323bb84a505a1d27efa13b6f5
+size 3544

--- a/test/standalone_chemistry.cpp
+++ b/test/standalone_chemistry.cpp
@@ -32,7 +32,7 @@ int main(int argc, char *argv[]) {
   temporalSchemeCoefficients temporal_coeff;
   temporal_coeff.order = 1;
 
-  ReactingFlow *thermo = new ReactingFlow(pmesh, &loMach_opts, temporal_coeff, &tps);
+  ReactingFlow *thermo = new ReactingFlow(pmesh, &loMach_opts, temporal_coeff, nullptr, &tps);
   thermo->initializeSelf();
 
   int nSpecies;

--- a/test/supg-scalars.test
+++ b/test/supg-scalars.test
@@ -1,0 +1,47 @@
+#!./bats
+# -*- mode: sh -*-
+
+TEST="supg-scalars"
+
+EXE="../src/tps"
+
+@test "[$TEST] Regression test for SUPG implementation in CaloricallyPerfectThermoChem" {
+    # Solution to be generated
+    SOLN_FILE=restart_output_wstab1T.sol.h5
+    rm -f $SOLN_FILE
+
+    # Case to run
+    RUNFILE=inputs/input.supgBox.ini
+    test -s $RUNFILE
+
+    # run
+    $EXE --runFile $RUNFILE
+    test -s $SOLN_FILE
+
+    # check
+    REF_SOLN=ref_solns/supg/restart_output_wstab1T.sol.h5
+    test -s $REF_FILE
+
+    h5diff -r --relative=1e-10 $SOLN_FILE $REF_SOLN /temperature/temperature
+}
+
+@test "[$TEST] Regression test for SUPG implementation in LteThermoChem" {
+    # Solution to be generated
+    SOLN_FILE=restart_output_lte_supg.sol.h5
+    rm -f $SOLN_FILE
+
+    # Case to run
+    RUNFILE=inputs/input.supgLte.ini
+    test -s $RUNFILE
+
+    # run
+    $EXE --runFile $RUNFILE
+    test -s $SOLN_FILE
+
+    # check
+    REF_SOLN=ref_solns/supg/restart_output_lte_supg.sol.h5
+    test -s $REF_FILE
+
+    h5diff -r --relative=1e-10 $SOLN_FILE $REF_SOLN /temperature/temperature
+}
+


### PR DESCRIPTION
This PR adds support for streamline-upwind Petrov-Galerkin (SUPG) stabilization for scalar transport equations implemented in classes derived from `ThermoChemModelBase`, including `CaloricallyPerfectThermoChem`, `ReactingFlow` and `LteThermoChem`.

The new capabilities are exercised in a small regression test.  See `test/supg-scalars.test`.

To support these tests, the `ZeroFlow` class has been extended to provide a user-specified uniform velocity.  For example, to set the velocity field to (1,0,0), use the following options in the tps input file:
```
[loMach]
flow-solver = zero-flow

[loMach/zeroflow]
nonzero-flow = true
nonzero-vel = '1.0 0.0 0.0'
```