### PR TITLE
Oscillating input power

### DIFF
--- a/src/cycle_avg_joule_coupling.cpp
+++ b/src/cycle_avg_joule_coupling.cpp
@@ -66,8 +66,8 @@ CycleAvgJouleCoupling::CycleAvgJouleCoupling(string &inputFileName, TPS::Tps *tp
   tps->getInput("cycle-avg-joule-coupled/fixed-conductivity", fixed_conductivity_, false);
 
   tps->getInput("cycle-avg-joule-coupled/oscillating-power", oscillating_power_, false);
-  tps->getInput("cycle-avg-joule-coupled/input-power-amplitude",  power_amplitude_, 0.0);
-  tps->getInput("cycle-avg-joule-coupled/input-power-period",  power_period_, 1.0);
+  tps->getInput("cycle-avg-joule-coupled/input-power-amplitude", power_amplitude_, 0.0);
+  tps->getInput("cycle-avg-joule-coupled/input-power-period", power_period_, 1.0);
 
   if (axisym) {
     qmsa_solver_ = new QuasiMagnetostaticSolverAxiSym(em_opt_, tps);

--- a/src/cycle_avg_joule_coupling.cpp
+++ b/src/cycle_avg_joule_coupling.cpp
@@ -65,6 +65,10 @@ CycleAvgJouleCoupling::CycleAvgJouleCoupling(string &inputFileName, TPS::Tps *tp
   tps->getInput("cycle-avg-joule-coupled/initial-input-power", initial_input_power_, -1.);
   tps->getInput("cycle-avg-joule-coupled/fixed-conductivity", fixed_conductivity_, false);
 
+  tps->getInput("cycle-avg-joule-coupled/oscillating-power", oscillating_power_, false);
+  tps->getInput("cycle-avg-joule-coupled/input-power-amplitude",  power_amplitude_, 0.0);
+  tps->getInput("cycle-avg-joule-coupled/input-power-period",  power_period_, 1.0);
+
   if (axisym) {
     qmsa_solver_ = new QuasiMagnetostaticSolverAxiSym(em_opt_, tps);
   } else {
@@ -450,11 +454,19 @@ void CycleAvgJouleCoupling::solveStep() {
 
     // scale the Joule heating (if we are controlling the power input)
     if (input_power_ > 0) {
-      const double target_power = initial_input_power_ + (current_iter_ / solve_em_every_n_ + 1) * delta_power;
+      double target_power = initial_input_power_ + (current_iter_ / solve_em_every_n_ + 1) * delta_power;
+      if (oscillating_power_) {
+        const double tau = ((double)current_iter_) / power_period_;
+        target_power = input_power_ + power_amplitude_ * sin(2 * M_PI * tau);
+        if (rank0_) {
+          grvy_printf(GRVY_INFO, "target_power = %.6e\n", target_power);
+        }
+      }
       const double ratio = target_power / tot_jh;
       qmsa_solver_->scaleJouleHeating(ratio);
       const double upd_jh = qmsa_solver_->totalJouleHeating();
       if (rank0_) {
+        grvy_printf(GRVY_INFO, "current_iter = %d\n", current_iter_);
         grvy_printf(GRVY_INFO, "The total input Joule heating after scaling = %.6e\n", upd_jh);
       }
     }

--- a/src/cycle_avg_joule_coupling.hpp
+++ b/src/cycle_avg_joule_coupling.hpp
@@ -85,8 +85,7 @@ class CycleAvgJouleCoupling : public TPS::Solver {
 
   bool oscillating_power_;
   double power_amplitude_;
-  double power_period_; // in time steps
-
+  double power_period_;  // in time steps
 
   int rank_;
   int nprocs_;

--- a/src/cycle_avg_joule_coupling.hpp
+++ b/src/cycle_avg_joule_coupling.hpp
@@ -83,6 +83,11 @@ class CycleAvgJouleCoupling : public TPS::Solver {
   double input_power_;
   double initial_input_power_;
 
+  bool oscillating_power_;
+  double power_amplitude_;
+  double power_period_; // in time steps
+
+
   int rank_;
   int nprocs_;
   bool rank0_;

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -125,6 +125,11 @@ void LoMachSolver::initialize() {
   // local pointers
   serial_mesh_ = meshData_->getSerialMesh();
   pmesh_ = meshData_->getMesh();
+
+  if (pmesh_->GetNodes() == NULL) {
+    pmesh_->SetCurvature(1);
+  }
+
   partitioning_ = meshData_->getPartition();
 
   // Stash mesh dimension (convenience)

--- a/src/loMach.cpp
+++ b/src/loMach.cpp
@@ -510,6 +510,8 @@ void LoMachSolver::solveEnd() {
     if (rank0_) std::cout << "At time = " << temporal_coeff_.time << ", flow L2 error = " << flow_err << std::endl;
   }
 
+  restart_files_hdf5("write");
+
   // paraview
   pvdc_->SetCycle(iter);
   pvdc_->SetTime(temporal_coeff_.time);

--- a/src/lte_thermo_chem.cpp
+++ b/src/lte_thermo_chem.cpp
@@ -69,7 +69,7 @@ static FunctionCoefficient sigma_start_up(sigmaTorchStartUp);
 
 LteThermoChem::LteThermoChem(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &time_coeff,
                              ParGridFunction *gridScale, TPS::Tps *tps)
-    : tpsP_(tps), pmesh_(pmesh), time_coeff_(time_coeff), gridScale_gf_(gridScale) {
+    : tpsP_(tps), pmesh_(pmesh), gll_rules_(0, Quadrature1D::GaussLobatto), time_coeff_(time_coeff), gridScale_gf_(gridScale)  {
   rank0_ = (pmesh_->GetMyRank() == 0);
   order_ = loMach_opts->order;
 
@@ -174,6 +174,9 @@ LteThermoChem::LteThermoChem(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, t
   tps->getInput("loMach/ltethermo/linear-solver-verbosity", pl_solve_, 0);
 
   tpsP_->getInput("loMach/ltethermo/streamwise-stabilization", sw_stab_, false);
+  if (sw_stab_) {
+    if (rank0_) std::cout << "Using SUPG in LTE thermo chem!" << std::endl;
+  }
 }
 
 LteThermoChem::~LteThermoChem() {
@@ -493,7 +496,7 @@ void LteThermoChem::initializeSelf() {
       tpsP_->getRequiredInput((basepath + "/type").c_str(), type);
 
       if (type == "viscous_isothermal") {
-        std::cout << "Adding patch = " << patch << " to isothermal wall list!" << std::endl;
+        if(rank0_) std::cout << "Adding patch = " << patch << " to isothermal wall list!" << std::endl;
 
         attr_wall = 0;
         attr_wall[patch - 1] = 1;
@@ -531,9 +534,12 @@ void LteThermoChem::initializeOperators() {
   // unsteady: p+p [+p] = 2p [3p]
   // convection: p+p+(p-1) [+p] = 3p-1 [4p-1]
   // diffusion: (p-1)+(p-1) [+p] = 2p-2 [3p-2]
-  const IntegrationRule &ir_i = gll_rules_.Get(sfes_->GetFE(0)->GetGeomType(), 2 * order_ + 1);
-  const IntegrationRule &ir_nli = gll_rules_.Get(sfes_->GetFE(0)->GetGeomType(), 4 * order_);
-  const IntegrationRule &ir_di = gll_rules_.Get(sfes_->GetFE(0)->GetGeomType(), 3 * order_ - 1);
+  // const IntegrationRule &ir_i = gll_rules_.Get(sfes_->GetFE(0)->GetGeomType(), 2 * order_ + 1);
+  // const IntegrationRule &ir_nli = gll_rules_.Get(sfes_->GetFE(0)->GetGeomType(), 4 * order_);
+  // const IntegrationRule &ir_di = gll_rules_.Get(sfes_->GetFE(0)->GetGeomType(), 3 * order_ - 1);
+  const IntegrationRule &ir_i = gll_rules_.Get(sfes_->GetFE(0)->GetGeomType(), 2 * order_ - 1);
+  const IntegrationRule &ir_nli = gll_rules_.Get(sfes_->GetFE(0)->GetGeomType(), 2 * order_ - 1);
+  const IntegrationRule &ir_di = gll_rules_.Get(sfes_->GetFE(0)->GetGeomType(), 2 * order_ - 1);
   if (rank0_) std::cout << "Integration rules set" << endl;
 
   // coefficients for operators

--- a/src/lte_thermo_chem.cpp
+++ b/src/lte_thermo_chem.cpp
@@ -52,9 +52,9 @@ static double radius(const Vector &pos) { return pos[0]; }
 static FunctionCoefficient radius_coeff(radius);
 
 static double sigmaTorchStartUp(const Vector &pos) {
-  //const double x = pos[0];  // radial location
+  // const double x = pos[0];  // radial location
   const double x = std::sqrt(pos[0] * pos[0] + pos[2] * pos[2]);  // radial location
-  const double y = pos[1];  // axial location
+  const double y = pos[1];                                        // axial location
 
   const double r0 = 0.005;
   const double y0 = 0.135;
@@ -70,7 +70,11 @@ static FunctionCoefficient sigma_start_up(sigmaTorchStartUp);
 
 LteThermoChem::LteThermoChem(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, temporalSchemeCoefficients &time_coeff,
                              ParGridFunction *gridScale, TPS::Tps *tps)
-    : tpsP_(tps), pmesh_(pmesh), gll_rules_(0, Quadrature1D::GaussLobatto), time_coeff_(time_coeff), gridScale_gf_(gridScale)  {
+    : tpsP_(tps),
+      pmesh_(pmesh),
+      gll_rules_(0, Quadrature1D::GaussLobatto),
+      time_coeff_(time_coeff),
+      gridScale_gf_(gridScale) {
   rank0_ = (pmesh_->GetMyRank() == 0);
   order_ = loMach_opts->order;
 
@@ -183,7 +187,6 @@ LteThermoChem::LteThermoChem(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, t
   if (qt_filter_) {
     if (rank0_) std::cout << "Using Qt filter in LTE thermo chem!" << std::endl;
   }
-
 }
 
 LteThermoChem::~LteThermoChem() {
@@ -503,7 +506,7 @@ void LteThermoChem::initializeSelf() {
       tpsP_->getRequiredInput((basepath + "/type").c_str(), type);
 
       if (type == "viscous_isothermal") {
-        if(rank0_) std::cout << "Adding patch = " << patch << " to isothermal wall list!" << std::endl;
+        if (rank0_) std::cout << "Adding patch = " << patch << " to isothermal wall list!" << std::endl;
 
         attr_wall = 0;
         attr_wall[patch - 1] = 1;
@@ -909,7 +912,6 @@ void LteThermoChem::initializeOperators() {
   Tn_next_gf_.SetFromTrueDofs(Tn_);
   Tn_next_gf_.GetTrueDofs(Tn_next_);
 
-
   // Smooth the restart temperature field (if requested)
   if (filter_restart_ && qt_filter_) {
     if (rank0_) std::cout << "************ Filtering temperature restart (Qt) ******************" << std::endl;
@@ -1019,8 +1021,8 @@ void LteThermoChem::initializeStats(Averaging &average, IODataOrganizer &io, boo
     average.registerField(std::string("temperature"), &Tn_gf_, false, 0, 1);
 
     // io init
-    io.registerIOFamily("Time-averaged temperature", "/meanTemp", average.GetMeanField(std::string("temperature")), false,
-                        continuation, sfec_);
+    io.registerIOFamily("Time-averaged temperature", "/meanTemp", average.GetMeanField(std::string("temperature")),
+                        false, continuation, sfec_);
     io.registerIOVar("/meanTemp", "<T>", 0, true);
   }
 }
@@ -1154,10 +1156,12 @@ void LteThermoChem::step() {
     double Tmin = Tmin_;
     double Tmax = Tmax_;
     auto d_Tn_gf = Tn_next_gf_.ReadWrite();
-    MFEM_FORALL(i, Tn_next_gf_.Size(),
-                { if (d_Tn_gf[i] < Tmin) d_Tn_gf[i] = Tmin; });
-    MFEM_FORALL(i, Tn_next_gf_.Size(),
-                { if (d_Tn_gf[i] > Tmax) d_Tn_gf[i] = Tmax; });
+    MFEM_FORALL(i, Tn_next_gf_.Size(), {
+      if (d_Tn_gf[i] < Tmin) d_Tn_gf[i] = Tmin;
+    });
+    MFEM_FORALL(i, Tn_next_gf_.Size(), {
+      if (d_Tn_gf[i] > Tmax) d_Tn_gf[i] = Tmax;
+    });
     Tn_next_gf_.GetTrueDofs(Tn_next_);
   }
 

--- a/src/lte_thermo_chem.cpp
+++ b/src/lte_thermo_chem.cpp
@@ -1046,7 +1046,7 @@ void LteThermoChem::computeExplicitTempConvectionOP() {
 }
 
 void LteThermoChem::initializeIO(IODataOrganizer &io) {
-  io.registerIOFamily("Temperature", "/temperature", &Tn_gf_, false);
+  io.registerIOFamily("Temperature", "/temperature", &Tn_gf_, true, true, sfec_);
   io.registerIOVar("/temperature", "temperature", 0);
 }
 

--- a/src/lte_thermo_chem.cpp
+++ b/src/lte_thermo_chem.cpp
@@ -1054,6 +1054,7 @@ void LteThermoChem::initializeViz(ParaViewDataCollection &pvdc) {
   pvdc.RegisterField("temperature", &Tn_gf_);
   pvdc.RegisterField("density", &rn_gf_);
   pvdc.RegisterField("kappa", &kappa_gf_);
+  pvdc.RegisterField("mu", &mu_gf_);
   pvdc.RegisterField("sigma", &sigma_gf_);
   pvdc.RegisterField("kappaT", &thermal_diff_total_gf_);
   pvdc.RegisterField("Qt", &Qt_gf_);

--- a/src/lte_thermo_chem.cpp
+++ b/src/lte_thermo_chem.cpp
@@ -86,6 +86,8 @@ LteThermoChem::LteThermoChem(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, t
   std::string table_file;
   tps->getRequiredInput("loMach/ltethermo/table-file", table_file);
 
+  tps->getInput("loMach/ltethermo/filter-restart", filter_restart_, false);
+
   // Read data from hdf5 file containing 6 columns: T, mu, kappa, sigma, Rgas, Cp
   DenseMatrix table_data;
   bool success;
@@ -872,6 +874,59 @@ void LteThermoChem::initializeOperators() {
   Tn_next_gf_.SetFromTrueDofs(Tn_);
   Tn_next_gf_.GetTrueDofs(Tn_next_);
 
+
+  // Smooth the restart temperature field (if requested)
+  if (filter_restart_) {
+    if (rank0_) std::cout << "************ Filtering temperature restart ******************" << std::endl;
+
+    // Build the right-hand-side
+    resT_ = 0.0;
+    M_rho_Cp_->AddMult(Tn_, resT_);
+
+    bd0_over_dt.constant = 1.0;
+    kappa_gf_ = 0.01;
+
+    Ht_form_->Update();
+    Ht_form_->Assemble();
+    Ht_form_->FormSystemMatrix(temp_ess_tdof_, Ht_);
+
+    HtInv_->SetOperator(*Ht_);
+    if (partial_assembly_) {
+      delete HtInvPC_;
+      Vector diag_pa(sfes_->GetTrueVSize());
+      Ht_form_->AssembleDiagonal(diag_pa);
+      HtInvPC_ = new OperatorJacobiSmoother(diag_pa, temp_ess_tdof_);
+      HtInv_->SetPreconditioner(*HtInvPC_);
+    }
+
+    // Prepare for the solve
+    for (auto &temp_dbc : temp_dbcs_) {
+      Tn_next_gf_.ProjectBdrCoefficient(*temp_dbc.coeff, temp_dbc.attr);
+    }
+    sfes_->GetRestrictionMatrix()->MultTranspose(resT_, resT_gf_);
+
+    Vector Xt2, Bt2;
+    if (partial_assembly_) {
+      auto *HC = Ht_.As<ConstrainedOperator>();
+      EliminateRHS(*Ht_form_, *HC, temp_ess_tdof_, Tn_next_gf_, resT_gf_, Xt2, Bt2, 1);
+    } else {
+      Ht_form_->FormLinearSystem(temp_ess_tdof_, Tn_next_gf_, resT_gf_, Ht_, Xt2, Bt2, 1);
+    }
+
+    // solve helmholtz eq for temp
+    HtInv_->Mult(Bt2, Xt2);
+    assert(HtInv_->GetConverged());
+
+    Ht_form_->RecoverFEMSolution(Xt2, resT_gf_, Tn_next_gf_);
+    Tn_next_gf_.GetTrueDofs(Tn_next_);
+
+    Tn_gf_.SetFromTrueDofs(Tn_next_);
+
+    Tn_gf_.GetTrueDofs(Tn_);
+    Tn_next_gf_.SetFromTrueDofs(Tn_);
+    Tn_next_gf_.GetTrueDofs(Tn_next_);
+  }
+
   // After IC is filled, compute density
   updateDensity();
 
@@ -894,6 +949,21 @@ void LteThermoChem::initializeOperators() {
 
   // and initialize system mass
   computeSystemMass();
+
+  // Get the initial props into the viz field at time 0
+  updateProperties();
+}
+
+void LteThermoChem::initializeStats(Averaging &average, IODataOrganizer &io, bool continuation) {
+  if (average.ComputeMean()) {
+    // fields for averaging
+    average.registerField(std::string("temperature"), &Tn_gf_, false, 0, 1);
+
+    // io init
+    io.registerIOFamily("Time-averaged temperature", "/meanTemp", average.GetMeanField(std::string("temperature")), false,
+                        continuation, sfec_);
+    io.registerIOVar("/meanTemp", "<T>", 0, true);
+  }
 }
 
 /**

--- a/src/lte_thermo_chem.hpp
+++ b/src/lte_thermo_chem.hpp
@@ -91,6 +91,7 @@ class LteThermoChem final : public ThermoChemModelBase {
   bool domain_is_open_ = false;   /**< true if domain is open */
   bool axisym_ = false;
   bool sw_stab_ = false; /**< Enable/disable supg stabilization. */
+  bool filter_restart_ = false;
 
   // Linear-solver-related options
   int pl_solve_ = 0;    /**< Verbosity level passed to mfem solvers */
@@ -266,6 +267,7 @@ class LteThermoChem final : public ThermoChemModelBase {
   // Functions overriden from base class
   void initializeSelf() final;
   void initializeOperators() final;
+  void initializeStats(Averaging &average, IODataOrganizer &io, bool continuation) final;
   void step() final;
   void initializeIO(IODataOrganizer &io) final;
   void initializeViz(ParaViewDataCollection &pvdc) final;

--- a/src/lte_thermo_chem.hpp
+++ b/src/lte_thermo_chem.hpp
@@ -92,6 +92,7 @@ class LteThermoChem final : public ThermoChemModelBase {
   bool axisym_ = false;
   bool sw_stab_ = false; /**< Enable/disable supg stabilization. */
   bool filter_restart_ = false;
+  bool qt_filter_ = false; /**< Enable/disable filter in thermal div calc. */
 
   // Linear-solver-related options
   int pl_solve_ = 0;    /**< Verbosity level passed to mfem solvers */
@@ -191,6 +192,7 @@ class LteThermoChem final : public ThermoChemModelBase {
 
   VectorMagnitudeCoefficient *umag_coeff_ = nullptr;
   GridFunctionCoefficient *gscale_coeff_ = nullptr;
+  ProductCoefficient *gscale2_coeff_ = nullptr;
   GridFunctionCoefficient *visc_coeff_ = nullptr;
   PowerCoefficient *visc_inv_coeff_ = nullptr;
   ProductCoefficient *reh1_coeff_ = nullptr;

--- a/src/lte_thermo_chem.hpp
+++ b/src/lte_thermo_chem.hpp
@@ -126,6 +126,10 @@ class LteThermoChem final : public ThermoChemModelBase {
   double Prt_;
   double invPrt_;
 
+  bool Tclip_ = false;
+  double Tmin_ = 0.0;
+  double Tmax_ = 100000.0;
+
   // FEM related fields and objects
 
   // Scalar \f$H^1\f$ finite element collection.

--- a/src/reactingFlow.cpp
+++ b/src/reactingFlow.cpp
@@ -90,8 +90,6 @@ ReactingFlow::ReactingFlow(mfem::ParMesh *pmesh, LoMachOptions *loMach_opts, tem
   tpsP_->getInput("loMach/reacting/min-temperature", Tmin_, 0.0);
   tpsP_->getInput("loMach/reacting/max-temperature", Tmax_, 100000.0);
 
-
-
   workFluid_ = USER_DEFINED;
   gasModel_ = PERFECT_MIXTURE;
   chemistryModel_ = NUM_CHEMISTRYMODEL;
@@ -2148,10 +2146,12 @@ void ReactingFlow::temperatureStep() {
     double Tmin = Tmin_;
     double Tmax = Tmax_;
     auto d_Tn_gf = Tn_next_gf_.ReadWrite();
-    MFEM_FORALL(i, Tn_next_gf_.Size(),
-                { if (d_Tn_gf[i] < Tmin) d_Tn_gf[i] = Tmin; });
-    MFEM_FORALL(i, Tn_next_gf_.Size(),
-                { if (d_Tn_gf[i] > Tmax) d_Tn_gf[i] = Tmax; });
+    MFEM_FORALL(i, Tn_next_gf_.Size(), {
+      if (d_Tn_gf[i] < Tmin) d_Tn_gf[i] = Tmin;
+    });
+    MFEM_FORALL(i, Tn_next_gf_.Size(), {
+      if (d_Tn_gf[i] > Tmax) d_Tn_gf[i] = Tmax;
+    });
     Tn_next_gf_.GetTrueDofs(Tn_next_);
   }
 

--- a/src/reactingFlow.hpp
+++ b/src/reactingFlow.hpp
@@ -147,6 +147,10 @@ class ReactingFlow : public ThermoChemModelBase {
   double Sc_, invSc_;
   double static_rho_;
 
+  bool Tclip_ = false;
+  double Tmin_ = 0.0;
+  double Tmax_ = 100000.0;
+
   /// pressure-related, closed-system thermo pressure changes
   double ambient_pressure_, thermo_pressure_, system_mass_;
   double dtP_;

--- a/src/tomboulides.cpp
+++ b/src/tomboulides.cpp
@@ -1243,7 +1243,6 @@ void Tomboulides::step() {
   (*iorho_gf_) = 1.0;
   (*iorho_gf_) /= (*thermo_interface_->density);
 
-
   // Update the variable coefficient Laplacian to account for change
   // in density
   sw_press_.Start();

--- a/src/tomboulides.cpp
+++ b/src/tomboulides.cpp
@@ -1072,7 +1072,7 @@ void Tomboulides::initializeViz(mfem::ParaViewDataCollection &pvdc) const {
 void Tomboulides::initializeStats(Averaging &average, IODataOrganizer &io, bool continuation) const {
   if (average.ComputeMean()) {
     // fields for averaging
-    average.registerField(std::string("velocity"), u_curr_gf_, true, 0, nvel_);
+    average.registerField(std::string("velocity"), u_curr_gf_, true, 0, dim_);
     average.registerField(std::string("pressure"), p_gf_, false, 0, 1);
     average.registerField(std::string("dissipation"), epsi_gf_, false, 0, 1);
 

--- a/src/tomboulides.hpp
+++ b/src/tomboulides.hpp
@@ -82,6 +82,7 @@ class Tomboulides final : public FlowBase {
   // Options
   bool numerical_integ_ = false;
   bool partial_assembly_ = false;
+  bool use_iorho_gf_ = false;
 
   // linear-solver options
   int smoother_poly_order_;
@@ -231,6 +232,7 @@ class Tomboulides final : public FlowBase {
   mfem::FiniteElementCollection *pfec_ = nullptr;
   mfem::ParFiniteElementSpace *pfes_ = nullptr;
   mfem::ParGridFunction *p_gf_ = nullptr;
+  mfem::ParGridFunction *iorho_gf_ = nullptr;
   mfem::ParGridFunction *resp_gf_ = nullptr;
   mfem::ParGridFunction *pp_div_rad_comp_gf_ = nullptr;
 
@@ -244,7 +246,9 @@ class Tomboulides final : public FlowBase {
 
   /// mfem::Coefficients used in forming necessary operators
   mfem::GridFunctionCoefficient *rho_coeff_ = nullptr;
-  mfem::RatioCoefficient *iorho_coeff_ = nullptr;
+  //mfem::RatioCoefficient *iorho_coeff_ = nullptr;
+  //mfem::GridFunctionCoefficient *iorho_coeff_ = nullptr;
+  mfem::Coefficient *iorho_coeff_ = nullptr;
   mfem::ConstantCoefficient nlcoeff_;
   mfem::ConstantCoefficient one_coeff_;
   mfem::ConstantCoefficient Hv_bdfcoeff_;

--- a/src/tomboulides.hpp
+++ b/src/tomboulides.hpp
@@ -246,8 +246,8 @@ class Tomboulides final : public FlowBase {
 
   /// mfem::Coefficients used in forming necessary operators
   mfem::GridFunctionCoefficient *rho_coeff_ = nullptr;
-  //mfem::RatioCoefficient *iorho_coeff_ = nullptr;
-  //mfem::GridFunctionCoefficient *iorho_coeff_ = nullptr;
+  // mfem::RatioCoefficient *iorho_coeff_ = nullptr;
+  // mfem::GridFunctionCoefficient *iorho_coeff_ = nullptr;
   mfem::Coefficient *iorho_coeff_ = nullptr;
   mfem::ConstantCoefficient nlcoeff_;
   mfem::ConstantCoefficient one_coeff_;


### PR DESCRIPTION
This PR collects some recent minor extensions and robustness improvements, including the following:

1) Options to control an oscillating power for the `cycle-avg-joule-coupled` solver.  Specifically the options are
```
cycle-avg-joule-coupled/oscillating-power = true # boolean to tell solver to use oscillating power, defaults to false
cycle-avg-joule-coupled/input-power-amplitude = 2000.0 # amplitude of oscillation, in Watts
cycle-avg-joule-coupled/power-period = 5000 # period of oscillation, in time steps
```
2) Minor restart and averaging fixes (e.g., allowing variable order restart with `LteThemoChem`)
3) Options to clip the temperature field for `LteThermoChem` and `ReactingFlow`.  Specifically, for reacting,
```
loMach/reacting/clip-temperature = true # use the clipping, defaults to false
loMach/reacting/min-temperature = 250.0 # set values below 250 to 250 (in Kelvin)
loMach/reacting/max-temperature = 13000.0 # set values above 13000 to 13000 (in Kelvin)
```
4) An option (use `loMach/tomboulides/iorho_gf = true`, default behavior is `false`) to treat the coefficient 1/density as a `GridFunctionCoefficient` in `Tomboulides`.  This can improve robustness for under-resolved cases.  Currently only implemented for 3D.
5) An option to filter the thermal divergence field (use `loMach/ltethermo/filter-Q = true`, defaults to fales) using a second order differential filter (Qf - \nabla \cdot (\ell^2 Qf) = Q, where Q is the original thermal divergence, Qf is the filtered version, and ell is the mesh resolution length scale.  This option is  only currently available for `LteThermoChem`.

Items 4 and 5 should be considered experimental, but are included because of their potential to improve robustness for marginally resolved cases.