### PR TITLE
Minor style fixes

### DIFF
--- a/src/M2ulPhyS.cpp
+++ b/src/M2ulPhyS.cpp
@@ -237,7 +237,7 @@ void M2ulPhyS::initMixtureAndTransportModels() {
                                               TPSCommWorld, trans_data, trans_tables);
         if (!success) exit(ERROR);
 
-        // Instantiate LteTransport class
+          // Instantiate LteTransport class
 #if defined(_CUDA_) || defined(_HIP_)
         // Tables from above have host pointers.  Must get device
         // pointers here before instantiating device class
@@ -2465,9 +2465,7 @@ void M2ulPhyS::Check_NAN() {
   int dof = vfes->GetNDofs();
 
 #ifdef _GPU_
-  {
-    local_print = M2ulPhyS::Check_NaN_GPU(U, dof * num_equation, loc_print);
-  }
+  { local_print = M2ulPhyS::Check_NaN_GPU(U, dof * num_equation, loc_print); }
   if (local_print > 0) {
     cout << "Found a NaN!" << endl;
   }

--- a/src/em_options.hpp
+++ b/src/em_options.hpp
@@ -52,8 +52,8 @@ class ElectromagneticOptions {
   double atol;                            /**< Linear solver absolute tolerance */
   double preconditioner_background_sigma; /**< Uniform conductivity to use to preconditioner (ignored if <= 0) */
 
-  bool top_only; /**< Flag to specify current in top rings only */
-  bool bot_only; /**< Flag to specify current in bottom rings only */
+  bool top_only;         /**< Flag to specify current in top rings only */
+  bool bot_only;         /**< Flag to specify current in bottom rings only */
   bool variable_current; /**< Flag to specify variable current in each ring */
 
   bool evaluate_magnetic_field;

--- a/src/lte_thermo_chem.cpp
+++ b/src/lte_thermo_chem.cpp
@@ -68,8 +68,8 @@ static double sigmaTorchStartUp(const Vector &pos) {
 static FunctionCoefficient sigma_start_up(sigmaTorchStartUp);
 
 LteThermoChem::LteThermoChem(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &time_coeff,
-                ParGridFunction *gridScale, TPS::Tps *tps)
-    : tpsP_(tps), pmesh_(pmesh), time_coeff_(time_coeff), gridScale_gf_(gridScale)  {
+                             ParGridFunction *gridScale, TPS::Tps *tps)
+    : tpsP_(tps), pmesh_(pmesh), time_coeff_(time_coeff), gridScale_gf_(gridScale) {
   rank0_ = (pmesh_->GetMyRank() == 0);
   order_ = loMach_opts->order;
 
@@ -469,7 +469,7 @@ void LteThermoChem::initializeSelf() {
 
   // outlet bc
   {
-      // Assumed homogeneous Nuemann on T, so nothing to do
+    // Assumed homogeneous Nuemann on T, so nothing to do
   }
 
   // Wall BCs
@@ -600,7 +600,6 @@ void LteThermoChem::initializeOperators() {
 
     supg_coeff_ = new ScalarMatrixProductCoefficient(*upwind_coeff_, *swdiff_coeff_);
   }
-
 
   // Convection: Atemperature(i,j) = \int_{\Omega} \phi_i \rho Cp u \cdot \nabla \phi_j
   At_form_ = new ParBilinearForm(sfes_);

--- a/src/lte_thermo_chem.hpp
+++ b/src/lte_thermo_chem.hpp
@@ -90,7 +90,7 @@ class LteThermoChem final : public ThermoChemModelBase {
   bool numerical_integ_ = false;  /**< Enable/disable numerical integration rules of forms. */
   bool domain_is_open_ = false;   /**< true if domain is open */
   bool axisym_ = false;
-  bool sw_stab_ = false;          /**< Enable/disable supg stabilization. */
+  bool sw_stab_ = false; /**< Enable/disable supg stabilization. */
 
   // Linear-solver-related options
   int pl_solve_ = 0;    /**< Verbosity level passed to mfem solvers */

--- a/src/quasimagnetostatic.cpp
+++ b/src/quasimagnetostatic.cpp
@@ -272,9 +272,7 @@ void QuasiMagnetostaticSolver3D::InitializeCurrent() {
   }
 
   if (rank0_) {
-    std::cout << "J0 = " << J0(0) << ", " << J0(1)
-              << ", " << J0(2) << ", " << J0(3)
-              << ", " << J0(4) << endl;
+    std::cout << "J0 = " << J0(0) << ", " << J0(1) << ", " << J0(2) << ", " << J0(3) << ", " << J0(4) << endl;
   }
 
   PWConstCoefficient J0coef(J0);
@@ -924,9 +922,7 @@ void QuasiMagnetostaticSolverAxiSym::InitializeCurrent() {
   }
 
   if (rank0_) {
-    std::cout << "J0 = " << J0(0) << ", " << J0(1)
-              << ", " << J0(2) << ", " << J0(3)
-              << ", " << J0(4) << endl;
+    std::cout << "J0 = " << J0(0) << ", " << J0(1) << ", " << J0(2) << ", " << J0(3) << ", " << J0(4) << endl;
   }
 
   FunctionCoefficient radius_coeff(radius);

--- a/src/tps.cpp
+++ b/src/tps.cpp
@@ -327,7 +327,8 @@ void Tps::parseInput() {
   getInput("gpu/numGpusPerRank", numGpusPerRank_, 1);
 #ifdef _HIP_
   // Sometimes hip call stack is too small.  Allow user to resize it.
-  // See https://rocm.docs.amd.com/projects/HIP/en/docs-6.4.2/how-to/hip_runtime_api/call_stack.html#call-stack-management-with-hip
+  // See
+  // https://rocm.docs.amd.com/projects/HIP/en/docs-6.4.2/how-to/hip_runtime_api/call_stack.html#call-stack-management-with-hip
   int stackSizeMult;
   getInput("gpu/hipStackSizeMult", stackSizeMult, 2);
 

--- a/src/wallBC.cpp
+++ b/src/wallBC.cpp
@@ -814,8 +814,8 @@ void WallBC::interpWalls_gpu(const mfem::Vector &x, const elementIndexingData &e
           d_flux[eq + q * num_equation + n * maxIntPoints * num_equation] = Rflux[eq];
         }
       }  // end quadrature point loop
-    }    // end face loop
-  });    // end element loop
+    }  // end face loop
+  });  // end element loop
 #endif
 }
 


### PR DESCRIPTION
This commit includes minor style fixes that do not cause the `make style` check to fail but are applied by `make enforcestyle`.  Applying them all at once here makes it easier to use `make enforcestyle` without introducing extraneous changes in other commits and PRs.